### PR TITLE
Strip stale provider defaults from inputs during Diff

### DIFF
--- a/pkg/tests/regress_1020_test.go
+++ b/pkg/tests/regress_1020_test.go
@@ -152,7 +152,16 @@ func TestRegress1020(t *testing.T) {
 			Repository:  "https://github.com/pulumi/pulumi-aws",
 			Version:     "0.0.2",
 			Resources: map[string]*tfbridge.ResourceInfo{
-				"aws_wafv2_ip_set": {Tok: "aws:wafv2/ipSet:IpSet"},
+				"aws_wafv2_ip_set": {
+					Tok: "aws:wafv2/ipSet:IpSet",
+					Fields: map[string]*tfbridge.SchemaInfo{
+						"name": {Default: &tfbridge.DefaultInfo{
+							ComputeDefault: func(ctx context.Context, opts tfbridge.ComputeDefaultOptions) (interface{}, error) {
+								return "auto-named", nil
+							},
+						}},
+					},
+				},
 			},
 		}
 		return tfbridge.NewProvider(ctx,

--- a/pkg/tests/regress_aws_2352_test.go
+++ b/pkg/tests/regress_aws_2352_test.go
@@ -128,7 +128,16 @@ func TestRegressAws2352(t *testing.T) {
 		Repository:  "https://github.com/phillipedwards/pulumi-aws",
 		Version:     "0.0.2",
 		Resources: map[string]*tfbridge.ResourceInfo{
-			"aws_route53_resolver_endpoint": {Tok: "aws:route53/resolverEndpoint:ResolverEndpoint"},
+			"aws_route53_resolver_endpoint": {
+				Tok: "aws:route53/resolverEndpoint:ResolverEndpoint",
+				Fields: map[string]*tfbridge.SchemaInfo{
+					"name": {Default: &tfbridge.DefaultInfo{
+						ComputeDefault: func(ctx context.Context, opts tfbridge.ComputeDefaultOptions) (interface{}, error) {
+							return "auto-named", nil
+						},
+					}},
+				},
+			},
 		},
 	}
 

--- a/pkg/tests/strip_stale_defaults_integration_test.go
+++ b/pkg/tests/strip_stale_defaults_integration_test.go
@@ -15,8 +15,11 @@
 package tests
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -486,6 +489,128 @@ resources:
 	// run, but a stripped Diff could spuriously report an in-place update).
 	res := pt.Preview(t, optpreview.Diff())
 	assertNoChanges(t, res.ChangeSummary, "BridgeDefaultPreserved")
+}
+
+// TestStripStaleDefaultsIntegration_StripAppliesInUpdatePath is a regression guard for
+// the strip's symmetry across the two RPC paths that feed PlanResourceChange: Diff
+// (provider.go:1175) and Update's internal tf.Diff (provider.go:~1707). Both must
+// strip stale __defaults from `news` before building the TF config, otherwise a
+// future regression could let a stale value reach Update's plan while Diff's plan
+// stays clean — producing a Preview→Apply divergence.
+//
+// In current code Check sanitizes news upstream, so this test passes even if the
+// Update-path strip is removed. Its value is forward-looking: any future change that
+// lets stale entries survive Check (custom state-edit hooks, new RPC paths, refresh
+// flows that bypass Check) would be caught here only if both paths strip. The test
+// fires CustomizeDiff on every PlanResourceChange call — Diff RPC and Update RPC —
+// and records every site where opt_field reaches the raw config; the assertion is
+// zero sites.
+func TestStripStaleDefaultsIntegration_StripAppliesInUpdatePath(t *testing.T) {
+	t.Parallel()
+
+	withDefault := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"opt_field": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Default:  "old-default",
+					},
+					"trigger_update": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+	bp1 := pulcheck.BridgedProvider(t, "prov", withDefault)
+
+	// staleSeen records every CustomizeDiff invocation where opt_field appears in the
+	// raw config. The expected count under the fix is zero — both Diff RPC and Update
+	// RPC must strip before PlanResourceChange runs.
+	var staleSeen atomic.Int64
+	var seenLock sync.Mutex
+	var seenSites []string
+	recordSite := func(value any) {
+		seenLock.Lock()
+		defer seenLock.Unlock()
+		seenSites = append(seenSites, formatVal(value))
+	}
+
+	withoutDefault := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"opt_field": {
+						Type:     schema.TypeString,
+						Optional: true,
+						// Default removed.
+					},
+					"trigger_update": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+				CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, _ any) error {
+					raw := d.GetRawConfig()
+					if raw.IsNull() || !raw.Type().IsObjectType() || !raw.Type().HasAttribute("opt_field") {
+						return nil
+					}
+					optAttr := raw.GetAttr("opt_field")
+					if !optAttr.IsNull() && optAttr.IsKnown() {
+						staleSeen.Add(1)
+						recordSite(optAttr.AsString())
+					}
+					return nil
+				},
+			},
+		},
+	}
+	bp2 := pulcheck.BridgedProvider(t, "prov", withoutDefault)
+
+	// Trigger an Update by changing trigger_update across the upgrade — this forces the
+	// engine to call Update (not just Diff) so that Update's internal tf.Diff exercises
+	// the strip path under test.
+	programV1 := `
+name: test
+runtime: yaml
+resources:
+  mainRes:
+    type: prov:index:Test
+    properties:
+      triggerUpdate: "before"
+`
+	programV2 := `
+name: test
+runtime: yaml
+resources:
+  mainRes:
+    type: prov:index:Test
+    properties:
+      triggerUpdate: "after"
+`
+
+	pt := pulcheck.PulCheck(t, bp1, programV1)
+	pt.Up(t)
+	stack := pt.ExportStack(t)
+
+	pt2 := pulcheck.PulCheck(t, bp2, programV2)
+	pt2.ImportStack(t, stack)
+	pt2.Up(t)
+
+	require.Zerof(t, staleSeen.Load(),
+		"opt_field must not reach PlanResourceChange after the strip; saw it at: %v", seenSites)
+}
+
+// formatVal renders a cty value into a short string for diagnostic output. Defined
+// locally because the test only needs a best-effort representation.
+func formatVal(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return "<non-string>"
 }
 
 // TestStripStaleDefaultsIntegration_TypeSetHashStability is the regression guard for

--- a/pkg/tests/strip_stale_defaults_integration_test.go
+++ b/pkg/tests/strip_stale_defaults_integration_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -118,6 +117,18 @@ func TestStripStaleDefaultsIntegration_DefaultRemoved(t *testing.T) {
 	}
 	bp1 := pulcheck.BridgedProvider(t, "prov", withDefault)
 
+	// CustomizeDiff fires every PlanResourceChange and records sites where
+	// opt_field reaches RawConfig — the load-bearing observation, since post-Up
+	// stored inputs are shaped by Check (which already drops the field) and
+	// would not discriminate the strip from Check on their own.
+	var seenLock sync.Mutex
+	var seenSites []string
+	recordSite := func(value any) {
+		seenLock.Lock()
+		defer seenLock.Unlock()
+		seenSites = append(seenSites, formatVal(value))
+	}
+
 	withoutDefault := &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
 			"prov_test": {
@@ -127,6 +138,17 @@ func TestStripStaleDefaultsIntegration_DefaultRemoved(t *testing.T) {
 						Optional: true,
 						// Default removed.
 					},
+				},
+				CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, _ any) error {
+					raw := d.GetRawConfig()
+					if raw.IsNull() || !raw.Type().IsObjectType() || !raw.Type().HasAttribute("opt_field") {
+						return nil
+					}
+					attr := raw.GetAttr("opt_field")
+					if !attr.IsNull() && attr.IsKnown() {
+						recordSite(attr.AsString())
+					}
+					return nil
 				},
 			},
 		},
@@ -155,15 +177,15 @@ resources:
 	assertNoUnexpectedOps(t, res.ChangeSummary, "DefaultRemoved")
 	pt2.Up(t)
 
-	// Strong assertion: the strip removed optField from the new inputs, so the
-	// post-Up stored inputs must NOT contain it. Without the strip, Check's "old
-	// default" reuse path would re-pin "old-default" into news on every Diff,
-	// and the post-Up state would still record optField; this assertion would
-	// fail.
 	postInputs := resourceInputs(t, pt2.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
 	_, hasField := postInputs["optField"]
 	require.False(t, hasField,
 		"after Up against the schema with no Default, optField must be absent from stored inputs; got %+v", postInputs)
+
+	seenLock.Lock()
+	defer seenLock.Unlock()
+	require.Emptyf(t, seenSites,
+		"opt_field must not reach PlanResourceChange after the strip; saw it at: %v", seenSites)
 }
 
 // Note: there is no integration test for the *changed-default* scenario (provider
@@ -281,6 +303,17 @@ func TestStripStaleDefaultsIntegration_NestedTypeListBlock(t *testing.T) {
 	}
 	bp1 := pulcheck.BridgedProvider(t, "prov", withNestedDefault)
 
+	// CustomizeDiff records sites where the stripped nested_default reaches
+	// PlanResourceChange's RawConfig — load-bearing observation since post-Up
+	// stored inputs are shaped by Check and would not discriminate the strip.
+	var seenLock sync.Mutex
+	var seenSites []string
+	recordSite := func(value any) {
+		seenLock.Lock()
+		defer seenLock.Unlock()
+		seenSites = append(seenSites, formatVal(value))
+	}
+
 	withoutNestedDefault := &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
 			"prov_test": {
@@ -303,6 +336,28 @@ func TestStripStaleDefaultsIntegration_NestedTypeListBlock(t *testing.T) {
 							},
 						},
 					},
+				},
+				CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, _ any) error {
+					raw := d.GetRawConfig()
+					if raw.IsNull() || !raw.Type().IsObjectType() || !raw.Type().HasAttribute("block") {
+						return nil
+					}
+					block := raw.GetAttr("block")
+					if block.IsNull() || !block.IsKnown() || block.LengthInt() == 0 {
+						return nil
+					}
+					it := block.ElementIterator()
+					for it.Next() {
+						_, elem := it.Element()
+						if elem.IsNull() || !elem.Type().IsObjectType() || !elem.Type().HasAttribute("nested_default") {
+							continue
+						}
+						attr := elem.GetAttr("nested_default")
+						if !attr.IsNull() && attr.IsKnown() {
+							recordSite(attr.AsString())
+						}
+					}
+					return nil
 				},
 			},
 		},
@@ -344,15 +399,17 @@ resources:
 		"nestedDefault must be stripped from the nested block after Up; got %+v", postBlock)
 	require.Equalf(t, "alpha", postBlock["name"],
 		"sibling field 'name' must be preserved; got %+v", postBlock)
+
+	seenLock.Lock()
+	defer seenLock.Unlock()
+	require.Emptyf(t, seenSites,
+		"nested_default must not reach PlanResourceChange after the strip; saw it at: %v", seenSites)
 }
 
 // TestStripStaleDefaultsIntegration_TypeListOfBlocks covers stripArrayOfBlocks: a
 // non-MaxItemsOne TypeList of objects, each carrying a nested __defaults entry that
 // is removed in the upgraded schema. Distinct from _NestedTypeListBlock which uses
-// MaxItems=1 (single object branch). TypeSet is intentionally skipped by the strip
-// (set membership is hash-based on element fields), but TypeList elements are
-// positional — this test confirms the array recursion path is still exercised for
-// TypeList and not accidentally disabled along with TypeSet.
+// MaxItems=1 (single object branch).
 func TestStripStaleDefaultsIntegration_TypeListOfBlocks(t *testing.T) {
 	t.Parallel()
 
@@ -524,10 +581,10 @@ func TestStripStaleDefaultsIntegration_StripAppliesInUpdatePath(t *testing.T) {
 	}
 	bp1 := pulcheck.BridgedProvider(t, "prov", withDefault)
 
-	// staleSeen records every CustomizeDiff invocation where opt_field appears in the
-	// raw config. The expected count under the fix is zero — both Diff RPC and Update
-	// RPC must strip before PlanResourceChange runs.
-	var staleSeen atomic.Int64
+	// seenSites records every CustomizeDiff invocation where opt_field appears in
+	// the raw config. The expected count under the fix is zero — both Diff RPC and
+	// Update RPC must strip before PlanResourceChange runs. Counter and slice are
+	// updated together under the same lock so failure-path output stays coherent.
 	var seenLock sync.Mutex
 	var seenSites []string
 	recordSite := func(value any) {
@@ -557,7 +614,6 @@ func TestStripStaleDefaultsIntegration_StripAppliesInUpdatePath(t *testing.T) {
 					}
 					optAttr := raw.GetAttr("opt_field")
 					if !optAttr.IsNull() && optAttr.IsKnown() {
-						staleSeen.Add(1)
 						recordSite(optAttr.AsString())
 					}
 					return nil
@@ -597,7 +653,9 @@ resources:
 	pt2.ImportStack(t, stack)
 	pt2.Up(t)
 
-	require.Zerof(t, staleSeen.Load(),
+	seenLock.Lock()
+	defer seenLock.Unlock()
+	require.Emptyf(t, seenSites,
 		"opt_field must not reach PlanResourceChange after the strip; saw it at: %v", seenSites)
 }
 
@@ -610,13 +668,173 @@ func formatVal(v any) string {
 	return "<non-string>"
 }
 
-// TestStripStaleDefaultsIntegration_TypeSetHashStability is the regression guard for
-// the bug hit during development of this feature:
-// stripping nested fields from TypeSet elements changed element hashes and made TF
-// report set rearrangement instead of in-place updates.
-// The strip skips TypeSet entirely, so __defaults inside set elements remain intact
-// across the round-trip; this test verifies no spurious diff from that round-trip.
-func TestStripStaleDefaultsIntegration_TypeSetHashStability(t *testing.T) {
+// TestStripStaleDefaultsIntegration_StaleDefaultInSetElement guards the strip's
+// recursion into TypeSet elements end-to-end. Mirrors _NestedTypeListBlock but
+// with a TypeSet (non-MaxItemsOne) — element identity is hash-based, so
+// stripping a stale field changes the element hash. The test verifies the
+// lifecycle still lands cleanly: Up succeeds (no PlanResourceChange validation
+// error), the stale field is gone from RawConfig per the CustomizeDiff hook,
+// the post-Up stored inputs no longer carry it, and a follow-up preview shows
+// no further churn (the strip's effect is one-time).
+func TestStripStaleDefaultsIntegration_StaleDefaultInSetElement(t *testing.T) {
+	t.Parallel()
+
+	withElemDefault := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"items": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"elem_default": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "old-elem",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	bp1 := pulcheck.BridgedProvider(t, "prov", withElemDefault)
+
+	// CustomizeDiff records sites where the stripped elem_default reaches
+	// PlanResourceChange's RawConfig — load-bearing observation since post-Up
+	// stored inputs are shaped by Check and would not discriminate the strip.
+	var seenLock sync.Mutex
+	var seenSites []string
+	recordSite := func(value any) {
+		seenLock.Lock()
+		defer seenLock.Unlock()
+		seenSites = append(seenSites, formatVal(value))
+	}
+
+	withoutElemDefault := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"items": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"elem_default": {
+									Type:     schema.TypeString,
+									Optional: true,
+									// Default removed.
+								},
+							},
+						},
+					},
+				},
+				CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, _ any) error {
+					raw := d.GetRawConfig()
+					if raw.IsNull() || !raw.Type().IsObjectType() || !raw.Type().HasAttribute("items") {
+						return nil
+					}
+					items := raw.GetAttr("items")
+					if items.IsNull() || !items.IsKnown() {
+						return nil
+					}
+					it := items.ElementIterator()
+					for it.Next() {
+						_, elem := it.Element()
+						if elem.IsNull() || !elem.Type().IsObjectType() || !elem.Type().HasAttribute("elem_default") {
+							continue
+						}
+						attr := elem.GetAttr("elem_default")
+						if !attr.IsNull() && attr.IsKnown() {
+							recordSite(attr.AsString())
+						}
+					}
+					return nil
+				},
+			},
+		},
+	}
+	bp2 := pulcheck.BridgedProvider(t, "prov", withoutElemDefault)
+
+	program := `
+name: test
+runtime: yaml
+resources:
+  mainRes:
+    type: prov:index:Test
+    properties:
+      items:
+        - name: "alpha"
+`
+
+	pt := pulcheck.PulCheck(t, bp1, program)
+	pt.Up(t)
+	stack := pt.ExportStack(t)
+
+	pt2 := pulcheck.PulCheck(t, bp2, program)
+	pt2.ImportStack(t, stack)
+
+	// Sanity: imported state holds the stale element default before the strip runs.
+	preInputs := resourceInputs(t, pt2.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
+	preItems, _ := preInputs["items"].([]any)
+	require.Lenf(t, preItems, 1, "imported state should have one element; got %+v", preInputs)
+	preElem, _ := preItems[0].(map[string]any)
+	require.Equalf(t, "old-elem", preElem["elemDefault"],
+		"sanity: imported state should hold the stale elem default; got %+v", preElem)
+
+	// Up must succeed without a PlanResourceChange validation error. The strip
+	// causes a one-time element rearrangement (set hash change), which is
+	// expected — assertNoUnexpectedOps allows same/update but not replace.
+	res := pt2.Preview(t, optpreview.Diff())
+	assertNoUnexpectedOps(t, res.ChangeSummary, "StaleDefaultInSetElement")
+	pt2.Up(t)
+
+	// After Up: the stale field is stripped from stored inputs, the sibling
+	// 'name' is preserved.
+	postInputs := resourceInputs(t, pt2.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
+	postItems, ok := postInputs["items"].([]any)
+	require.Truef(t, ok, "items must remain in stored inputs; got %+v", postInputs)
+	require.Lenf(t, postItems, 1, "items must still have one element after Up; got %+v", postInputs)
+	postElem, _ := postItems[0].(map[string]any)
+	_, hasElem := postElem["elemDefault"]
+	require.Falsef(t, hasElem,
+		"elemDefault must be stripped from the Set element after Up; got %+v", postElem)
+	require.Equalf(t, "alpha", postElem["name"],
+		"sibling field 'name' must be preserved; got %+v", postElem)
+
+	// Stability: a second preview against the same v2 schema must report no
+	// further changes — the strip's effect is one-time.
+	res2 := pt2.Preview(t, optpreview.Diff())
+	assertNoChanges(t, res2.ChangeSummary, "StaleDefaultInSetElement-stability")
+
+	seenLock.Lock()
+	defer seenLock.Unlock()
+	require.Emptyf(t, seenSites,
+		"elem_default must not reach PlanResourceChange after the strip; saw it at: %v", seenSites)
+}
+
+// TestStripStaleDefaultsIntegration_TypeSetLiveDefaultPreserved pins the
+// preserve branch of shouldStripStaleDefault for Set element fields: when the
+// nested default is *still declared* by the current schema, the value must
+// neither be stripped (no churn) nor misclassified as stale. The test creates
+// a Set where the program omits the defaulted field, lets the bridge default
+// it on Up, and asserts the post-Up stored inputs still carry the schema
+// default value — proving the predicate's preserve branch fired.
+//
+// Note: this test does not pin full Set-hash stability across schema-evolution
+// boundaries (the strip-into-Set behavior intentionally does change hashes for
+// stale defaults — see _StaleDefaultInSetElement).
+func TestStripStaleDefaultsIntegration_TypeSetLiveDefaultPreserved(t *testing.T) {
 	t.Parallel()
 
 	prov := &schema.Provider{
@@ -661,6 +879,21 @@ resources:
 	pt := pulcheck.PulCheck(t, bp, program)
 	pt.Up(t)
 
+	// Strong assertion: the bridge applied the schema-declared default to each
+	// Set element, and the post-Up stored inputs round-tripped it. If
+	// shouldStripStaleDefault wrongly stripped this value, the post-Up inputs
+	// would lack nestedDefault.
+	postInputs := resourceInputs(t, pt.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
+	postItems, ok := postInputs["items"].([]any)
+	require.Truef(t, ok, "items must be present in stored inputs; got %+v", postInputs)
+	require.Lenf(t, postItems, 2, "must have two elements after Up; got %+v", postItems)
+	for i, raw := range postItems {
+		elem, _ := raw.(map[string]any)
+		require.Equalf(t, "default-value", elem["nestedDefault"],
+			"element %d must carry the schema-declared default value; got %+v", i, elem)
+	}
+
+	// Stability: a fresh preview must report no changes.
 	res := pt.Preview(t, optpreview.Diff())
-	assertNoChanges(t, res.ChangeSummary, "TypeSetHashStability")
+	assertNoChanges(t, res.ChangeSummary, "TypeSetLiveDefaultPreserved")
 }

--- a/pkg/tests/strip_stale_defaults_integration_test.go
+++ b/pkg/tests/strip_stale_defaults_integration_test.go
@@ -31,26 +31,22 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 )
 
-// These tests exercise stripStaleDefaults via the runtime SDKv2 paths (Diff RPC
-// and Update's internal tf.Diff). The unit tests in
-// pkg/tfbridge/strip_stale_defaults_test.go cover the function in isolation, but
-// cannot catch issues that arise from the interaction between stripped inputs and
-// TF's plan, hash, or detailed-diff machinery.
+// Tests in this file exercise stripStaleDefaults through the runtime SDKv2 paths
+// (Diff RPC and Update's internal tf.Diff), catching interactions with TF's
+// plan/hash/detailed-diff machinery that the unit tests in pkg/tfbridge can't see.
 //
-// Two assertion styles are used, calibrated to scenario:
-//
-//  1. No-op scenarios (unchanged schema, unchanged program): assertNoChanges enforces
-//     that the preview reports only "same" — any spurious diff signals a real bug.
-//  2. Schema-migration scenarios (provider swapped between Up calls): the strip's
-//     effect is verified by inspecting the post-Up exported stack via resourceInputs
-//     and asserting the stale field was removed (or, for a changed default, that
-//     stored state reflects the new value). Stub TF providers used here do not run
-//     validation, so a "no error" assertion would pass even if the strip were
-//     deleted — the inputs check is what proves the strip ran.
+// The stub TF providers used here don't run validation, so a "no error"
+// assertion would pass even with the strip deleted. Tests use one of two
+// stronger assertions instead:
+//   - assertNoChanges for no-op scenarios (unchanged schema, unchanged program):
+//     the preview must report only "same".
+//   - resourceInputs checks for schema-migration scenarios (provider swapped
+//     between Up calls): inspect the post-Up exported stack to confirm the
+//     stale field was removed.
 
-// assertNoChanges asserts that a preview reports only "same" resources. Use this on
-// no-op scenarios (no schema change, program unchanged) to catch spurious diffs that
-// would indicate the strip is producing inputs that don't round-trip through TF cleanly.
+// assertNoChanges fails if the preview reports any op other than "same". Use on
+// no-op scenarios to catch spurious diffs caused by inputs that don't round-trip
+// through TF cleanly.
 func assertNoChanges(t *testing.T, summary map[apitype.OpType]int, label string) {
 	t.Helper()
 	for op, count := range summary {
@@ -60,13 +56,10 @@ func assertNoChanges(t *testing.T, summary map[apitype.OpType]int, label string)
 	}
 }
 
-// assertNoUnexpectedOps asserts that a preview reports only "same" or "update"
-// resources — never replace, create, or delete. Use this on schema-migration
-// scenarios where a transitional in-place update is expected (the strip removes a
-// stale value, so the resource updates to drop the field) but a replace would
-// indicate the strip caused unintended set-hash or identity changes. The function
-// only rejects unexpected op kinds; it does not require the summary to be
-// non-empty or assert that an update happened.
+// assertNoUnexpectedOps fails if the preview reports any op other than "same"
+// or "update". Use on schema-migration scenarios where an in-place update is
+// expected; a replace would indicate the strip caused unintended set-hash or
+// identity changes. Does not require the summary to be non-empty.
 func assertNoUnexpectedOps(t *testing.T, summary map[apitype.OpType]int, label string) {
 	t.Helper()
 	for op, count := range summary {
@@ -161,10 +154,9 @@ resources:
 	assertNoUnexpectedOps(t, res.ChangeSummary, "DefaultRemoved")
 	pt2.Up(t)
 
-	// Strong assertion: the strip removed optField from the new inputs, so the post-Up
-	// stored inputs must NOT contain it. Without the strip, Check's "old default"
-	// reuse path would re-pin "old-default" into news on every Diff, and the post-Up
-	// state would still record optField; this assertion would fail.
+	// Without the strip, Check's "old default" reuse path would re-pin
+	// "old-default" into news on every Diff and post-Up inputs would still
+	// record optField — so absence here proves the strip ran.
 	postInputs := resourceInputs(t, pt2.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
 	_, hasField := postInputs["optField"]
 	require.False(t, hasField,
@@ -493,20 +485,17 @@ resources:
 	assertNoChanges(t, res.ChangeSummary, "BridgeDefaultPreserved")
 }
 
-// TestStripStaleDefaultsIntegration_StripAppliesInUpdatePath is a regression guard for
-// the strip's symmetry across the two RPC paths that feed PlanResourceChange: the
-// Diff RPC and Update's internal tf.Diff. Both must strip stale __defaults from
-// `news` before building the TF config, otherwise a future regression could let a
-// stale value reach Update's plan while Diff's plan stays clean — producing a
-// Preview→Apply divergence.
+// TestStripStaleDefaultsIntegration_StripAppliesInUpdatePath is a regression
+// guard for strip symmetry across the two RPC paths that feed PlanResourceChange
+// (Diff RPC and Update's internal tf.Diff). Both must strip before building the
+// TF config; if Update drifts, Preview and Apply diverge.
 //
-// In current code Check sanitizes news upstream, so this test passes even if the
-// Update-path strip is removed. Its value is forward-looking: any future change that
-// lets stale entries survive Check (custom state-edit hooks, new RPC paths, refresh
-// flows that bypass Check) would be caught here only if both paths strip. The test
-// fires CustomizeDiff on every PlanResourceChange call — Diff RPC and Update RPC —
-// and records every site where opt_field reaches the raw config; the assertion is
-// zero sites.
+// Check sanitizes news upstream today, so the test passes even if Update's
+// strip is removed. The value is forward-looking: a future path that leaks
+// stale entries past Check (custom state-edit hooks, new RPC paths, refresh
+// flows that bypass Check) would be caught only if both Diff and Update strip.
+// CustomizeDiff records every PlanResourceChange site that sees opt_field; the
+// assertion is zero.
 func TestStripStaleDefaultsIntegration_StripAppliesInUpdatePath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tests/strip_stale_defaults_integration_test.go
+++ b/pkg/tests/strip_stale_defaults_integration_test.go
@@ -1,0 +1,544 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optpreview"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/pulcheck"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+)
+
+// These tests exercise stripStaleDefaults via the real Diff RPC path. The unit tests
+// in pkg/tfbridge/strip_stale_defaults_test.go cover the function in isolation, but
+// cannot catch issues that arise from the interaction between stripped inputs and
+// TF's plan, hash, or detailed-diff machinery.
+//
+// Two assertion styles are used, calibrated to scenario:
+//
+//  1. No-op scenarios (unchanged schema, unchanged program): assertNoChanges enforces
+//     that the preview reports only "same" — any spurious diff signals a real bug.
+//  2. Schema-migration scenarios (provider swapped between Up calls): the strip's
+//     effect is verified by inspecting the post-Up exported stack via resourceInputs
+//     and asserting the stale field was removed (or, for a changed default, that
+//     stored state reflects the new value). Stub TF providers used here do not run
+//     validation, so a "no error" assertion would pass even if the strip were
+//     deleted — the inputs check is what proves the strip ran.
+
+// assertNoChanges asserts that a preview reports only "same" resources. Use this on
+// no-op scenarios (no schema change, program unchanged) to catch spurious diffs that
+// would indicate the strip is producing inputs that don't round-trip through TF cleanly.
+func assertNoChanges(t *testing.T, summary map[apitype.OpType]int, label string) {
+	t.Helper()
+	for op, count := range summary {
+		require.Equalf(t, apitype.OpSame, op,
+			"%s: preview must report only 'same' resources; got %d %q ops (full summary: %+v)",
+			label, count, op, summary)
+	}
+}
+
+// assertOnlySameOrUpdate asserts that a preview reports only "same" or "update"
+// resources — never replace, create, or delete. Use this on schema-migration
+// scenarios where a transitional in-place update is expected (the strip removes a
+// stale value, so the resource updates to drop the field) but a replace would
+// indicate the strip caused unintended set-hash or identity changes.
+func assertOnlySameOrUpdate(t *testing.T, summary map[apitype.OpType]int, label string) {
+	t.Helper()
+	for op, count := range summary {
+		switch op {
+		case apitype.OpSame, apitype.OpUpdate:
+			// expected
+		default:
+			t.Errorf("%s: preview must report only same/update; got %d %q ops (full summary: %+v)",
+				label, count, op, summary)
+		}
+	}
+}
+
+// resourceInputs parses an exported stack and returns the stored Pulumi inputs map
+// for the first resource whose URN contains urnFragment. Inputs come from Check's
+// output and reflect "what the user (after default application) intended."
+func resourceInputs(t *testing.T, deployment []byte, urnFragment string) map[string]any {
+	t.Helper()
+	var stack struct {
+		Resources []map[string]any `json:"resources"`
+	}
+	require.NoError(t, json.Unmarshal(deployment, &stack), "decoding exported stack")
+	for _, r := range stack.Resources {
+		urn, _ := r["urn"].(string)
+		if strings.Contains(urn, urnFragment) {
+			val, _ := r["inputs"].(map[string]any)
+			require.NotNilf(t, val,
+				"resource %q has no stored inputs — the strip's effect cannot be verified", urn)
+			return val
+		}
+	}
+	t.Fatalf("no resource matching %q in exported stack", urnFragment)
+	return nil
+}
+
+// TestStripStaleDefaultsIntegration_DefaultRemoved exercises the original motivating
+// scenario: a TF schema default that exists when a resource is created is removed in
+// a later provider version. Preview after upgrade must report no spurious diff — the
+// strip removes the stale value so PlanResourceChange does not see it.
+func TestStripStaleDefaultsIntegration_DefaultRemoved(t *testing.T) {
+	t.Parallel()
+
+	withDefault := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"opt_field": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Default:  "old-default",
+					},
+				},
+			},
+		},
+	}
+	bp1 := pulcheck.BridgedProvider(t, "prov", withDefault)
+
+	withoutDefault := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"opt_field": {
+						Type:     schema.TypeString,
+						Optional: true,
+						// Default removed.
+					},
+				},
+			},
+		},
+	}
+	bp2 := pulcheck.BridgedProvider(t, "prov", withoutDefault)
+
+	program := `
+name: test
+runtime: yaml
+resources:
+  mainRes:
+    type: prov:index:Test
+`
+
+	pt := pulcheck.PulCheck(t, bp1, program)
+	pt.Up(t)
+	stack := pt.ExportStack(t)
+
+	pt2 := pulcheck.PulCheck(t, bp2, program)
+	pt2.ImportStack(t, stack)
+	preInputs := resourceInputs(t, pt2.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
+	require.Equal(t, "old-default", preInputs["optField"],
+		"sanity: imported state should still have the stale value before Up")
+
+	res := pt2.Preview(t, optpreview.Diff())
+	assertOnlySameOrUpdate(t, res.ChangeSummary, "DefaultRemoved")
+	pt2.Up(t)
+
+	// Strong assertion: the strip removed optField from the new inputs, so the post-Up
+	// stored inputs must NOT contain it. Without the strip, Check's "old default"
+	// reuse path would re-pin "old-default" into news on every Diff, and the post-Up
+	// state would still record optField; this assertion would fail.
+	postInputs := resourceInputs(t, pt2.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
+	_, hasField := postInputs["optField"]
+	require.False(t, hasField,
+		"after Up against the schema with no Default, optField must be absent from stored inputs; got %+v", postInputs)
+}
+
+// Note: there is no integration test for the *changed-default* scenario (provider
+// upgrade where a TF schema Default goes from v1 to v2). With the strip applied only
+// in Diff, the changed-default case is a known phantom-diff limitation — Diff/Preview
+// shows v1 → v2 but Update keeps v1 in state. This cannot be fixed by mirroring the
+// strip into Update without regressing the legacy-stack falsy-default round-trip
+// invariant from PR #3420 (TestUpdatePreservesLegacyFalsyTFDefaults). The TODO near
+// stripStaleDefaults points to the architectural cleanup that resolves this.
+
+// TestStripStaleDefaultsIntegration_FieldRemovedFromSchema covers the case where a
+// field is removed from the TF schema entirely. The stale value must not be forwarded
+// as an unknown attribute to PlanResourceChange.
+func TestStripStaleDefaultsIntegration_FieldRemovedFromSchema(t *testing.T) {
+	t.Parallel()
+
+	withField := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"keep_field": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"removed_field": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Default:  "default-value",
+					},
+				},
+			},
+		},
+	}
+	bp1 := pulcheck.BridgedProvider(t, "prov", withField)
+
+	withoutField := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"keep_field": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+	bp2 := pulcheck.BridgedProvider(t, "prov", withoutField)
+
+	program := `
+name: test
+runtime: yaml
+resources:
+  mainRes:
+    type: prov:index:Test
+    properties:
+      keepField: "value"
+`
+
+	pt := pulcheck.PulCheck(t, bp1, program)
+	pt.Up(t)
+	stack := pt.ExportStack(t)
+
+	pt2 := pulcheck.PulCheck(t, bp2, program)
+	pt2.ImportStack(t, stack)
+	preInputs := resourceInputs(t, pt2.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
+	require.Equal(t, "default-value", preInputs["removedField"],
+		"sanity: imported state should hold the stale removed_field value")
+
+	res := pt2.Preview(t, optpreview.Diff())
+	assertOnlySameOrUpdate(t, res.ChangeSummary, "FieldRemovedFromSchema")
+	pt2.Up(t)
+
+	// Strong assertion: the strip removed the dropped field entirely; the post-Up
+	// stored inputs must not carry it forward.
+	postInputs := resourceInputs(t, pt2.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
+	_, hasRemoved := postInputs["removedField"]
+	require.Falsef(t, hasRemoved,
+		"removedField must be absent from stored inputs after Up; got %+v", postInputs)
+	require.Equalf(t, "value", postInputs["keepField"],
+		"keepField must be preserved across the upgrade; got %+v", postInputs)
+}
+
+// TestStripStaleDefaultsIntegration_NestedTypeListBlock covers the recursion path:
+// a TypeList MaxItemsOne block with a nested field whose TF default is removed in
+// the upgraded schema. The nested __defaults entry must be stripped without
+// disturbing the surrounding block.
+func TestStripStaleDefaultsIntegration_NestedTypeListBlock(t *testing.T) {
+	t.Parallel()
+
+	withNestedDefault := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"block": {
+						Type:     schema.TypeList,
+						MaxItems: 1,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"nested_default": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "old-nested",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	bp1 := pulcheck.BridgedProvider(t, "prov", withNestedDefault)
+
+	withoutNestedDefault := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"block": {
+						Type:     schema.TypeList,
+						MaxItems: 1,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"nested_default": {
+									Type:     schema.TypeString,
+									Optional: true,
+									// Default removed.
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	bp2 := pulcheck.BridgedProvider(t, "prov", withoutNestedDefault)
+
+	program := `
+name: test
+runtime: yaml
+resources:
+  mainRes:
+    type: prov:index:Test
+    properties:
+      block:
+        name: "alpha"
+`
+
+	pt := pulcheck.PulCheck(t, bp1, program)
+	pt.Up(t)
+	stack := pt.ExportStack(t)
+
+	pt2 := pulcheck.PulCheck(t, bp2, program)
+	pt2.ImportStack(t, stack)
+	preInputs := resourceInputs(t, pt2.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
+	preBlock, _ := preInputs["block"].(map[string]any)
+	require.Equalf(t, "old-nested", preBlock["nestedDefault"],
+		"sanity: imported state should hold the stale nested default; got %+v", preBlock)
+
+	res := pt2.Preview(t, optpreview.Diff())
+	assertOnlySameOrUpdate(t, res.ChangeSummary, "NestedTypeListBlock")
+	pt2.Up(t)
+
+	// Strong assertion: nested recursion stripped the stale nested default.
+	postInputs := resourceInputs(t, pt2.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
+	postBlock, ok := postInputs["block"].(map[string]any)
+	require.Truef(t, ok, "block must remain in stored inputs; got %+v", postInputs)
+	_, hasNested := postBlock["nestedDefault"]
+	require.Falsef(t, hasNested,
+		"nestedDefault must be stripped from the nested block after Up; got %+v", postBlock)
+	require.Equalf(t, "alpha", postBlock["name"],
+		"sibling field 'name' must be preserved; got %+v", postBlock)
+}
+
+// TestStripStaleDefaultsIntegration_TypeListOfBlocks covers stripArrayOfBlocks: a
+// non-MaxItemsOne TypeList of objects, each carrying a nested __defaults entry that
+// is removed in the upgraded schema. Distinct from _NestedTypeListBlock which uses
+// MaxItems=1 (single object branch). TypeSet is intentionally skipped by the strip
+// (set membership is hash-based on element fields), but TypeList elements are
+// positional — this test confirms the array recursion path is still exercised for
+// TypeList and not accidentally disabled along with TypeSet.
+func TestStripStaleDefaultsIntegration_TypeListOfBlocks(t *testing.T) {
+	t.Parallel()
+
+	withNested := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"items": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {Type: schema.TypeString, Optional: true},
+								"nested_default": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "old-nested",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	bp1 := pulcheck.BridgedProvider(t, "prov", withNested)
+
+	withoutNested := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"items": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name":           {Type: schema.TypeString, Optional: true},
+								"nested_default": {Type: schema.TypeString, Optional: true},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	bp2 := pulcheck.BridgedProvider(t, "prov", withoutNested)
+
+	program := `
+name: test
+runtime: yaml
+resources:
+  mainRes:
+    type: prov:index:Test
+    properties:
+      items:
+        - name: "alpha"
+        - name: "beta"
+`
+
+	pt := pulcheck.PulCheck(t, bp1, program)
+	pt.Up(t)
+	stack := pt.ExportStack(t)
+
+	pt2 := pulcheck.PulCheck(t, bp2, program)
+	pt2.ImportStack(t, stack)
+	preInputs := resourceInputs(t, pt2.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
+	preItems, _ := preInputs["items"].([]any)
+	require.Lenf(t, preItems, 2, "sanity: imported state should hold two array elements; got %+v", preInputs)
+
+	res := pt2.Preview(t, optpreview.Diff())
+	assertOnlySameOrUpdate(t, res.ChangeSummary, "TypeListOfBlocks")
+	pt2.Up(t)
+
+	// Strong assertion: stripArrayOfBlocks recursed into each element and removed the
+	// stale nested default. Both elements must survive (positional identity is
+	// preserved for TypeList) and neither must carry the stripped field.
+	postInputs := resourceInputs(t, pt2.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
+	postItems, ok := postInputs["items"].([]any)
+	require.Truef(t, ok, "items must remain an array in stored inputs; got %+v", postInputs)
+	require.Lenf(t, postItems, 2, "both array elements must survive; got %+v", postItems)
+	for i, elem := range postItems {
+		obj, ok := elem.(map[string]any)
+		require.Truef(t, ok, "element %d must be an object; got %+v", i, elem)
+		_, hasNested := obj["nestedDefault"]
+		require.Falsef(t, hasNested,
+			"element %d must have nestedDefault stripped; got %+v", i, obj)
+	}
+}
+
+// TestStripStaleDefaultsIntegration_BridgeDefaultPreserved verifies that fields with
+// a bridge-managed default (SchemaInfo.Default) are NOT stripped on Diff — Check is
+// responsible for those, and stripping them would interfere with auto-naming and
+// similar bridge-side defaults.
+func TestStripStaleDefaultsIntegration_BridgeDefaultPreserved(t *testing.T) {
+	t.Parallel()
+
+	prov := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+	resourceInfo := map[string]*info.Resource{
+		"prov_test": {
+			Fields: map[string]*info.Schema{
+				"name": {Default: &info.Default{Value: "bridge-managed"}},
+			},
+		},
+	}
+	bp := pulcheck.BridgedProvider(t, "prov", prov, pulcheck.WithResourceInfo(resourceInfo))
+
+	program := `
+name: test
+runtime: yaml
+resources:
+  mainRes:
+    type: prov:index:Test
+`
+
+	pt := pulcheck.PulCheck(t, bp, program)
+	pt.Up(t)
+
+	// A no-op Preview must report only "same" — the bridge default for "name" must
+	// survive Diff with __defaults intact (otherwise Check would re-add it on the next
+	// run, but a stripped Diff could spuriously report an in-place update).
+	res := pt.Preview(t, optpreview.Diff())
+	assertNoChanges(t, res.ChangeSummary, "BridgeDefaultPreserved")
+}
+
+// TestStripStaleDefaultsIntegration_TypeSetHashStability is the regression guard for
+// the bug hit during development of this feature:
+// stripping nested fields from TypeSet elements changed element hashes and made TF
+// report set rearrangement instead of in-place updates.
+// The strip skips TypeSet entirely, so __defaults inside set elements remain intact
+// across the round-trip; this test verifies no spurious diff from that round-trip.
+func TestStripStaleDefaultsIntegration_TypeSetHashStability(t *testing.T) {
+	t.Parallel()
+
+	prov := &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			"prov_test": {
+				Schema: map[string]*schema.Schema{
+					"items": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:     schema.TypeString,
+									Optional: true,
+								},
+								"nested_default": {
+									Type:     schema.TypeString,
+									Optional: true,
+									Default:  "default-value",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	bp := pulcheck.BridgedProvider(t, "prov", prov)
+
+	program := `
+name: test
+runtime: yaml
+resources:
+  mainRes:
+    type: prov:index:Test
+    properties:
+      items:
+        - name: "alpha"
+        - name: "beta"
+`
+
+	pt := pulcheck.PulCheck(t, bp, program)
+	pt.Up(t)
+
+	res := pt.Preview(t, optpreview.Diff())
+	assertNoChanges(t, res.ChangeSummary, "TypeSetHashStability")
+}

--- a/pkg/tests/strip_stale_defaults_integration_test.go
+++ b/pkg/tests/strip_stale_defaults_integration_test.go
@@ -552,7 +552,7 @@ resources:
 // a future regression could let a stale value reach Update's plan while Diff's
 // plan stays clean — producing a Preview→Apply divergence.
 //
-// In current code Check sanitizes news upstream, so this test passes even if
+// In current code Check sanitizes `news` upstream, so this test passes even if
 // the Update-path strip is removed. Its value is forward-looking: any future
 // change that lets stale entries survive Check (custom state-edit hooks, new
 // RPC paths, refresh flows that bypass Check) would be caught here only if

--- a/pkg/tests/strip_stale_defaults_integration_test.go
+++ b/pkg/tests/strip_stale_defaults_integration_test.go
@@ -44,8 +44,9 @@ import (
 //     between Up calls): inspect the post-Up exported stack to confirm the
 //     stale field was removed.
 
-// assertNoChanges fails if the preview reports any op other than "same". Use on
-// no-op scenarios to catch spurious diffs caused by inputs that don't round-trip
+// assertNoChanges asserts that a preview reports only "same" resources. Use this
+// on no-op scenarios (no schema change, program unchanged) to catch spurious
+// diffs that would indicate the strip is producing inputs that don't round-trip
 // through TF cleanly.
 func assertNoChanges(t *testing.T, summary map[apitype.OpType]int, label string) {
 	t.Helper()
@@ -154,9 +155,11 @@ resources:
 	assertNoUnexpectedOps(t, res.ChangeSummary, "DefaultRemoved")
 	pt2.Up(t)
 
-	// Without the strip, Check's "old default" reuse path would re-pin
-	// "old-default" into news on every Diff and post-Up inputs would still
-	// record optField — so absence here proves the strip ran.
+	// Strong assertion: the strip removed optField from the new inputs, so the
+	// post-Up stored inputs must NOT contain it. Without the strip, Check's "old
+	// default" reuse path would re-pin "old-default" into news on every Diff,
+	// and the post-Up state would still record optField; this assertion would
+	// fail.
 	postInputs := resourceInputs(t, pt2.ExportStack(t).Deployment, "prov:index/test:Test::mainRes")
 	_, hasField := postInputs["optField"]
 	require.False(t, hasField,
@@ -486,16 +489,19 @@ resources:
 }
 
 // TestStripStaleDefaultsIntegration_StripAppliesInUpdatePath is a regression
-// guard for strip symmetry across the two RPC paths that feed PlanResourceChange
-// (Diff RPC and Update's internal tf.Diff). Both must strip before building the
-// TF config; if Update drifts, Preview and Apply diverge.
+// guard for the strip's symmetry across the two RPC paths that feed
+// PlanResourceChange: the Diff RPC and Update's internal tf.Diff. Both must
+// strip stale __defaults from `news` before building the TF config, otherwise
+// a future regression could let a stale value reach Update's plan while Diff's
+// plan stays clean — producing a Preview→Apply divergence.
 //
-// Check sanitizes news upstream today, so the test passes even if Update's
-// strip is removed. The value is forward-looking: a future path that leaks
-// stale entries past Check (custom state-edit hooks, new RPC paths, refresh
-// flows that bypass Check) would be caught only if both Diff and Update strip.
-// CustomizeDiff records every PlanResourceChange site that sees opt_field; the
-// assertion is zero.
+// In current code Check sanitizes news upstream, so this test passes even if
+// the Update-path strip is removed. Its value is forward-looking: any future
+// change that lets stale entries survive Check (custom state-edit hooks, new
+// RPC paths, refresh flows that bypass Check) would be caught here only if
+// both paths strip. The test fires CustomizeDiff on every PlanResourceChange
+// call — Diff RPC and Update RPC — and records every site where opt_field
+// reaches the raw config; the assertion is zero sites.
 func TestStripStaleDefaultsIntegration_StripAppliesInUpdatePath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tests/strip_stale_defaults_integration_test.go
+++ b/pkg/tests/strip_stale_defaults_integration_test.go
@@ -31,8 +31,9 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 )
 
-// These tests exercise stripStaleDefaults via the real Diff RPC path. The unit tests
-// in pkg/tfbridge/strip_stale_defaults_test.go cover the function in isolation, but
+// These tests exercise stripStaleDefaults via the runtime SDKv2 paths (Diff RPC
+// and Update's internal tf.Diff). The unit tests in
+// pkg/tfbridge/strip_stale_defaults_test.go cover the function in isolation, but
 // cannot catch issues that arise from the interaction between stripped inputs and
 // TF's plan, hash, or detailed-diff machinery.
 //
@@ -59,12 +60,14 @@ func assertNoChanges(t *testing.T, summary map[apitype.OpType]int, label string)
 	}
 }
 
-// assertOnlySameOrUpdate asserts that a preview reports only "same" or "update"
+// assertNoUnexpectedOps asserts that a preview reports only "same" or "update"
 // resources — never replace, create, or delete. Use this on schema-migration
 // scenarios where a transitional in-place update is expected (the strip removes a
 // stale value, so the resource updates to drop the field) but a replace would
-// indicate the strip caused unintended set-hash or identity changes.
-func assertOnlySameOrUpdate(t *testing.T, summary map[apitype.OpType]int, label string) {
+// indicate the strip caused unintended set-hash or identity changes. The function
+// only rejects unexpected op kinds; it does not require the summary to be
+// non-empty or assert that an update happened.
+func assertNoUnexpectedOps(t *testing.T, summary map[apitype.OpType]int, label string) {
 	t.Helper()
 	for op, count := range summary {
 		switch op {
@@ -155,7 +158,7 @@ resources:
 		"sanity: imported state should still have the stale value before Up")
 
 	res := pt2.Preview(t, optpreview.Diff())
-	assertOnlySameOrUpdate(t, res.ChangeSummary, "DefaultRemoved")
+	assertNoUnexpectedOps(t, res.ChangeSummary, "DefaultRemoved")
 	pt2.Up(t)
 
 	// Strong assertion: the strip removed optField from the new inputs, so the post-Up
@@ -169,12 +172,11 @@ resources:
 }
 
 // Note: there is no integration test for the *changed-default* scenario (provider
-// upgrade where a TF schema Default goes from v1 to v2). With the strip applied only
-// in Diff, the changed-default case is a known phantom-diff limitation — Diff/Preview
-// shows v1 → v2 but Update keeps v1 in state. This cannot be fixed by mirroring the
-// strip into Update without regressing the legacy-stack falsy-default round-trip
-// invariant from PR #3420 (TestUpdatePreservesLegacyFalsyTFDefaults). The TODO near
-// stripStaleDefaults points to the architectural cleanup that resolves this.
+// upgrade where a TF schema Default goes from v1 to v2). The changed-default case
+// is a known phantom-diff limitation tracked by issue #3434; resolving it without
+// regressing the legacy-stack falsy-default round-trip invariant
+// (TestUpdatePreservesLegacyFalsyTFDefaults) requires the architectural cleanup
+// described there.
 
 // TestStripStaleDefaultsIntegration_FieldRemovedFromSchema covers the case where a
 // field is removed from the TF schema entirely. The stale value must not be forwarded
@@ -236,7 +238,7 @@ resources:
 		"sanity: imported state should hold the stale removed_field value")
 
 	res := pt2.Preview(t, optpreview.Diff())
-	assertOnlySameOrUpdate(t, res.ChangeSummary, "FieldRemovedFromSchema")
+	assertNoUnexpectedOps(t, res.ChangeSummary, "FieldRemovedFromSchema")
 	pt2.Up(t)
 
 	// Strong assertion: the strip removed the dropped field entirely; the post-Up
@@ -335,7 +337,7 @@ resources:
 		"sanity: imported state should hold the stale nested default; got %+v", preBlock)
 
 	res := pt2.Preview(t, optpreview.Diff())
-	assertOnlySameOrUpdate(t, res.ChangeSummary, "NestedTypeListBlock")
+	assertNoUnexpectedOps(t, res.ChangeSummary, "NestedTypeListBlock")
 	pt2.Up(t)
 
 	// Strong assertion: nested recursion stripped the stale nested default.
@@ -426,7 +428,7 @@ resources:
 	require.Lenf(t, preItems, 2, "sanity: imported state should hold two array elements; got %+v", preInputs)
 
 	res := pt2.Preview(t, optpreview.Diff())
-	assertOnlySameOrUpdate(t, res.ChangeSummary, "TypeListOfBlocks")
+	assertNoUnexpectedOps(t, res.ChangeSummary, "TypeListOfBlocks")
 	pt2.Up(t)
 
 	// Strong assertion: stripArrayOfBlocks recursed into each element and removed the
@@ -492,11 +494,11 @@ resources:
 }
 
 // TestStripStaleDefaultsIntegration_StripAppliesInUpdatePath is a regression guard for
-// the strip's symmetry across the two RPC paths that feed PlanResourceChange: Diff
-// (provider.go:1175) and Update's internal tf.Diff (provider.go:~1707). Both must
-// strip stale __defaults from `news` before building the TF config, otherwise a
-// future regression could let a stale value reach Update's plan while Diff's plan
-// stays clean — producing a Preview→Apply divergence.
+// the strip's symmetry across the two RPC paths that feed PlanResourceChange: the
+// Diff RPC and Update's internal tf.Diff. Both must strip stale __defaults from
+// `news` before building the TF config, otherwise a future regression could let a
+// stale value reach Update's plan while Diff's plan stays clean — producing a
+// Preview→Apply divergence.
 //
 // In current code Check sanitizes news upstream, so this test passes even if the
 // Update-path strip is removed. Its value is forward-looking: any future change that

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -2173,8 +2173,9 @@ func stripStaleDefaultsRec(
 		return m, false
 	}
 
-	// Log only keys actually present in m; phantom __defaults entries are pruned
-	// silently — logging them as "stripped" would mislead.
+	// Log only stale keys that were actually present in m — phantom __defaults
+	// entries (listed but absent) are pruned silently from the kept list, since
+	// logging them as "stripped" would be misleading.
 	var loggedKeys []resource.PropertyKey
 	for _, k := range staleKeys {
 		if _, present := m[k]; present {
@@ -2204,26 +2205,30 @@ func stripStaleDefaultsRec(
 	return result, true
 }
 
-// shouldStripStaleDefault classifies a __defaults entry as strip or preserve.
-// Parity invariant: strip iff the same field would be excluded from default
-// application by applyDefaults during Check. The shared gate defaultExcluded
-// (schema.go) encodes the marker portion of that invariant; both applyDefaults
-// branches and this function call it.
+// shouldStripStaleDefault decides whether a __defaults entry should be stripped
+// from news or preserved. The strip is correct only when the same field would
+// be excluded from default application by applyDefaults during Check. The
+// shared gate defaultExcluded (schema.go) encodes the parity invariant; both
+// applyDefaults branches and this function call it.
 //
 // Precedence (first match wins):
 //
-//  1. defaultExcluded(tfSchema, psi) → strip. Removal markers override any
-//     HasDefault preservation so stale values can't reach PlanResourceChange.
-//  2. Bridge SchemaInfo.Default → preserve. Bridge defaults are
-//     non-deterministic (auto-naming, EnvVars, From); stripping would force
-//     re-derivation and break ID stability.
-//  3. TF schema Default or DefaultFunc → preserve. Avoids the changed-default
-//     phantom diff and preserves the legacy-stack falsy round-trip. Use the
-//     structural check, not DefaultValue() — the latter invokes DefaultFunc,
-//     which can return nil at runtime (unset env var) and would be
-//     misclassified as "no default."
-//  4. Default → strip. Neither side declares a default; the stored entry is
-//     stale.
+//  1. defaultExcluded(tfSchema, psi) → strip. Removal markers (bridge psi.Removed,
+//     TF Removed, TF Deprecated && !Required) take precedence over any HasDefault
+//     preservation so a stale stored value cannot leak through to PlanResourceChange
+//     even if a Default is still attached.
+//  2. Bridge SchemaInfo with a managed Default → preserve. These are
+//     non-deterministic (auto-naming, EnvVars, From callbacks); stripping
+//     would force re-derivation and break ID stability.
+//  3. TF schema declares Default or DefaultFunc → preserve. Avoids the
+//     changed-default phantom diff and preserves the legacy-stack falsy
+//     round-trip when a stored value matches the schema-declared default.
+//     Structural check (Default/DefaultFunc), not DefaultValue() — the latter
+//     invokes DefaultFunc, which can return nil at runtime (e.g. unset env
+//     var) and that runtime-nil result must not be misclassified as "no
+//     default."
+//  4. Default → strip. Neither the bridge nor the current TF schema declares
+//     a default for this field, so the stored entry is genuinely stale.
 func shouldStripStaleDefault(
 	pulumiName resource.PropertyKey,
 	tfs shim.SchemaMap,
@@ -2258,8 +2263,11 @@ func rewrapSecret(v resource.PropertyValue, isSecret bool) resource.PropertyValu
 	return v
 }
 
-// stripStaleDefaultsValue dispatches the recursion through a PropertyValue of
-// unknown shape (object, array-of-objects, or scalar). Returns whether v changed.
+// stripStaleDefaultsValue strips stale __defaults from a single PropertyValue
+// that may contain nested blocks (object or array-of-objects). Use this when
+// recursing through a value of unknown shape; use stripStaleDefaults directly
+// when you already have a PropertyMap. Returns the (possibly updated) value
+// and whether it changed.
 func stripStaleDefaultsValue(
 	v resource.PropertyValue,
 	key resource.PropertyKey,
@@ -2296,7 +2304,8 @@ func stripStaleDefaultsValue(
 	if psi != nil {
 		nestedPS = psi.Fields
 	}
-	// No nested resource → no nested __defaults.
+	// nestedTFS is nil for scalar fields, unknown fields, or fields whose Elem is
+	// not a Resource — none of those carry nested __defaults.
 	if nestedTFS == nil {
 		return v, false
 	}
@@ -2317,7 +2326,8 @@ func stripStaleDefaultsValue(
 		return resource.NewObjectProperty(stripped), true
 	}
 
-	// TypeList of blocks — positional identity, safe to strip nested fields.
+	// v.IsArray() — TypeList of blocks. (TypeSet was rejected above; TypeList
+	// elements have positional identity, so stripping nested fields is safe.)
 	if newArr, changed := stripArrayOfBlocks(v.ArrayValue(), nestedTFS, nestedPS); changed {
 		return resource.NewArrayProperty(newArr), true
 	}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -2269,10 +2269,10 @@ func rewrapSecret(v resource.PropertyValue, isSecret bool) resource.PropertyValu
 	return v
 }
 
-// stripStaleDefaultsValue strips stale __defaults from a single PropertyValue that may
-// contain nested blocks (object, array-of-objects, or map-of-objects). Use this when
-// recursing through a value of unknown shape; use stripStaleDefaults directly when you
-// already have a PropertyMap. Returns the (possibly updated) value and whether it changed.
+// stripStaleDefaultsValue strips stale __defaults from a single PropertyValue that
+// may contain nested blocks (object or array-of-objects). Use this when recursing
+// through a value of unknown shape; use stripStaleDefaults directly when you already
+// have a PropertyMap. Returns the (possibly updated) value and whether it changed.
 func stripStaleDefaultsValue(
 	v resource.PropertyValue,
 	key resource.PropertyKey,
@@ -2326,11 +2326,7 @@ func stripStaleDefaultsValue(
 	}
 
 	if v.IsObject() {
-		// Block-as-object: TypeList with MaxItemsOne flattened to a single object,
-		// or (in PF, where the strip does not currently apply) a TypeMap with
-		// Resource element. SDKv2 reinterprets TypeMap+Elem=Resource as a
-		// string-string map (see shim.go's Schema.Elem doc), so for the SDKv2 path
-		// the values would be scalars and stripStaleDefaults would no-op anyway.
+		// Block-as-object: TypeList with MaxItemsOne flattened to a single object.
 		stripped, changed := stripStaleDefaultsRec(v.ObjectValue(), nestedTFS, nestedPS)
 		if !changed {
 			return v, false

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -2103,7 +2103,7 @@ func newTimeoutOverrides(key shim.TimeoutKey, maybeTimeoutSeconds float64) map[s
 // i.e. the schema's Default/DefaultFunc is gone, the bridge's SchemaInfo no
 // longer supplies one, or the field is marked Removed/Deprecated. Without
 // this, Diff and Update would feed stale provider-defaulted values back into
-// PlanResourceChange and produce phantom diffs against an upgraded provider.
+// PlanResourceChange, which has caused problems during provider upgrades.
 //
 // Parity contract: a key is stripped iff applyDefaults (schema.go) would not
 // re-supply that default on the next Check.
@@ -2120,11 +2120,11 @@ func newTimeoutOverrides(key shim.TimeoutKey, maybeTimeoutSeconds float64) map[s
 //
 // Scope is deliberately narrow: only Diff and Update, only the config built
 // for PlanResourceChange. Check still runs full applyDefaults, and the
-// unstripped news is still handed to PlanStateEdit hooks via DiffOptions so
+// unstripped `news` is still handed to PlanStateEdit hooks via DiffOptions so
 // user-visible inputs aren't mutated.
 //
 // Known limitation: a changed TF default (v1 → v2) is preserved with the stale
-// v1 value because the schema still declares a Default.
+// v1 value because the schema still declares a Default. #3434 tracks this.
 func stripStaleDefaults(
 	news resource.PropertyMap,
 	tfs shim.SchemaMap,
@@ -2135,8 +2135,7 @@ func stripStaleDefaults(
 }
 
 // stripStaleDefaultsRec is the recursive worker. The bool reports whether anything
-// changed so recursion can skip reallocation on unchanged subtrees; the public
-// stripStaleDefaults wrapper drops it.
+// changed so recursion can skip reallocation on unchanged subtrees.
 func stripStaleDefaultsRec(
 	news resource.PropertyMap,
 	tfs shim.SchemaMap,
@@ -2186,7 +2185,7 @@ func stripStaleDefaultsRec(
 		return news, false
 	}
 
-	// Log only stale keys that were actually present in news — phantom __defaults
+	// Log only stale keys that were actually present in `news` — phantom __defaults
 	// entries (listed but absent) are pruned silently from the kept list, since
 	// logging them as "stripped" would be misleading.
 	var loggedKeys []resource.PropertyKey
@@ -2198,7 +2197,7 @@ func stripStaleDefaultsRec(
 	if len(loggedKeys) > 0 {
 		// V(5): same level as other unusual schema-evolution events (e.g.
 		// normalizeBlockCollections). Loud enough to triage post-upgrade-churn
-		// reports under `-v=5` without spamming routine logs at default verbosity.
+		// without spamming routine logs at default verbosity.
 		pulumilog.V(5).Infof("stripStaleDefaults: removing stale provider defaults from inputs: %v", loggedKeys)
 	}
 
@@ -2218,29 +2217,8 @@ func stripStaleDefaultsRec(
 }
 
 // shouldStripStaleDefault decides whether a __defaults entry should be stripped
-// from news or preserved. The strip is correct only when the same field would
-// be excluded from default application by applyDefaults during Check. The
-// shared gate defaultExcluded (schema.go) encodes the parity invariant; both
-// applyDefaults branches and this function call it.
-//
-// Precedence (first match wins):
-//
-//  1. defaultExcluded(tfSchema, psi) → strip. Removal markers (bridge psi.Removed,
-//     TF Removed, TF Deprecated && !Required) take precedence over any HasDefault
-//     preservation so a stale stored value cannot leak through to PlanResourceChange
-//     even if a Default is still attached.
-//  2. Bridge SchemaInfo with a managed Default → preserve. These are
-//     non-deterministic (auto-naming, EnvVars, From callbacks); stripping
-//     would force re-derivation and break ID stability.
-//  3. TF schema declares Default or DefaultFunc → preserve. Avoids the
-//     changed-default phantom diff and preserves the legacy-stack falsy
-//     round-trip when a stored value matches the schema-declared default.
-//     Structural check (Default/DefaultFunc), not DefaultValue() — the latter
-//     invokes DefaultFunc, which can return nil at runtime (e.g. unset env
-//     var) and that runtime-nil result must not be misclassified as "no
-//     default."
-//  4. Otherwise → strip. Neither the bridge nor the current TF schema
-//     declares a default for this field, so the stored entry is genuinely stale.
+// The strip is correct only when the same field would be excluded from default 
+// application by applyDefaults during Check, based on the shared defaultExcluded()
 func shouldStripStaleDefault(
 	pulumiName resource.PropertyKey,
 	tfs shim.SchemaMap,
@@ -2248,18 +2226,24 @@ func shouldStripStaleDefault(
 ) bool {
 	_, tfSchema, psi := getInfoFromPulumiName(pulumiName, tfs, ps)
 	switch {
+	// Removal markers on the schema field take precedence
 	case defaultExcluded(tfSchema, psi):
 		return true
+	// Bridge injected SchemaInfo with a managed default
+	// (e.g. auto-naming, EnvVars, etc)
 	case psi != nil && psi.HasDefault():
 		return false
+	// TF schema declares a default. Structural check (Default/DefaultFunc), 
+	// not DefaultValue() which invokes DefaultFunc() and can return a misleading nil 
+	// (e.g. unset env var)
 	case tfSchema != nil && (tfSchema.Default() != nil || tfSchema.DefaultFunc() != nil):
 		return false
+	// Neither the bridge nor the current TF schema declares a default for this field
 	default:
 		return true
 	}
 }
 
-// unwrapSecret returns the inner value and true if v is a secret, or v itself and false otherwise.
 func unwrapSecret(v resource.PropertyValue) (resource.PropertyValue, bool) {
 	if v.IsSecret() {
 		return v.SecretValue().Element, true
@@ -2267,7 +2251,6 @@ func unwrapSecret(v resource.PropertyValue) (resource.PropertyValue, bool) {
 	return v, false
 }
 
-// rewrapSecret wraps v in a secret if isSecret is true.
 func rewrapSecret(v resource.PropertyValue, isSecret bool) resource.PropertyValue {
 	if isSecret {
 		return resource.MakeSecret(v)

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"maps"
 	"os"
 	"sort"
 	"strings"
@@ -1210,9 +1211,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 
 		if changes == pulumirpc.DiffResponse_DIFF_SOME {
 			// Perhaps collectionDiffs can shed some light and locate the changes to the end-user.
-			for path, diff := range dd.collectionDiffs {
-				detailedDiff[path] = diff
-			}
+			maps.Copy(detailedDiff, dd.collectionDiffs)
 		}
 	}
 
@@ -2099,7 +2098,7 @@ func newTimeoutOverrides(key shim.TimeoutKey, maybeTimeoutSeconds float64) map[s
 	return timeoutOverrides
 }
 
-// stripStaleDefaults drops entries from m[reservedkeys.Defaults] (and the
+// stripStaleDefaults drops entries from news[reservedkeys.Defaults] (and the
 // corresponding values) when the provider would no longer fill them today —
 // i.e. the schema's Default/DefaultFunc is gone, the bridge's SchemaInfo no
 // longer supplies one, or the field is marked Removed/Deprecated. Without
@@ -2107,27 +2106,31 @@ func newTimeoutOverrides(key shim.TimeoutKey, maybeTimeoutSeconds float64) map[s
 // PlanResourceChange and produce phantom diffs against an upgraded provider.
 //
 // Parity contract: a key is stripped iff applyDefaults (schema.go) would not
-// re-supply that default on the next Check. Per-entry classification lives in
-// shouldStripStaleDefault; this function is just the recursive walk over
-// nested objects and array-of-object elements. TypeSet is intentionally
-// skipped: TF hashes set elements over all their fields, so editing a nested
-// field would scramble element identity and produce spurious set churn on the
-// next plan.
+// re-supply that default on the next Check.
+//
+// User-visible effect: a strip can surface as a one-time element rearrangement
+// on the next plan when the affected field sits inside a TypeSet element (TF
+// hashes Set membership over element fields, so removing a stale field changes
+// the element's hash). This mirrors `terraform apply` against the same
+// provider schema change and is preferable to silently retaining a value the
+// current schema can no longer attribute to a default.
+//
+// Per-entry classification lives in shouldStripStaleDefault; this function is
+// just the recursive walk over nested objects and array-of-object elements.
 //
 // Scope is deliberately narrow: only Diff and Update, only the config built
 // for PlanResourceChange. Check still runs full applyDefaults, and the
 // unstripped news is still handed to PlanStateEdit hooks via DiffOptions so
 // user-visible inputs aren't mutated.
 //
-// Known limitations, both resolved by #3434: a changed TF default (v1 → v2)
-// is preserved with the stale v1 value because the schema still declares a
-// Default; stale defaults inside TypeSet element schemas are not stripped.
+// Known limitation: a changed TF default (v1 → v2) is preserved with the stale
+// v1 value because the schema still declares a Default.
 func stripStaleDefaults(
-	m resource.PropertyMap,
+	news resource.PropertyMap,
 	tfs shim.SchemaMap,
 	ps map[string]*SchemaInfo,
 ) resource.PropertyMap {
-	stripped, _ := stripStaleDefaultsRec(m, tfs, ps)
+	stripped, _ := stripStaleDefaultsRec(news, tfs, ps)
 	return stripped
 }
 
@@ -2135,14 +2138,14 @@ func stripStaleDefaults(
 // changed so recursion can skip reallocation on unchanged subtrees; the public
 // stripStaleDefaults wrapper drops it.
 func stripStaleDefaultsRec(
-	m resource.PropertyMap,
+	news resource.PropertyMap,
 	tfs shim.SchemaMap,
 	ps map[string]*SchemaInfo,
 ) (resource.PropertyMap, bool) {
 	var staleKeys []resource.PropertyKey
 	var keptDefaults []resource.PropertyValue
 
-	if defaults, hasDefaults := m[reservedkeys.Defaults]; hasDefaults && defaults.IsArray() {
+	if defaults, hasDefaults := news[reservedkeys.Defaults]; hasDefaults && defaults.IsArray() {
 		for _, key := range defaults.ArrayValue() {
 			if !key.IsString() {
 				// Non-string entries shouldn't appear in __defaults but if they do,
@@ -2167,7 +2170,7 @@ func stripStaleDefaultsRec(
 		staleSet[k] = true
 	}
 	var nestedChanges map[resource.PropertyKey]resource.PropertyValue
-	for k, v := range m {
+	for k, v := range news {
 		if k == reservedkeys.Defaults || staleSet[k] {
 			continue
 		}
@@ -2180,33 +2183,32 @@ func stripStaleDefaultsRec(
 	}
 
 	if len(staleKeys) == 0 && len(nestedChanges) == 0 {
-		return m, false
+		return news, false
 	}
 
-	// Log only stale keys that were actually present in m — phantom __defaults
+	// Log only stale keys that were actually present in news — phantom __defaults
 	// entries (listed but absent) are pruned silently from the kept list, since
 	// logging them as "stripped" would be misleading.
 	var loggedKeys []resource.PropertyKey
 	for _, k := range staleKeys {
-		if _, present := m[k]; present {
+		if _, present := news[k]; present {
 			loggedKeys = append(loggedKeys, k)
 		}
 	}
 	if len(loggedKeys) > 0 {
-		pulumilog.V(9).Infof("stripStaleDefaults: removing stale provider defaults from inputs: %v", loggedKeys)
+		// V(5): same level as other unusual schema-evolution events (e.g.
+		// normalizeBlockCollections). Loud enough to triage post-upgrade-churn
+		// reports under `-v=5` without spamming routine logs at default verbosity.
+		pulumilog.V(5).Infof("stripStaleDefaults: removing stale provider defaults from inputs: %v", loggedKeys)
 	}
 
 	// Make a shallow copy to avoid mutating the original.
-	result := make(resource.PropertyMap, len(m))
-	for k, v := range m {
-		result[k] = v
-	}
+	result := make(resource.PropertyMap, len(news))
+	maps.Copy(result, news)
 	for _, k := range staleKeys {
 		delete(result, k)
 	}
-	for k, v := range nestedChanges {
-		result[k] = v
-	}
+	maps.Copy(result, nestedChanges)
 	if len(keptDefaults) > 0 {
 		result[reservedkeys.Defaults] = resource.NewArrayProperty(keptDefaults)
 	} else {
@@ -2237,8 +2239,8 @@ func stripStaleDefaultsRec(
 //     invokes DefaultFunc, which can return nil at runtime (e.g. unset env
 //     var) and that runtime-nil result must not be misclassified as "no
 //     default."
-//  4. Default → strip. Neither the bridge nor the current TF schema declares
-//     a default for this field, so the stored entry is genuinely stale.
+//  4. Otherwise → strip. Neither the bridge nor the current TF schema
+//     declares a default for this field, so the stored entry is genuinely stale.
 func shouldStripStaleDefault(
 	pulumiName resource.PropertyKey,
 	tfs shim.SchemaMap,
@@ -2278,15 +2280,18 @@ func rewrapSecret(v resource.PropertyValue, isSecret bool) resource.PropertyValu
 // recursing through a value of unknown shape; use stripStaleDefaults directly
 // when you already have a PropertyMap. Returns the (possibly updated) value
 // and whether it changed.
+//
+// parentKey is the Pulumi name under which v sits in its parent map; it's
+// used to resolve v's own schema so the recursion knows what shape v has.
 func stripStaleDefaultsValue(
 	v resource.PropertyValue,
-	key resource.PropertyKey,
+	parentKey resource.PropertyKey,
 	tfs shim.SchemaMap,
 	ps map[string]*SchemaInfo,
 ) (resource.PropertyValue, bool) {
 	// Unwrap secrets transparently — recurse on the inner value, re-wrap if changed.
 	if inner, isSecret := unwrapSecret(v); isSecret {
-		stripped, changed := stripStaleDefaultsValue(inner, key, tfs, ps)
+		stripped, changed := stripStaleDefaultsValue(inner, parentKey, tfs, ps)
 		if !changed {
 			return v, false
 		}
@@ -2302,7 +2307,7 @@ func stripStaleDefaultsValue(
 		return v, false
 	}
 
-	_, tfSchema, psi := getInfoFromPulumiName(key, tfs, ps)
+	_, tfSchema, psi := getInfoFromPulumiName(parentKey, tfs, ps)
 
 	var nestedTFS shim.SchemaMap
 	var nestedPS map[string]*SchemaInfo
@@ -2320,15 +2325,8 @@ func stripStaleDefaultsValue(
 		return v, false
 	}
 
-	// TypeSet membership hashes over element fields, so stripping a nested field
-	// would force spurious set rearrangement diffs. Skip whether flattened to an
-	// object (MaxItemsOne) or kept as an array.
-	if tfSchema.Type() == shim.TypeSet {
-		return v, false
-	}
-
 	if v.IsObject() {
-		// MaxItemsOne TypeList flattened to a single object.
+		// MaxItemsOne TypeList/TypeSet flattened to a single object.
 		stripped, changed := stripStaleDefaultsRec(v.ObjectValue(), nestedTFS, nestedPS)
 		if !changed {
 			return v, false
@@ -2336,8 +2334,7 @@ func stripStaleDefaultsValue(
 		return resource.NewObjectProperty(stripped), true
 	}
 
-	// v.IsArray() — TypeList of blocks. (TypeSet was rejected above; TypeList
-	// elements have positional identity, so stripping nested fields is safe.)
+	// v.IsArray() — TypeList or TypeSet of blocks.
 	if newArr, changed := stripArrayOfBlocks(v.ArrayValue(), nestedTFS, nestedPS); changed {
 		return resource.NewArrayProperty(newArr), true
 	}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/logging"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/providerserver"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/reservedkeys"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/typechecker"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
@@ -1153,6 +1154,15 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 
 	schema, fields := res.TF.Schema(), res.Schema.Fields
 
+	// Strip values from news that were provider defaults in a previous schema version
+	// but are no longer defaults in the current schema. This prevents stale defaults
+	// (carried in __defaults) from being sent as config to PlanResourceChange, where
+	// they can trigger validation errors during provider upgrades.
+	//
+	// This only affects the Diff path. Check is not affected because it receives fresh
+	// program inputs (not stored inputs with stale __defaults).
+	news = stripStaleDefaults(ctx, news, olds, schema, fields)
+
 	config, assets, err := MakeTerraformConfig(ctx, p, olds, news, schema, fields)
 	if err != nil {
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
@@ -2087,4 +2097,71 @@ func newTimeoutOverrides(key shim.TimeoutKey, maybeTimeoutSeconds float64) map[s
 		timeoutOverrides[key] = time.Duration(maybeTimeoutSeconds * float64(time.Second))
 	}
 	return timeoutOverrides
+}
+
+// stripStaleDefaults removes properties from the property map that were set as provider
+// defaults (listed in __defaults) but whose corresponding TF schema field no longer has
+// a default value. This handles the case where a provider upgrade removes a default:
+// the old default value persists in stored inputs via __defaults, and without stripping
+// it, the value gets sent as config to PlanResourceChange where it can fail validation.
+//
+// Fields with bridge-level defaults (e.g. auto-naming via SchemaInfo.Default) are
+// preserved since those defaults are still active and managed by the bridge.
+//
+// Note: when tfSchema is nil (field completely removed from schema), the field is kept
+// in news. This is safe because MakeTerraformConfig -> makeTerraformInputsWithOptions
+// drops fields with no corresponding TF schema entry during Pulumi-to-TF conversion,
+// so removed fields never reach PlanResourceChange regardless.
+func stripStaleDefaults(
+	ctx context.Context,
+	m resource.PropertyMap,
+	_ resource.PropertyMap, // olds, reserved for future use
+	tfs shim.SchemaMap,
+	ps map[string]*SchemaInfo,
+) resource.PropertyMap {
+	defaults, hasDefaults := m[reservedkeys.Defaults]
+	if !hasDefaults || !defaults.IsArray() {
+		return m
+	}
+
+	var staleKeys []resource.PropertyKey
+	var keptDefaults []resource.PropertyValue
+	for _, key := range defaults.ArrayValue() {
+		if !key.IsString() {
+			keptDefaults = append(keptDefaults, key)
+			continue
+		}
+		pulumiName := resource.PropertyKey(key.StringValue())
+		_, tfSchema, psi := getInfoFromPulumiName(pulumiName, tfs, ps)
+		hasTFDefault := tfSchema != nil && (tfSchema.Default() != nil || tfSchema.DefaultFunc() != nil)
+		hasBridgeDefault := psi != nil && psi.HasDefault()
+		if tfSchema != nil && !hasTFDefault && !hasBridgeDefault {
+			// This field was defaulted by the old TF provider but no longer has a
+			// default in either the TF schema or the bridge SchemaInfo.
+			staleKeys = append(staleKeys, pulumiName)
+		} else {
+			keptDefaults = append(keptDefaults, key)
+		}
+	}
+
+	if len(staleKeys) == 0 {
+		return m
+	}
+
+	log.Printf("[DEBUG] stripStaleDefaults: removing stale provider defaults from inputs: %v", staleKeys)
+
+	// Make a shallow copy to avoid mutating the original.
+	result := make(resource.PropertyMap, len(m))
+	for k, v := range m {
+		result[k] = v
+	}
+	for _, k := range staleKeys {
+		delete(result, k)
+	}
+	if len(keptDefaults) > 0 {
+		result[reservedkeys.Defaults] = resource.NewArrayProperty(keptDefaults)
+	} else {
+		delete(result, reservedkeys.Defaults)
+	}
+	return result
 }

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1162,7 +1162,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	// for shim.DiffOptions.NewInputs. NewInputs is consumed by PlanStateEdit hooks
 	// (WithPlanStateEdit) as the post-Check user input from Pulumi, so it must reflect
 	// what Check produced rather than the bridge's internal sanitization.
-	configNews, _ := stripStaleDefaults(ctx, news, schema, fields)
+	configNews, _ := stripStaleDefaults(news, schema, fields)
 
 	config, assets, err := MakeTerraformConfig(ctx, p, olds, configNews, schema, fields)
 	if err != nil {
@@ -1684,7 +1684,14 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 
 	schema, fields := res.TF.Schema(), res.Schema.Fields
 
-	config, assets, err := MakeTerraformConfig(ctx, p, olds, news, schema, fields)
+	// Mirror Diff: strip stale __defaults from the TF-facing config so Update's
+	// internal tf.Diff sees the same shape Diff RPC saw. Check normally sanitizes
+	// news before Update, so this is defense-in-depth for paths where Check is
+	// bypassed or where future state-edit hooks reintroduce stale entries. See the
+	// stripStaleDefaults doc for the full rationale.
+	configNews, _ := stripStaleDefaults(news, schema, fields)
+
+	config, assets, err := MakeTerraformConfig(ctx, p, olds, configNews, schema, fields)
 	if err != nil {
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
 	}
@@ -2106,6 +2113,11 @@ func newTimeoutOverrides(key shim.TimeoutKey, maybeTimeoutSeconds float64) map[s
 // PlanResourceChange can trigger validation errors or attribute-not-found errors;
 // stripping it lets the provider's plan re-derive (or omit) the field cleanly.
 //
+// Scope: applied to the news input on the Diff and Update RPCs (both feed
+// PlanResourceChange). Other RPCs (Create, Read, Refresh, Check) do not invoke
+// this — Check is responsible for not propagating stale defaults forward in the
+// first place; #3434 below tracks consolidating those guarantees.
+//
 // Each entry in __defaults is classified by classifyStaleDefault — see that
 // function's doc for the precedence rules and rationale for each branch. The
 // short version: strip if no mechanism (bridge default, current TF Default,
@@ -2144,7 +2156,6 @@ func newTimeoutOverrides(key shim.TimeoutKey, maybeTimeoutSeconds float64) map[s
 // the full SDKv2 lifecycle (validation interactions, GetRawConfig semantics, provider
 // Configure with Required+DefaultFunc, data source Invoke). Worth a dedicated PR.
 func stripStaleDefaults(
-	ctx context.Context,
 	m resource.PropertyMap,
 	tfs shim.SchemaMap,
 	ps map[string]*SchemaInfo,
@@ -2161,7 +2172,7 @@ func stripStaleDefaults(
 				continue
 			}
 			pulumiName := resource.PropertyKey(key.StringValue())
-			if classifyStaleDefault(pulumiName, tfs, ps) == staleDefaultStrip {
+			if shouldStripStaleDefault(pulumiName, tfs, ps) {
 				staleKeys = append(staleKeys, pulumiName)
 			} else {
 				keptDefaults = append(keptDefaults, key)
@@ -2181,7 +2192,7 @@ func stripStaleDefaults(
 		if k == reservedkeys.Defaults || staleSet[k] {
 			continue
 		}
-		if stripped, changed := stripStaleDefaultsValue(ctx, v, k, tfs, ps); changed {
+		if stripped, changed := stripStaleDefaultsValue(v, k, tfs, ps); changed {
 			if nestedChanges == nil {
 				nestedChanges = make(map[resource.PropertyKey]resource.PropertyValue)
 			}
@@ -2216,61 +2227,54 @@ func stripStaleDefaults(
 	return result, true
 }
 
-// staleDefaultDisposition classifies what stripStaleDefaults should do with a
-// __defaults entry: strip the corresponding value or preserve it.
-type staleDefaultDisposition int
-
-const (
-	staleDefaultStrip staleDefaultDisposition = iota
-	staleDefaultPreserve
-)
-
-// classifyStaleDefault decides whether a __defaults entry should be stripped
-// from news or preserved. The rules are ordered by precedence; each branch
-// mirrors the eligibility gate that applyDefaults applies in schema.go's
-// makeObjectTerraformInputs. Keep this in sync with applyDefaults — the strip
-// is correct only when the same field would be excluded from default
-// application by Check.
+// shouldStripStaleDefault decides whether a __defaults entry should be stripped
+// from news or preserved. The rules are ordered by precedence.
+//
+// The strip is correct only when the same field would be excluded from default
+// application by applyDefaults during Check. The shared gate
+// schemaMarkersSkipDefault (schema.go) encodes the TF-marker portion of that
+// invariant — both applyDefaults branches and this function call it, so changes
+// land in one place.
 //
 // Precedence (first match wins):
 //
 //  1. Bridge SchemaInfo.Removed → strip. Mirrors applyDefaults' overlay-branch
-//     skip; signals an overlay-level removal/rename.
-//  2. Bridge SchemaInfo with a managed Default → preserve. These are
+//     skip at schema.go:772.
+//  2. TF schema marker via schemaMarkersSkipDefault → strip. Mirrors the
+//     overlay-branch skip at schema.go:782 and TF-branch skip at schema.go:895.
+//     Removal-markers take precedence over HasDefault preservation so a stale
+//     stored value cannot leak through to PlanResourceChange even if a Default
+//     is still attached. Required-and-Deprecated is excluded by
+//     schemaMarkersSkipDefault — dropping a required field would break
+//     PlanResourceChange's required-field validation.
+//  3. Bridge SchemaInfo with a managed Default → preserve. These are
 //     non-deterministic (auto-naming, EnvVars, From callbacks); stripping
 //     would force re-derivation and break ID stability.
-//  3. TF schema Removed → strip. Field is no longer accepted by the provider;
-//     forwarding the stale value risks validation failure.
-//  4. TF schema Deprecated && !Required → strip. applyDefaults skips this case;
-//     deprecated-and-required is left to the Default-preservation branch below
-//     (a required field can't be stripped without breaking validation).
-//  5. TF schema declares Default or DefaultFunc → preserve. Avoids the
+//  4. TF schema declares Default or DefaultFunc → preserve. Avoids the
 //     changed-default phantom diff and preserves the legacy-stack falsy
-//     round-trip from PR #3420. Note: structural check (Default/DefaultFunc),
-//     not DefaultValue() — the latter invokes DefaultFunc, which can return
-//     nil at Diff time (e.g. unset env var) and that runtime-nil result must
-//     not be misclassified as "no default."
-//  6. Default → strip. No mechanism in the current bridge or schema can
+//     round-trip from PR #3420. Structural check (Default/DefaultFunc), not
+//     DefaultValue() — the latter invokes DefaultFunc, which can return nil
+//     at Diff time (e.g. unset env var) and that runtime-nil result must not
+//     be misclassified as "no default."
+//  5. Default → strip. No mechanism in the current bridge or schema can
 //     re-derive the value, so the stored entry is genuinely stale.
-func classifyStaleDefault(
+func shouldStripStaleDefault(
 	pulumiName resource.PropertyKey,
 	tfs shim.SchemaMap,
 	ps map[string]*SchemaInfo,
-) staleDefaultDisposition {
+) bool {
 	_, tfSchema, psi := getInfoFromPulumiName(pulumiName, tfs, ps)
 	switch {
 	case psi != nil && psi.Removed:
-		return staleDefaultStrip
+		return true
+	case schemaMarkersSkipDefault(tfSchema):
+		return true
 	case psi != nil && psi.HasDefault():
-		return staleDefaultPreserve
-	case tfSchema != nil && tfSchema.Removed() != "":
-		return staleDefaultStrip
-	case tfSchema != nil && tfSchema.Deprecated() != "" && !tfSchema.Required():
-		return staleDefaultStrip
+		return false
 	case tfSchema != nil && (tfSchema.Default() != nil || tfSchema.DefaultFunc() != nil):
-		return staleDefaultPreserve
+		return false
 	default:
-		return staleDefaultStrip
+		return true
 	}
 }
 
@@ -2295,7 +2299,6 @@ func rewrapSecret(v resource.PropertyValue, isSecret bool) resource.PropertyValu
 // recursing through a value of unknown shape; use stripStaleDefaults directly when you
 // already have a PropertyMap. Returns the (possibly updated) value and whether it changed.
 func stripStaleDefaultsValue(
-	ctx context.Context,
 	v resource.PropertyValue,
 	key resource.PropertyKey,
 	tfs shim.SchemaMap,
@@ -2303,7 +2306,7 @@ func stripStaleDefaultsValue(
 ) (resource.PropertyValue, bool) {
 	// Unwrap secrets transparently — recurse on the inner value, re-wrap if changed.
 	if v.IsSecret() {
-		inner, changed := stripStaleDefaultsValue(ctx, v.SecretValue().Element, key, tfs, ps)
+		inner, changed := stripStaleDefaultsValue(v.SecretValue().Element, key, tfs, ps)
 		if !changed {
 			return v, false
 		}
@@ -2353,7 +2356,7 @@ func stripStaleDefaultsValue(
 		// Resource element. SDKv2 reinterprets TypeMap+Elem=Resource as a
 		// string-string map (see shim.go's Schema.Elem doc), so for the SDKv2 path
 		// the values would be scalars and stripStaleDefaults would no-op anyway.
-		stripped, changed := stripStaleDefaults(ctx, v.ObjectValue(), nestedTFS, nestedPS)
+		stripped, changed := stripStaleDefaults(v.ObjectValue(), nestedTFS, nestedPS)
 		if !changed {
 			return v, false
 		}
@@ -2362,7 +2365,7 @@ func stripStaleDefaultsValue(
 
 	// v.IsArray() — TypeList of blocks. (TypeSet was rejected above; TypeList elements
 	// have positional identity, so stripping nested fields is safe.)
-	return stripArrayOfBlocks(ctx, v.ArrayValue(), nestedTFS, nestedPS)
+	return stripArrayOfBlocks(v.ArrayValue(), nestedTFS, nestedPS)
 }
 
 // stripArrayOfBlocks strips stale __defaults from each nested-block element of an
@@ -2370,7 +2373,6 @@ func stripStaleDefaultsValue(
 // input/state extraction does not produce multi-level Secret(Secret(...)) nesting
 // in practice, so deeper unwrapping would only be defensive.
 func stripArrayOfBlocks(
-	ctx context.Context,
 	arr []resource.PropertyValue,
 	nestedTFS shim.SchemaMap,
 	nestedPS map[string]*SchemaInfo,
@@ -2381,7 +2383,7 @@ func stripArrayOfBlocks(
 		if !inner.IsObject() {
 			continue
 		}
-		stripped, changed := stripStaleDefaults(ctx, inner.ObjectValue(), nestedTFS, nestedPS)
+		stripped, changed := stripStaleDefaults(inner.ObjectValue(), nestedTFS, nestedPS)
 		if !changed {
 			continue
 		}

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1154,10 +1154,9 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 
 	schema, fields := res.TF.Schema(), res.Schema.Fields
 
-	// Strip stale provider defaults for the TF-facing config only; pass the original
-	// `news` to shim.DiffOptions.NewInputs below so PlanStateEdit hooks see the
-	// post-Check user input rather than the bridge's internal sanitization. See the
-	// stripStaleDefaults doc for the full rationale.
+	// configNews has stale defaults stripped, so PlanResourceChange doesn't see
+	// them. NewInputs below keeps the raw `news` because PlanStateEdit hooks
+	// contract on Check's output, not on this bridge-internal transform.
 	configNews := stripStaleDefaults(news, schema, fields)
 
 	config, assets, err := MakeTerraformConfig(ctx, p, olds, configNews, schema, fields)
@@ -1680,8 +1679,8 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 
 	schema, fields := res.TF.Schema(), res.Schema.Fields
 
-	// Mirror Diff: strip stale provider defaults from the TF-facing config so
-	// Update's internal tf.Diff sees the same shape. See the stripStaleDefaults doc.
+	// Mirror Diff: strip stale defaults so Update's internal tf.Diff sees the
+	// same config shape Diff RPC saw.
 	configNews := stripStaleDefaults(news, schema, fields)
 
 	config, assets, err := MakeTerraformConfig(ctx, p, olds, configNews, schema, fields)
@@ -2100,11 +2099,13 @@ func newTimeoutOverrides(key shim.TimeoutKey, maybeTimeoutSeconds float64) map[s
 	return timeoutOverrides
 }
 
-// stripStaleDefaults removes properties from the property map that were recorded as
-// provider defaults (listed in __defaults) but for which the current schema offers
-// no mechanism to re-derive the value. Forwarding a stale stored value to
-// PlanResourceChange can trigger validation errors or attribute-not-found errors;
-// stripping it lets the provider's plan re-derive (or omit) the field cleanly.
+// stripStaleDefaults removes properties from the property map that were recorded
+// as provider defaults (listed in __defaults) but whose default the current
+// schema no longer declares — either because the field's Default was removed,
+// the field itself was removed, or the field is now marked Removed/Deprecated.
+// Forwarding such a stale stored value to PlanResourceChange can trigger
+// validation errors or attribute-not-found errors; stripping it lets the
+// provider's plan handle the field cleanly.
 //
 // Scope: applied to the news input on the Diff and Update RPCs. Other RPCs do not
 // invoke this — Check is responsible for not propagating stale defaults forward.
@@ -2233,8 +2234,8 @@ func stripStaleDefaultsRec(
 //     invokes DefaultFunc, which can return nil at runtime (e.g. unset env
 //     var) and that runtime-nil result must not be misclassified as "no
 //     default."
-//  4. Default → strip. No mechanism in the current bridge or schema can
-//     re-derive the value, so the stored entry is genuinely stale.
+//  4. Default → strip. Neither the bridge nor the current TF schema declares
+//     a default for this field, so the stored entry is genuinely stale.
 func shouldStripStaleDefault(
 	pulumiName resource.PropertyKey,
 	tfs shim.SchemaMap,

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -2099,19 +2099,29 @@ func newTimeoutOverrides(key shim.TimeoutKey, maybeTimeoutSeconds float64) map[s
 	return timeoutOverrides
 }
 
-// stripStaleDefaults removes __defaults entries whose default the current schema
-// no longer declares (Default removed, field removed, or field marked
-// Removed/Deprecated). Forwarding such a value to PlanResourceChange triggers
-// validation or attribute-not-found errors.
+// stripStaleDefaults drops entries from m[reservedkeys.Defaults] (and the
+// corresponding values) when the provider would no longer fill them today —
+// i.e. the schema's Default/DefaultFunc is gone, the bridge's SchemaInfo no
+// longer supplies one, or the field is marked Removed/Deprecated. Without
+// this, Diff and Update would feed stale provider-defaulted values back into
+// PlanResourceChange and produce phantom diffs against an upgraded provider.
 //
-// Applied to news in Diff and Update; other RPCs rely on Check to keep stale
-// defaults out. Per-entry rules: see shouldStripStaleDefault. Recurses into
-// nested blocks; skips TypeSet because set membership hashes over element
-// fields, so stripping would force spurious rearrangement diffs.
+// Parity contract: a key is stripped iff applyDefaults (schema.go) would not
+// re-supply that default on the next Check. Per-entry classification lives in
+// shouldStripStaleDefault; this function is just the recursive walk over
+// nested objects and array-of-object elements. TypeSet is intentionally
+// skipped: TF hashes set elements over all their fields, so editing a nested
+// field would scramble element identity and produce spurious set churn on the
+// next plan.
 //
-// Known limitations, both resolved by #3434: a changed TF default (v1 → v2) is
-// preserved with the stale v1 value because the schema still declares a Default;
-// stale defaults inside TypeSet element schemas are not stripped.
+// Scope is deliberately narrow: only Diff and Update, only the config built
+// for PlanResourceChange. Check still runs full applyDefaults, and the
+// unstripped news is still handed to PlanStateEdit hooks via DiffOptions so
+// user-visible inputs aren't mutated.
+//
+// Known limitations, both resolved by #3434: a changed TF default (v1 → v2)
+// is preserved with the stale v1 value because the schema still declares a
+// Default; stale defaults inside TypeSet element schemas are not stripped.
 func stripStaleDefaults(
 	m resource.PropertyMap,
 	tfs shim.SchemaMap,

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -2099,25 +2099,19 @@ func newTimeoutOverrides(key shim.TimeoutKey, maybeTimeoutSeconds float64) map[s
 	return timeoutOverrides
 }
 
-// stripStaleDefaults removes properties from the property map that were recorded
-// as provider defaults (listed in __defaults) but whose default the current
-// schema no longer declares — either because the field's Default was removed,
-// the field itself was removed, or the field is now marked Removed/Deprecated.
-// Forwarding such a stale stored value to PlanResourceChange can trigger
-// validation errors or attribute-not-found errors; stripping it lets the
-// provider's plan handle the field cleanly.
+// stripStaleDefaults removes __defaults entries whose default the current schema
+// no longer declares (Default removed, field removed, or field marked
+// Removed/Deprecated). Forwarding such a value to PlanResourceChange triggers
+// validation or attribute-not-found errors.
 //
-// Scope: applied to the news input on the Diff and Update RPCs. Other RPCs do not
-// invoke this — Check is responsible for not propagating stale defaults forward.
-// See shouldStripStaleDefault for the per-entry classification rules. The function
-// recurses into nested objects and array elements; TypeSet is skipped (set
-// membership is hash-based on element fields, so stripping nested fields would
-// change hashes and produce spurious set-rearrangement diffs).
+// Applied to news in Diff and Update; other RPCs rely on Check to keep stale
+// defaults out. Per-entry rules: see shouldStripStaleDefault. Recurses into
+// nested blocks; skips TypeSet because set membership hashes over element
+// fields, so stripping would force spurious rearrangement diffs.
 //
-// Known limitations (see issue #3434 for the architectural follow-up that resolves
-// both): a changed TF schema default v1 → v2 is preserved with the stale v1 value
-// because the schema still declares a Default; nested defaults inside TypeSet
-// element schemas are not stripped.
+// Known limitations, both resolved by #3434: a changed TF default (v1 → v2) is
+// preserved with the stale v1 value because the schema still declares a Default;
+// stale defaults inside TypeSet element schemas are not stripped.
 func stripStaleDefaults(
 	m resource.PropertyMap,
 	tfs shim.SchemaMap,
@@ -2127,10 +2121,9 @@ func stripStaleDefaults(
 	return stripped
 }
 
-// stripStaleDefaultsRec is the recursive worker behind stripStaleDefaults. The bool
-// return reports whether anything changed; recursion uses it to short-circuit
-// re-allocation when a subtree is unchanged. The public stripStaleDefaults wrapper
-// drops the bool because no caller acts on it.
+// stripStaleDefaultsRec is the recursive worker. The bool reports whether anything
+// changed so recursion can skip reallocation on unchanged subtrees; the public
+// stripStaleDefaults wrapper drops it.
 func stripStaleDefaultsRec(
 	m resource.PropertyMap,
 	tfs shim.SchemaMap,
@@ -2156,9 +2149,9 @@ func stripStaleDefaultsRec(
 		}
 	}
 
-	// Recurse into non-stale keys to strip nested __defaults. Stale keys are skipped
-	// here — they're deleted below, and recursing into them would accidentally re-insert
-	// them via nestedChanges.
+	// Recurse into non-stale keys to strip nested __defaults. Stale keys are
+	// skipped here because recursing into them would re-insert them via
+	// nestedChanges, defeating the deletion below.
 	staleSet := make(map[resource.PropertyKey]bool, len(staleKeys))
 	for _, k := range staleKeys {
 		staleSet[k] = true
@@ -2180,9 +2173,8 @@ func stripStaleDefaultsRec(
 		return m, false
 	}
 
-	// Log only stale keys that were actually present in m — phantom __defaults
-	// entries (listed but absent) are pruned silently from the kept list, since
-	// logging them as "stripped" would be misleading.
+	// Log only keys actually present in m; phantom __defaults entries are pruned
+	// silently — logging them as "stripped" would mislead.
 	var loggedKeys []resource.PropertyKey
 	for _, k := range staleKeys {
 		if _, present := m[k]; present {
@@ -2212,30 +2204,26 @@ func stripStaleDefaultsRec(
 	return result, true
 }
 
-// shouldStripStaleDefault decides whether a __defaults entry should be stripped
-// from news or preserved. The strip is correct only when the same field would
-// be excluded from default application by applyDefaults during Check. The
-// shared gate defaultExcluded (schema.go) encodes the parity invariant; both
-// applyDefaults branches and this function call it.
+// shouldStripStaleDefault classifies a __defaults entry as strip or preserve.
+// Parity invariant: strip iff the same field would be excluded from default
+// application by applyDefaults during Check. The shared gate defaultExcluded
+// (schema.go) encodes the marker portion of that invariant; both applyDefaults
+// branches and this function call it.
 //
 // Precedence (first match wins):
 //
-//  1. defaultExcluded(tfSchema, psi) → strip. Removal markers (bridge psi.Removed,
-//     TF Removed, TF Deprecated && !Required) take precedence over any HasDefault
-//     preservation so a stale stored value cannot leak through to PlanResourceChange
-//     even if a Default is still attached.
-//  2. Bridge SchemaInfo with a managed Default → preserve. These are
-//     non-deterministic (auto-naming, EnvVars, From callbacks); stripping
-//     would force re-derivation and break ID stability.
-//  3. TF schema declares Default or DefaultFunc → preserve. Avoids the
-//     changed-default phantom diff and preserves the legacy-stack falsy
-//     round-trip when a stored value matches the schema-declared default.
-//     Structural check (Default/DefaultFunc), not DefaultValue() — the latter
-//     invokes DefaultFunc, which can return nil at runtime (e.g. unset env
-//     var) and that runtime-nil result must not be misclassified as "no
-//     default."
-//  4. Default → strip. Neither the bridge nor the current TF schema declares
-//     a default for this field, so the stored entry is genuinely stale.
+//  1. defaultExcluded(tfSchema, psi) → strip. Removal markers override any
+//     HasDefault preservation so stale values can't reach PlanResourceChange.
+//  2. Bridge SchemaInfo.Default → preserve. Bridge defaults are
+//     non-deterministic (auto-naming, EnvVars, From); stripping would force
+//     re-derivation and break ID stability.
+//  3. TF schema Default or DefaultFunc → preserve. Avoids the changed-default
+//     phantom diff and preserves the legacy-stack falsy round-trip. Use the
+//     structural check, not DefaultValue() — the latter invokes DefaultFunc,
+//     which can return nil at runtime (unset env var) and would be
+//     misclassified as "no default."
+//  4. Default → strip. Neither side declares a default; the stored entry is
+//     stale.
 func shouldStripStaleDefault(
 	pulumiName resource.PropertyKey,
 	tfs shim.SchemaMap,
@@ -2270,10 +2258,8 @@ func rewrapSecret(v resource.PropertyValue, isSecret bool) resource.PropertyValu
 	return v
 }
 
-// stripStaleDefaultsValue strips stale __defaults from a single PropertyValue that
-// may contain nested blocks (object or array-of-objects). Use this when recursing
-// through a value of unknown shape; use stripStaleDefaults directly when you already
-// have a PropertyMap. Returns the (possibly updated) value and whether it changed.
+// stripStaleDefaultsValue dispatches the recursion through a PropertyValue of
+// unknown shape (object, array-of-objects, or scalar). Returns whether v changed.
 func stripStaleDefaultsValue(
 	v resource.PropertyValue,
 	key resource.PropertyKey,
@@ -2298,10 +2284,8 @@ func stripStaleDefaultsValue(
 		return v, false
 	}
 
-	// Look up the TF schema and bridge SchemaInfo for this field in the parent schema.
 	_, tfSchema, psi := getInfoFromPulumiName(key, tfs, ps)
 
-	// Get the nested SchemaMap and Fields from the element schema.
 	var nestedTFS shim.SchemaMap
 	var nestedPS map[string]*SchemaInfo
 	if tfSchema != nil {
@@ -2312,22 +2296,20 @@ func stripStaleDefaultsValue(
 	if psi != nil {
 		nestedPS = psi.Fields
 	}
-	// nestedTFS is nil for scalar fields, unknown fields, or fields whose Elem is not a
-	// Resource — none of those carry nested __defaults.
+	// No nested resource → no nested __defaults.
 	if nestedTFS == nil {
 		return v, false
 	}
 
-	// Skip TypeSet entirely: set membership is hash-based on all element fields, so
-	// stripping a field from a nested element changes its hash and makes TF see set
-	// reorder/add/remove diffs instead of in-place updates. This applies whether the
-	// set is flattened to an object (MaxItemsOne) or kept as an array.
+	// TypeSet membership hashes over element fields, so stripping a nested field
+	// would force spurious set rearrangement diffs. Skip whether flattened to an
+	// object (MaxItemsOne) or kept as an array.
 	if tfSchema.Type() == shim.TypeSet {
 		return v, false
 	}
 
 	if v.IsObject() {
-		// Block-as-object: TypeList with MaxItemsOne flattened to a single object.
+		// MaxItemsOne TypeList flattened to a single object.
 		stripped, changed := stripStaleDefaultsRec(v.ObjectValue(), nestedTFS, nestedPS)
 		if !changed {
 			return v, false
@@ -2335,21 +2317,17 @@ func stripStaleDefaultsValue(
 		return resource.NewObjectProperty(stripped), true
 	}
 
-	// v.IsArray() — TypeList of blocks. (TypeSet was rejected above; TypeList elements
-	// have positional identity, so stripping nested fields is safe.)
+	// TypeList of blocks — positional identity, safe to strip nested fields.
 	if newArr, changed := stripArrayOfBlocks(v.ArrayValue(), nestedTFS, nestedPS); changed {
 		return resource.NewArrayProperty(newArr), true
 	}
 	return v, false
 }
 
-// stripArrayOfBlocks strips stale __defaults from each nested-block element of an
-// array. Returns the new slice (only when changed) and whether any element was
-// rewritten. Callers wrap in NewArrayProperty only on the changed path so the
-// no-change path doesn't allocate.
-//
-// Each element is unwrapped at most one level of secret; the bridge's input/state
-// extraction does not produce multi-level Secret(Secret(...)) nesting in practice.
+// stripArrayOfBlocks strips stale __defaults from each block element. Returns
+// the new slice only if at least one element changed; the no-change path
+// returns nil so callers skip the NewArrayProperty allocation. Element secrets
+// are unwrapped one level (the bridge doesn't produce nested Secret wraps).
 func stripArrayOfBlocks(
 	arr []resource.PropertyValue,
 	nestedTFS shim.SchemaMap,

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -2217,7 +2217,7 @@ func stripStaleDefaultsRec(
 }
 
 // shouldStripStaleDefault decides whether a __defaults entry should be stripped
-// The strip is correct only when the same field would be excluded from default 
+// The strip is correct only when the same field would be excluded from default
 // application by applyDefaults during Check, based on the shared defaultExcluded()
 func shouldStripStaleDefault(
 	pulumiName resource.PropertyKey,
@@ -2233,8 +2233,8 @@ func shouldStripStaleDefault(
 	// (e.g. auto-naming, EnvVars, etc)
 	case psi != nil && psi.HasDefault():
 		return false
-	// TF schema declares a default. Structural check (Default/DefaultFunc), 
-	// not DefaultValue() which invokes DefaultFunc() and can return a misleading nil 
+	// TF schema declares a default. Structural check (Default/DefaultFunc),
+	// not DefaultValue() which invokes DefaultFunc() and can return a misleading nil
 	// (e.g. unset env var)
 	case tfSchema != nil && (tfSchema.Default() != nil || tfSchema.DefaultFunc() != nil):
 		return false

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1154,15 +1154,11 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 
 	schema, fields := res.TF.Schema(), res.Schema.Fields
 
-	// Drop values that were provider-defaulted (recorded in __defaults) but are no longer
-	// bridge-managed, so PlanResourceChange does not see stale defaults from a prior
-	// schema version. See the function doc for the full rationale.
-	//
-	// Use the stripped map only for the TF-facing config; preserve the original `news`
-	// for shim.DiffOptions.NewInputs. NewInputs is consumed by PlanStateEdit hooks
-	// (WithPlanStateEdit) as the post-Check user input from Pulumi, so it must reflect
-	// what Check produced rather than the bridge's internal sanitization.
-	configNews, _ := stripStaleDefaults(news, schema, fields)
+	// Strip stale provider defaults for the TF-facing config only; pass the original
+	// `news` to shim.DiffOptions.NewInputs below so PlanStateEdit hooks see the
+	// post-Check user input rather than the bridge's internal sanitization. See the
+	// stripStaleDefaults doc for the full rationale.
+	configNews := stripStaleDefaults(news, schema, fields)
 
 	config, assets, err := MakeTerraformConfig(ctx, p, olds, configNews, schema, fields)
 	if err != nil {
@@ -1684,12 +1680,9 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 
 	schema, fields := res.TF.Schema(), res.Schema.Fields
 
-	// Mirror Diff: strip stale __defaults from the TF-facing config so Update's
-	// internal tf.Diff sees the same shape Diff RPC saw. Check normally sanitizes
-	// news before Update, so this is defense-in-depth for paths where Check is
-	// bypassed or where future state-edit hooks reintroduce stale entries. See the
-	// stripStaleDefaults doc for the full rationale.
-	configNews, _ := stripStaleDefaults(news, schema, fields)
+	// Mirror Diff: strip stale provider defaults from the TF-facing config so
+	// Update's internal tf.Diff sees the same shape. See the stripStaleDefaults doc.
+	configNews := stripStaleDefaults(news, schema, fields)
 
 	config, assets, err := MakeTerraformConfig(ctx, p, olds, configNews, schema, fields)
 	if err != nil {
@@ -2113,49 +2106,31 @@ func newTimeoutOverrides(key shim.TimeoutKey, maybeTimeoutSeconds float64) map[s
 // PlanResourceChange can trigger validation errors or attribute-not-found errors;
 // stripping it lets the provider's plan re-derive (or omit) the field cleanly.
 //
-// Scope: applied to the news input on the Diff and Update RPCs (both feed
-// PlanResourceChange). Other RPCs (Create, Read, Refresh, Check) do not invoke
-// this — Check is responsible for not propagating stale defaults forward in the
-// first place; #3434 below tracks consolidating those guarantees.
+// Scope: applied to the news input on the Diff and Update RPCs. Other RPCs do not
+// invoke this — Check is responsible for not propagating stale defaults forward.
+// See shouldStripStaleDefault for the per-entry classification rules. The function
+// recurses into nested objects and array elements; TypeSet is skipped (set
+// membership is hash-based on element fields, so stripping nested fields would
+// change hashes and produce spurious set-rearrangement diffs).
 //
-// Each entry in __defaults is classified by classifyStaleDefault — see that
-// function's doc for the precedence rules and rationale for each branch. The
-// short version: strip if no mechanism (bridge default, current TF Default,
-// current TF DefaultFunc) can re-derive the value, or if the field is marked
-// Removed/Deprecated such that the stored value should not be forwarded.
-//
-// This function recurses into nested objects and array elements, since each nested
-// block can carry its own __defaults with independently-stale entries. TypeSet
-// fields are skipped during recursion entirely — set membership is hash-based on
-// all element fields, and stripping a nested field would change element hashes and
-// produce spurious set rearrangement diffs.
-//
-// Known limitations:
-//
-//   - Changed TF schema default (v1 → v2): the field is preserved with its stale
-//     v1 value because the schema still declares a Default. Users silently keep the
-//     old default until they explicitly set the new value in their program. The
-//     architectural follow-up below resolves this case fully.
-//   - Stale defaults inside TypeSet element schemas: because the recursion skips
-//     TypeSet, a removed nested default inside a set element will still reach TF
-//     raw config. Providers that run CustomizeDiff validation on a removed-default
-//     field nested inside a TypeSet block will continue to fail in that case until
-//     the architectural cleanup lands.
-//
-// Running state upgraders on inputs is not viable: upgraders expect the full output
-// shape (computed fields, IDs) and would corrupt the input subset.
-//
-// TODO[pulumi/pulumi-terraform-bridge#3434]: the architectural fix is for applyDefaults to
-// stop tracking TF schema defaults in __defaults at all (only bridge defaults like
-// auto-naming, EnvVars, From should be tracked). Then Check re-derives TF defaults
-// from the current schema each call, the "old default" reuse path only fires for
-// bridge defaults, and the changed-default phantom diff disappears because Check
-// produces the new default in news rather than reusing the old. PR #3398 took the
-// first step (suppressing fresh falsy TF defaults from being materialized) but
-// explicitly held off on the broader change pending evidence that it is safe across
-// the full SDKv2 lifecycle (validation interactions, GetRawConfig semantics, provider
-// Configure with Required+DefaultFunc, data source Invoke). Worth a dedicated PR.
+// Known limitations (see issue #3434 for the architectural follow-up that resolves
+// both): a changed TF schema default v1 → v2 is preserved with the stale v1 value
+// because the schema still declares a Default; nested defaults inside TypeSet
+// element schemas are not stripped.
 func stripStaleDefaults(
+	m resource.PropertyMap,
+	tfs shim.SchemaMap,
+	ps map[string]*SchemaInfo,
+) resource.PropertyMap {
+	stripped, _ := stripStaleDefaultsRec(m, tfs, ps)
+	return stripped
+}
+
+// stripStaleDefaultsRec is the recursive worker behind stripStaleDefaults. The bool
+// return reports whether anything changed; recursion uses it to short-circuit
+// re-allocation when a subtree is unchanged. The public stripStaleDefaults wrapper
+// drops the bool because no caller acts on it.
+func stripStaleDefaultsRec(
 	m resource.PropertyMap,
 	tfs shim.SchemaMap,
 	ps map[string]*SchemaInfo,
@@ -2204,8 +2179,17 @@ func stripStaleDefaults(
 		return m, false
 	}
 
-	if len(staleKeys) > 0 {
-		pulumilog.V(9).Infof("stripStaleDefaults: removing stale provider defaults from inputs: %v", staleKeys)
+	// Log only stale keys that were actually present in m — phantom __defaults
+	// entries (listed but absent) are pruned silently from the kept list, since
+	// logging them as "stripped" would be misleading.
+	var loggedKeys []resource.PropertyKey
+	for _, k := range staleKeys {
+		if _, present := m[k]; present {
+			loggedKeys = append(loggedKeys, k)
+		}
+	}
+	if len(loggedKeys) > 0 {
+		pulumilog.V(9).Infof("stripStaleDefaults: removing stale provider defaults from inputs: %v", loggedKeys)
 	}
 
 	// Make a shallow copy to avoid mutating the original.
@@ -2228,35 +2212,28 @@ func stripStaleDefaults(
 }
 
 // shouldStripStaleDefault decides whether a __defaults entry should be stripped
-// from news or preserved. The rules are ordered by precedence.
-//
-// The strip is correct only when the same field would be excluded from default
-// application by applyDefaults during Check. The shared gate
-// schemaMarkersSkipDefault (schema.go) encodes the TF-marker portion of that
-// invariant — both applyDefaults branches and this function call it, so changes
-// land in one place.
+// from news or preserved. The strip is correct only when the same field would
+// be excluded from default application by applyDefaults during Check. The
+// shared gate defaultExcluded (schema.go) encodes the parity invariant; both
+// applyDefaults branches and this function call it.
 //
 // Precedence (first match wins):
 //
-//  1. Bridge SchemaInfo.Removed → strip. Mirrors applyDefaults' overlay-branch
-//     skip at schema.go:772.
-//  2. TF schema marker via schemaMarkersSkipDefault → strip. Mirrors the
-//     overlay-branch skip at schema.go:782 and TF-branch skip at schema.go:895.
-//     Removal-markers take precedence over HasDefault preservation so a stale
-//     stored value cannot leak through to PlanResourceChange even if a Default
-//     is still attached. Required-and-Deprecated is excluded by
-//     schemaMarkersSkipDefault — dropping a required field would break
-//     PlanResourceChange's required-field validation.
-//  3. Bridge SchemaInfo with a managed Default → preserve. These are
+//  1. defaultExcluded(tfSchema, psi) → strip. Removal markers (bridge psi.Removed,
+//     TF Removed, TF Deprecated && !Required) take precedence over any HasDefault
+//     preservation so a stale stored value cannot leak through to PlanResourceChange
+//     even if a Default is still attached.
+//  2. Bridge SchemaInfo with a managed Default → preserve. These are
 //     non-deterministic (auto-naming, EnvVars, From callbacks); stripping
 //     would force re-derivation and break ID stability.
-//  4. TF schema declares Default or DefaultFunc → preserve. Avoids the
+//  3. TF schema declares Default or DefaultFunc → preserve. Avoids the
 //     changed-default phantom diff and preserves the legacy-stack falsy
-//     round-trip from PR #3420. Structural check (Default/DefaultFunc), not
-//     DefaultValue() — the latter invokes DefaultFunc, which can return nil
-//     at Diff time (e.g. unset env var) and that runtime-nil result must not
-//     be misclassified as "no default."
-//  5. Default → strip. No mechanism in the current bridge or schema can
+//     round-trip when a stored value matches the schema-declared default.
+//     Structural check (Default/DefaultFunc), not DefaultValue() — the latter
+//     invokes DefaultFunc, which can return nil at runtime (e.g. unset env
+//     var) and that runtime-nil result must not be misclassified as "no
+//     default."
+//  4. Default → strip. No mechanism in the current bridge or schema can
 //     re-derive the value, so the stored entry is genuinely stale.
 func shouldStripStaleDefault(
 	pulumiName resource.PropertyKey,
@@ -2265,9 +2242,7 @@ func shouldStripStaleDefault(
 ) bool {
 	_, tfSchema, psi := getInfoFromPulumiName(pulumiName, tfs, ps)
 	switch {
-	case psi != nil && psi.Removed:
-		return true
-	case schemaMarkersSkipDefault(tfSchema):
+	case defaultExcluded(tfSchema, psi):
 		return true
 	case psi != nil && psi.HasDefault():
 		return false
@@ -2305,12 +2280,12 @@ func stripStaleDefaultsValue(
 	ps map[string]*SchemaInfo,
 ) (resource.PropertyValue, bool) {
 	// Unwrap secrets transparently — recurse on the inner value, re-wrap if changed.
-	if v.IsSecret() {
-		inner, changed := stripStaleDefaultsValue(v.SecretValue().Element, key, tfs, ps)
+	if inner, isSecret := unwrapSecret(v); isSecret {
+		stripped, changed := stripStaleDefaultsValue(inner, key, tfs, ps)
 		if !changed {
 			return v, false
 		}
-		return resource.MakeSecret(inner), true
+		return rewrapSecret(stripped, true), true
 	}
 
 	// Only objects and arrays can contain nested __defaults.
@@ -2356,7 +2331,7 @@ func stripStaleDefaultsValue(
 		// Resource element. SDKv2 reinterprets TypeMap+Elem=Resource as a
 		// string-string map (see shim.go's Schema.Elem doc), so for the SDKv2 path
 		// the values would be scalars and stripStaleDefaults would no-op anyway.
-		stripped, changed := stripStaleDefaults(v.ObjectValue(), nestedTFS, nestedPS)
+		stripped, changed := stripStaleDefaultsRec(v.ObjectValue(), nestedTFS, nestedPS)
 		if !changed {
 			return v, false
 		}
@@ -2365,25 +2340,31 @@ func stripStaleDefaultsValue(
 
 	// v.IsArray() — TypeList of blocks. (TypeSet was rejected above; TypeList elements
 	// have positional identity, so stripping nested fields is safe.)
-	return stripArrayOfBlocks(v.ArrayValue(), nestedTFS, nestedPS)
+	if newArr, changed := stripArrayOfBlocks(v.ArrayValue(), nestedTFS, nestedPS); changed {
+		return resource.NewArrayProperty(newArr), true
+	}
+	return v, false
 }
 
 // stripArrayOfBlocks strips stale __defaults from each nested-block element of an
-// array. Each element is unwrapped at most one level of secret here; the bridge's
-// input/state extraction does not produce multi-level Secret(Secret(...)) nesting
-// in practice, so deeper unwrapping would only be defensive.
+// array. Returns the new slice (only when changed) and whether any element was
+// rewritten. Callers wrap in NewArrayProperty only on the changed path so the
+// no-change path doesn't allocate.
+//
+// Each element is unwrapped at most one level of secret; the bridge's input/state
+// extraction does not produce multi-level Secret(Secret(...)) nesting in practice.
 func stripArrayOfBlocks(
 	arr []resource.PropertyValue,
 	nestedTFS shim.SchemaMap,
 	nestedPS map[string]*SchemaInfo,
-) (resource.PropertyValue, bool) {
+) ([]resource.PropertyValue, bool) {
 	var newArr []resource.PropertyValue
 	for i, elem := range arr {
 		inner, isSecret := unwrapSecret(elem)
 		if !inner.IsObject() {
 			continue
 		}
-		stripped, changed := stripStaleDefaults(inner.ObjectValue(), nestedTFS, nestedPS)
+		stripped, changed := stripStaleDefaultsRec(inner.ObjectValue(), nestedTFS, nestedPS)
 		if !changed {
 			continue
 		}
@@ -2394,7 +2375,7 @@ func stripArrayOfBlocks(
 		newArr[i] = rewrapSecret(resource.NewObjectProperty(stripped), isSecret)
 	}
 	if newArr == nil {
-		return resource.NewArrayProperty(arr), false
+		return nil, false
 	}
-	return resource.NewArrayProperty(newArr), true
+	return newArr, true
 }

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1154,16 +1154,17 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 
 	schema, fields := res.TF.Schema(), res.Schema.Fields
 
-	// Strip values from news that were provider defaults in a previous schema version
-	// but are no longer defaults in the current schema. This prevents stale defaults
-	// (carried in __defaults) from being sent as config to PlanResourceChange, where
-	// they can trigger validation errors during provider upgrades.
+	// Drop values that were provider-defaulted (recorded in __defaults) but are no longer
+	// bridge-managed, so PlanResourceChange does not see stale defaults from a prior
+	// schema version. See the function doc for the full rationale.
 	//
-	// This only affects the Diff path. Check is not affected because it receives fresh
-	// program inputs (not stored inputs with stale __defaults).
-	news = stripStaleDefaults(ctx, news, olds, schema, fields)
+	// Use the stripped map only for the TF-facing config; preserve the original `news`
+	// for shim.DiffOptions.NewInputs. NewInputs is consumed by PlanStateEdit hooks
+	// (WithPlanStateEdit) as the post-Check user input from Pulumi, so it must reflect
+	// what Check produced rather than the bridge's internal sanitization.
+	configNews, _ := stripStaleDefaults(ctx, news, schema, fields)
 
-	config, assets, err := MakeTerraformConfig(ctx, p, olds, news, schema, fields)
+	config, assets, err := MakeTerraformConfig(ctx, p, olds, configNews, schema, fields)
 	if err != nil {
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
 	}
@@ -2099,56 +2100,102 @@ func newTimeoutOverrides(key shim.TimeoutKey, maybeTimeoutSeconds float64) map[s
 	return timeoutOverrides
 }
 
-// stripStaleDefaults removes properties from the property map that were set as provider
-// defaults (listed in __defaults) but whose corresponding TF schema field no longer has
-// a default value. This handles the case where a provider upgrade removes a default:
-// the old default value persists in stored inputs via __defaults, and without stripping
-// it, the value gets sent as config to PlanResourceChange where it can fail validation.
+// stripStaleDefaults removes properties from the property map that were recorded as
+// provider defaults (listed in __defaults) but for which the current schema offers
+// no mechanism to re-derive the value. Forwarding a stale stored value to
+// PlanResourceChange can trigger validation errors or attribute-not-found errors;
+// stripping it lets the provider's plan re-derive (or omit) the field cleanly.
 //
-// Fields with bridge-level defaults (e.g. auto-naming via SchemaInfo.Default) are
-// preserved since those defaults are still active and managed by the bridge.
+// Each entry in __defaults is classified by classifyStaleDefault — see that
+// function's doc for the precedence rules and rationale for each branch. The
+// short version: strip if no mechanism (bridge default, current TF Default,
+// current TF DefaultFunc) can re-derive the value, or if the field is marked
+// Removed/Deprecated such that the stored value should not be forwarded.
 //
-// Note: when tfSchema is nil (field completely removed from schema), the field is kept
-// in news. This is safe because MakeTerraformConfig -> makeTerraformInputsWithOptions
-// drops fields with no corresponding TF schema entry during Pulumi-to-TF conversion,
-// so removed fields never reach PlanResourceChange regardless.
+// This function recurses into nested objects and array elements, since each nested
+// block can carry its own __defaults with independently-stale entries. TypeSet
+// fields are skipped during recursion entirely — set membership is hash-based on
+// all element fields, and stripping a nested field would change element hashes and
+// produce spurious set rearrangement diffs.
+//
+// Known limitations:
+//
+//   - Changed TF schema default (v1 → v2): the field is preserved with its stale
+//     v1 value because the schema still declares a Default. Users silently keep the
+//     old default until they explicitly set the new value in their program. The
+//     architectural follow-up below resolves this case fully.
+//   - Stale defaults inside TypeSet element schemas: because the recursion skips
+//     TypeSet, a removed nested default inside a set element will still reach TF
+//     raw config. Providers that run CustomizeDiff validation on a removed-default
+//     field nested inside a TypeSet block will continue to fail in that case until
+//     the architectural cleanup lands.
+//
+// Running state upgraders on inputs is not viable: upgraders expect the full output
+// shape (computed fields, IDs) and would corrupt the input subset.
+//
+// TODO[pulumi/pulumi-terraform-bridge#3434]: the architectural fix is for applyDefaults to
+// stop tracking TF schema defaults in __defaults at all (only bridge defaults like
+// auto-naming, EnvVars, From should be tracked). Then Check re-derives TF defaults
+// from the current schema each call, the "old default" reuse path only fires for
+// bridge defaults, and the changed-default phantom diff disappears because Check
+// produces the new default in news rather than reusing the old. PR #3398 took the
+// first step (suppressing fresh falsy TF defaults from being materialized) but
+// explicitly held off on the broader change pending evidence that it is safe across
+// the full SDKv2 lifecycle (validation interactions, GetRawConfig semantics, provider
+// Configure with Required+DefaultFunc, data source Invoke). Worth a dedicated PR.
 func stripStaleDefaults(
 	ctx context.Context,
 	m resource.PropertyMap,
-	_ resource.PropertyMap, // olds, reserved for future use
 	tfs shim.SchemaMap,
 	ps map[string]*SchemaInfo,
-) resource.PropertyMap {
-	defaults, hasDefaults := m[reservedkeys.Defaults]
-	if !hasDefaults || !defaults.IsArray() {
-		return m
-	}
-
+) (resource.PropertyMap, bool) {
 	var staleKeys []resource.PropertyKey
 	var keptDefaults []resource.PropertyValue
-	for _, key := range defaults.ArrayValue() {
-		if !key.IsString() {
-			keptDefaults = append(keptDefaults, key)
+
+	if defaults, hasDefaults := m[reservedkeys.Defaults]; hasDefaults && defaults.IsArray() {
+		for _, key := range defaults.ArrayValue() {
+			if !key.IsString() {
+				// Non-string entries shouldn't appear in __defaults but if they do,
+				// preserve verbatim — we have nothing to look up against the schema.
+				keptDefaults = append(keptDefaults, key)
+				continue
+			}
+			pulumiName := resource.PropertyKey(key.StringValue())
+			if classifyStaleDefault(pulumiName, tfs, ps) == staleDefaultStrip {
+				staleKeys = append(staleKeys, pulumiName)
+			} else {
+				keptDefaults = append(keptDefaults, key)
+			}
+		}
+	}
+
+	// Recurse into non-stale keys to strip nested __defaults. Stale keys are skipped
+	// here — they're deleted below, and recursing into them would accidentally re-insert
+	// them via nestedChanges.
+	staleSet := make(map[resource.PropertyKey]bool, len(staleKeys))
+	for _, k := range staleKeys {
+		staleSet[k] = true
+	}
+	var nestedChanges map[resource.PropertyKey]resource.PropertyValue
+	for k, v := range m {
+		if k == reservedkeys.Defaults || staleSet[k] {
 			continue
 		}
-		pulumiName := resource.PropertyKey(key.StringValue())
-		_, tfSchema, psi := getInfoFromPulumiName(pulumiName, tfs, ps)
-		hasTFDefault := tfSchema != nil && (tfSchema.Default() != nil || tfSchema.DefaultFunc() != nil)
-		hasBridgeDefault := psi != nil && psi.HasDefault()
-		if tfSchema != nil && !hasTFDefault && !hasBridgeDefault {
-			// This field was defaulted by the old TF provider but no longer has a
-			// default in either the TF schema or the bridge SchemaInfo.
-			staleKeys = append(staleKeys, pulumiName)
-		} else {
-			keptDefaults = append(keptDefaults, key)
+		if stripped, changed := stripStaleDefaultsValue(ctx, v, k, tfs, ps); changed {
+			if nestedChanges == nil {
+				nestedChanges = make(map[resource.PropertyKey]resource.PropertyValue)
+			}
+			nestedChanges[k] = stripped
 		}
 	}
 
-	if len(staleKeys) == 0 {
-		return m
+	if len(staleKeys) == 0 && len(nestedChanges) == 0 {
+		return m, false
 	}
 
-	log.Printf("[DEBUG] stripStaleDefaults: removing stale provider defaults from inputs: %v", staleKeys)
+	if len(staleKeys) > 0 {
+		pulumilog.V(9).Infof("stripStaleDefaults: removing stale provider defaults from inputs: %v", staleKeys)
+	}
 
 	// Make a shallow copy to avoid mutating the original.
 	result := make(resource.PropertyMap, len(m))
@@ -2158,10 +2205,194 @@ func stripStaleDefaults(
 	for _, k := range staleKeys {
 		delete(result, k)
 	}
+	for k, v := range nestedChanges {
+		result[k] = v
+	}
 	if len(keptDefaults) > 0 {
 		result[reservedkeys.Defaults] = resource.NewArrayProperty(keptDefaults)
 	} else {
 		delete(result, reservedkeys.Defaults)
 	}
-	return result
+	return result, true
+}
+
+// staleDefaultDisposition classifies what stripStaleDefaults should do with a
+// __defaults entry: strip the corresponding value or preserve it.
+type staleDefaultDisposition int
+
+const (
+	staleDefaultStrip staleDefaultDisposition = iota
+	staleDefaultPreserve
+)
+
+// classifyStaleDefault decides whether a __defaults entry should be stripped
+// from news or preserved. The rules are ordered by precedence; each branch
+// mirrors the eligibility gate that applyDefaults applies in schema.go's
+// makeObjectTerraformInputs. Keep this in sync with applyDefaults — the strip
+// is correct only when the same field would be excluded from default
+// application by Check.
+//
+// Precedence (first match wins):
+//
+//  1. Bridge SchemaInfo.Removed → strip. Mirrors applyDefaults' overlay-branch
+//     skip; signals an overlay-level removal/rename.
+//  2. Bridge SchemaInfo with a managed Default → preserve. These are
+//     non-deterministic (auto-naming, EnvVars, From callbacks); stripping
+//     would force re-derivation and break ID stability.
+//  3. TF schema Removed → strip. Field is no longer accepted by the provider;
+//     forwarding the stale value risks validation failure.
+//  4. TF schema Deprecated && !Required → strip. applyDefaults skips this case;
+//     deprecated-and-required is left to the Default-preservation branch below
+//     (a required field can't be stripped without breaking validation).
+//  5. TF schema declares Default or DefaultFunc → preserve. Avoids the
+//     changed-default phantom diff and preserves the legacy-stack falsy
+//     round-trip from PR #3420. Note: structural check (Default/DefaultFunc),
+//     not DefaultValue() — the latter invokes DefaultFunc, which can return
+//     nil at Diff time (e.g. unset env var) and that runtime-nil result must
+//     not be misclassified as "no default."
+//  6. Default → strip. No mechanism in the current bridge or schema can
+//     re-derive the value, so the stored entry is genuinely stale.
+func classifyStaleDefault(
+	pulumiName resource.PropertyKey,
+	tfs shim.SchemaMap,
+	ps map[string]*SchemaInfo,
+) staleDefaultDisposition {
+	_, tfSchema, psi := getInfoFromPulumiName(pulumiName, tfs, ps)
+	switch {
+	case psi != nil && psi.Removed:
+		return staleDefaultStrip
+	case psi != nil && psi.HasDefault():
+		return staleDefaultPreserve
+	case tfSchema != nil && tfSchema.Removed() != "":
+		return staleDefaultStrip
+	case tfSchema != nil && tfSchema.Deprecated() != "" && !tfSchema.Required():
+		return staleDefaultStrip
+	case tfSchema != nil && (tfSchema.Default() != nil || tfSchema.DefaultFunc() != nil):
+		return staleDefaultPreserve
+	default:
+		return staleDefaultStrip
+	}
+}
+
+// unwrapSecret returns the inner value and true if v is a secret, or v itself and false otherwise.
+func unwrapSecret(v resource.PropertyValue) (resource.PropertyValue, bool) {
+	if v.IsSecret() {
+		return v.SecretValue().Element, true
+	}
+	return v, false
+}
+
+// rewrapSecret wraps v in a secret if isSecret is true.
+func rewrapSecret(v resource.PropertyValue, isSecret bool) resource.PropertyValue {
+	if isSecret {
+		return resource.MakeSecret(v)
+	}
+	return v
+}
+
+// stripStaleDefaultsValue strips stale __defaults from a single PropertyValue that may
+// contain nested blocks (object, array-of-objects, or map-of-objects). Use this when
+// recursing through a value of unknown shape; use stripStaleDefaults directly when you
+// already have a PropertyMap. Returns the (possibly updated) value and whether it changed.
+func stripStaleDefaultsValue(
+	ctx context.Context,
+	v resource.PropertyValue,
+	key resource.PropertyKey,
+	tfs shim.SchemaMap,
+	ps map[string]*SchemaInfo,
+) (resource.PropertyValue, bool) {
+	// Unwrap secrets transparently — recurse on the inner value, re-wrap if changed.
+	if v.IsSecret() {
+		inner, changed := stripStaleDefaultsValue(ctx, v.SecretValue().Element, key, tfs, ps)
+		if !changed {
+			return v, false
+		}
+		return resource.MakeSecret(inner), true
+	}
+
+	// Only objects and arrays can contain nested __defaults.
+	if !v.IsObject() && !v.IsArray() {
+		return v, false
+	}
+
+	if tfs == nil {
+		return v, false
+	}
+
+	// Look up the TF schema and bridge SchemaInfo for this field in the parent schema.
+	_, tfSchema, psi := getInfoFromPulumiName(key, tfs, ps)
+
+	// Get the nested SchemaMap and Fields from the element schema.
+	var nestedTFS shim.SchemaMap
+	var nestedPS map[string]*SchemaInfo
+	if tfSchema != nil {
+		if res, ok := tfSchema.Elem().(shim.Resource); ok {
+			nestedTFS = res.Schema()
+		}
+	}
+	if psi != nil {
+		nestedPS = psi.Fields
+	}
+	// nestedTFS is nil for scalar fields, unknown fields, or fields whose Elem is not a
+	// Resource — none of those carry nested __defaults.
+	if nestedTFS == nil {
+		return v, false
+	}
+
+	// Skip TypeSet entirely: set membership is hash-based on all element fields, so
+	// stripping a field from a nested element changes its hash and makes TF see set
+	// reorder/add/remove diffs instead of in-place updates. This applies whether the
+	// set is flattened to an object (MaxItemsOne) or kept as an array.
+	if tfSchema.Type() == shim.TypeSet {
+		return v, false
+	}
+
+	if v.IsObject() {
+		// Block-as-object: TypeList with MaxItemsOne flattened to a single object,
+		// or (in PF, where the strip does not currently apply) a TypeMap with
+		// Resource element. SDKv2 reinterprets TypeMap+Elem=Resource as a
+		// string-string map (see shim.go's Schema.Elem doc), so for the SDKv2 path
+		// the values would be scalars and stripStaleDefaults would no-op anyway.
+		stripped, changed := stripStaleDefaults(ctx, v.ObjectValue(), nestedTFS, nestedPS)
+		if !changed {
+			return v, false
+		}
+		return resource.NewObjectProperty(stripped), true
+	}
+
+	// v.IsArray() — TypeList of blocks. (TypeSet was rejected above; TypeList elements
+	// have positional identity, so stripping nested fields is safe.)
+	return stripArrayOfBlocks(ctx, v.ArrayValue(), nestedTFS, nestedPS)
+}
+
+// stripArrayOfBlocks strips stale __defaults from each nested-block element of an
+// array. Each element is unwrapped at most one level of secret here; the bridge's
+// input/state extraction does not produce multi-level Secret(Secret(...)) nesting
+// in practice, so deeper unwrapping would only be defensive.
+func stripArrayOfBlocks(
+	ctx context.Context,
+	arr []resource.PropertyValue,
+	nestedTFS shim.SchemaMap,
+	nestedPS map[string]*SchemaInfo,
+) (resource.PropertyValue, bool) {
+	var newArr []resource.PropertyValue
+	for i, elem := range arr {
+		inner, isSecret := unwrapSecret(elem)
+		if !inner.IsObject() {
+			continue
+		}
+		stripped, changed := stripStaleDefaults(ctx, inner.ObjectValue(), nestedTFS, nestedPS)
+		if !changed {
+			continue
+		}
+		if newArr == nil {
+			newArr = make([]resource.PropertyValue, len(arr))
+			copy(newArr, arr)
+		}
+		newArr[i] = rewrapSecret(resource.NewObjectProperty(stripped), isSecret)
+	}
+	if newArr == nil {
+		return resource.NewArrayProperty(arr), false
+	}
+	return resource.NewArrayProperty(newArr), true
 }

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -739,17 +739,13 @@ func buildConflictsWith(result map[string]interface{}, tfs shim.SchemaMap) map[s
 	return conflictsWith
 }
 
-// defaultExcluded returns true if the field must not have any default applied —
-// neither from the TF schema's Default/DefaultFunc, nor from a bridge overlay's
-// SchemaInfo.Default, nor reused from old state. The function combines bridge-
-// overlay markers (psi.Removed) with TF schema markers (Removed; Deprecated
-// without Required). Required-and-Deprecated is intentionally excluded: a
-// required field cannot be dropped without breaking PlanResourceChange's
-// required-field validation.
+// defaultExcluded reports fields that are ineligible for default application —
+// flagged by SchemaInfo.Removed or by TF schema markers (Removed, or Deprecated
+// && !Required). Required-and-Deprecated is intentionally excluded: dropping a
+// required field would break PlanResourceChange's required-field validation.
 //
-// This is the shared parity gate. applyDefaults' overlay and TF branches and
-// provider.go's shouldStripStaleDefault all call through here. Modify only
-// here; the three sites stay in lockstep automatically.
+// Shared parity gate: applyDefaults' overlay and TF branches and provider.go's
+// shouldStripStaleDefault all call through here. Modify only here.
 func defaultExcluded(sch shim.Schema, psi *SchemaInfo) bool {
 	if psi != nil && psi.Removed {
 		return true

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -739,13 +739,17 @@ func buildConflictsWith(result map[string]interface{}, tfs shim.SchemaMap) map[s
 	return conflictsWith
 }
 
-// defaultExcluded reports fields that are ineligible for default application —
-// flagged by SchemaInfo.Removed or by TF schema markers (Removed, or Deprecated
-// && !Required). Required-and-Deprecated is intentionally excluded: dropping a
-// required field would break PlanResourceChange's required-field validation.
+// defaultExcluded returns true if the field must not have any default applied —
+// neither from the TF schema's Default/DefaultFunc, nor from a bridge overlay's
+// SchemaInfo.Default, nor reused from old state. The function combines bridge-
+// overlay markers (psi.Removed) with TF schema markers (Removed; Deprecated
+// without Required). Required-and-Deprecated is intentionally excluded: a
+// required field cannot be dropped without breaking PlanResourceChange's
+// required-field validation.
 //
-// Shared parity gate: applyDefaults' overlay and TF branches and provider.go's
-// shouldStripStaleDefault all call through here. Modify only here.
+// This is the shared parity gate. applyDefaults' overlay and TF branches and
+// provider.go's shouldStripStaleDefault all call through here. Modify only
+// here; the three sites stay in lockstep automatically.
 func defaultExcluded(sch shim.Schema, psi *SchemaInfo) bool {
 	if psi != nil && psi.Removed {
 		return true

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -746,10 +746,6 @@ func buildConflictsWith(result map[string]interface{}, tfs shim.SchemaMap) map[s
 // without Required). Required-and-Deprecated is intentionally excluded: a
 // required field cannot be dropped without breaking PlanResourceChange's
 // required-field validation.
-//
-// This is the shared parity gate. applyDefaults' overlay and TF branches and
-// provider.go's shouldStripStaleDefault all call through here. Modify only
-// here; the three sites stay in lockstep automatically.
 func defaultExcluded(sch shim.Schema, psi *SchemaInfo) bool {
 	if psi != nil && psi.Removed {
 		return true

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -739,16 +739,21 @@ func buildConflictsWith(result map[string]interface{}, tfs shim.SchemaMap) map[s
 	return conflictsWith
 }
 
-// schemaMarkersSkipDefault returns true if the TF schema marks a field such
-// that applyDefaults must skip applying any default to it. The exact gate is
-// shared by applyDefaults' overlay and TF branches and by shouldStripStaleDefault
-// in provider.go — keeping the three call sites in lockstep is the parity
-// invariant. Modify only here.
+// defaultExcluded returns true if the field must not have any default applied —
+// neither from the TF schema's Default/DefaultFunc, nor from a bridge overlay's
+// SchemaInfo.Default, nor reused from old state. The function combines bridge-
+// overlay markers (psi.Removed) with TF schema markers (Removed; Deprecated
+// without Required). Required-and-Deprecated is intentionally excluded: a
+// required field cannot be dropped without breaking PlanResourceChange's
+// required-field validation.
 //
-// Required-and-Deprecated is intentionally excluded: a required field cannot be
-// dropped without breaking PlanResourceChange's required-field validation, so
-// applyDefaults still applies its default and the strip still preserves it.
-func schemaMarkersSkipDefault(sch shim.Schema) bool {
+// This is the shared parity gate. applyDefaults' overlay and TF branches and
+// provider.go's shouldStripStaleDefault all call through here. Modify only
+// here; the three sites stay in lockstep automatically.
+func defaultExcluded(sch shim.Schema, psi *SchemaInfo) bool {
+	if psi != nil && psi.Removed {
+		return true
+	}
 	if sch == nil {
 		return false
 	}
@@ -788,17 +793,14 @@ func (ctx *conversionContext) applyDefaults(
 
 	// First, attempt to use the overlays.
 	for name, info := range ps {
-		if info.Removed {
+		sch := getSchema(tfs, name)
+		if defaultExcluded(sch, info) {
 			continue
 		}
 		if _, conflicts := conflictsWith[name]; conflicts {
 			continue
 		}
 		if _, exactlyOneOfConflicts := exactlyOneOf[name]; exactlyOneOfConflicts {
-			continue
-		}
-		sch := getSchema(tfs, name)
-		if schemaMarkersSkipDefault(sch) {
 			continue
 		}
 
@@ -911,7 +913,7 @@ func (ctx *conversionContext) applyDefaults(
 	if tfs != nil && ctx.ApplyTFDefaults {
 		var valueErr error
 		tfs.Range(func(name string, sch shim.Schema) bool {
-			if schemaMarkersSkipDefault(sch) {
+			if defaultExcluded(sch, ps[name]) {
 				return true
 			}
 			if _, conflicts := conflictsWith[name]; conflicts {

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -739,6 +739,25 @@ func buildConflictsWith(result map[string]interface{}, tfs shim.SchemaMap) map[s
 	return conflictsWith
 }
 
+// schemaMarkersSkipDefault returns true if the TF schema marks a field such
+// that applyDefaults must skip applying any default to it. The exact gate is
+// shared by applyDefaults' overlay and TF branches and by shouldStripStaleDefault
+// in provider.go — keeping the three call sites in lockstep is the parity
+// invariant. Modify only here.
+//
+// Required-and-Deprecated is intentionally excluded: a required field cannot be
+// dropped without breaking PlanResourceChange's required-field validation, so
+// applyDefaults still applies its default and the strip still preserves it.
+func schemaMarkersSkipDefault(sch shim.Schema) bool {
+	if sch == nil {
+		return false
+	}
+	if sch.Removed() != "" {
+		return true
+	}
+	return sch.Deprecated() != "" && !sch.Required()
+}
+
 func (ctx *conversionContext) applyDefaults(
 	result map[string]interface{},
 	olds, _news resource.PropertyMap,
@@ -779,7 +798,7 @@ func (ctx *conversionContext) applyDefaults(
 			continue
 		}
 		sch := getSchema(tfs, name)
-		if sch != nil && (sch.Removed() != "" || sch.Deprecated() != "" && !sch.Required()) {
+		if schemaMarkersSkipDefault(sch) {
 			continue
 		}
 
@@ -892,10 +911,7 @@ func (ctx *conversionContext) applyDefaults(
 	if tfs != nil && ctx.ApplyTFDefaults {
 		var valueErr error
 		tfs.Range(func(name string, sch shim.Schema) bool {
-			if sch.Removed() != "" {
-				return true
-			}
-			if sch.Deprecated() != "" && !sch.Required() {
+			if schemaMarkersSkipDefault(sch) {
 				return true
 			}
 			if _, conflicts := conflictsWith[name]; conflicts {

--- a/pkg/tfbridge/strip_stale_defaults_test.go
+++ b/pkg/tfbridge/strip_stale_defaults_test.go
@@ -1,0 +1,199 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/reservedkeys"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+)
+
+func TestStripStaleDefaults(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Helper to build a SchemaMap from a map of schema definitions.
+	makeSchemaMap := func(schemas map[string]shim.Schema) shim.SchemaMap {
+		return schema.SchemaMap(schemas)
+	}
+
+	t.Run("no __defaults key returns unchanged", func(t *testing.T) {
+		m := resource.PropertyMap{
+			"foo": resource.NewStringProperty("bar"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"foo": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+		})
+		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		assert.Equal(t, m, result)
+	})
+
+	t.Run("empty __defaults array returns unchanged", func(t *testing.T) {
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{}),
+			"foo":                 resource.NewStringProperty("bar"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"foo": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+		})
+		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		assert.Equal(t, m, result)
+	})
+
+	t.Run("stale default stripped when TF schema has no default", func(t *testing.T) {
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("staleField"),
+			}),
+			"staleField": resource.NewStringProperty("ROTATE"),
+			"otherField": resource.NewStringProperty("keep"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+			"other_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+		})
+		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		_, hasStale := result["staleField"]
+		assert.False(t, hasStale, "stale default should be stripped")
+		assert.Equal(t, resource.NewStringProperty("keep"), result["otherField"])
+		_, hasDefaults := result[reservedkeys.Defaults]
+		assert.False(t, hasDefaults, "__defaults should be removed when empty")
+	})
+
+	t.Run("field with TF Default kept", func(t *testing.T) {
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("activeDefault"),
+			}),
+			"activeDefault": resource.NewStringProperty("default-value"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"active_default": (&schema.Schema{
+				Type:     shim.TypeString,
+				Optional: true,
+				Default:  "default-value",
+			}).Shim(),
+		})
+		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		assert.Equal(t, m, result)
+	})
+
+	t.Run("field with bridge Default kept", func(t *testing.T) {
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("name"),
+			}),
+			"name": resource.NewStringProperty("auto-generated-name"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"name": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+		})
+		ps := map[string]*SchemaInfo{
+			"name": {Default: &info.Default{
+				Value: "auto-default",
+			}},
+		}
+		result := stripStaleDefaults(ctx, m, nil, tfs, ps)
+		assert.Equal(t, m, result)
+	})
+
+	t.Run("field not in TF schema kept", func(t *testing.T) {
+		// When tfSchema is nil (field removed from schema), keep the field.
+		// MakeTerraformConfig will drop it during Pulumi-to-TF conversion anyway.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("removedField"),
+			}),
+			"removedField": resource.NewStringProperty("old-value"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{})
+		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		assert.Equal(t, m, result)
+	})
+
+	t.Run("mixed defaults some stale some active", func(t *testing.T) {
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("staleField"),
+				resource.NewStringProperty("activeField"),
+			}),
+			"staleField":  resource.NewStringProperty("old-default"),
+			"activeField": resource.NewStringProperty("current-default"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+			"active_field": (&schema.Schema{
+				Type:     shim.TypeString,
+				Optional: true,
+				Default:  "current-default",
+			}).Shim(),
+		})
+		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		_, hasStale := result["staleField"]
+		assert.False(t, hasStale, "stale field should be stripped")
+		assert.Equal(t, resource.NewStringProperty("current-default"), result["activeField"])
+		// __defaults should only contain the active field
+		defaults := result[reservedkeys.Defaults].ArrayValue()
+		assert.Len(t, defaults, 1)
+		assert.Equal(t, "activeField", defaults[0].StringValue())
+	})
+
+	t.Run("all defaults stale removes __defaults key", func(t *testing.T) {
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("stale1"),
+				resource.NewStringProperty("stale2"),
+			}),
+			"stale1": resource.NewStringProperty("val1"),
+			"stale2": resource.NewStringProperty("val2"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"stale1": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+			"stale2": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+		})
+		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		_, hasDefaults := result[reservedkeys.Defaults]
+		assert.False(t, hasDefaults, "__defaults should be removed entirely")
+		_, hasStale1 := result["stale1"]
+		_, hasStale2 := result["stale2"]
+		assert.False(t, hasStale1)
+		assert.False(t, hasStale2)
+	})
+
+	t.Run("does not mutate original map", func(t *testing.T) {
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("staleField"),
+			}),
+			"staleField": resource.NewStringProperty("old-default"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+		})
+		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		// Original should still have the field
+		assert.Equal(t, resource.NewStringProperty("old-default"), m["staleField"])
+		// Result should not
+		_, hasStale := result["staleField"]
+		assert.False(t, hasStale)
+	})
+}

--- a/pkg/tfbridge/strip_stale_defaults_test.go
+++ b/pkg/tfbridge/strip_stale_defaults_test.go
@@ -202,7 +202,7 @@ func TestStripStaleDefaults(t *testing.T) {
 
 	t.Run("field marked Removed in bridge SchemaInfo is stripped", func(t *testing.T) {
 		// A bridge SchemaInfo.Removed (overlay-level removal) must also strip the
-		// stored value, mirroring applyDefaults' overlay-branch skip at schema.go:772.
+		// stored value, mirroring applyDefaults' overlay-branch skip via defaultExcluded.
 		// This guards against bridge-overlay deprecation paths leaking stale values.
 		m := resource.PropertyMap{
 			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
@@ -249,11 +249,11 @@ func TestStripStaleDefaults(t *testing.T) {
 	})
 
 	t.Run("TF Removed shadows bridge Default (parity with applyDefaults)", func(t *testing.T) {
-		// applyDefaults at schema.go:781-784 skips overlay defaulting when TF marks
-		// the field Removed. classifyStaleDefault must mirror this — a stale value
-		// must be stripped even when an overlay declares a Default, otherwise the
-		// strip would forward the value to PlanResourceChange where SDKv2 rejects
-		// the Removed attribute.
+		// applyDefaults skips defaulting when TF marks the field Removed (via the
+		// shared defaultExcluded gate). shouldStripStaleDefault must mirror this —
+		// a stale value must be stripped even when an overlay declares a Default,
+		// otherwise the strip would forward the value to PlanResourceChange where
+		// SDKv2 rejects the Removed attribute.
 		m := resource.PropertyMap{
 			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewStringProperty("retiredField"),
@@ -277,8 +277,8 @@ func TestStripStaleDefaults(t *testing.T) {
 	})
 
 	t.Run("TF Deprecated&&!Required shadows bridge Default (parity with applyDefaults)", func(t *testing.T) {
-		// applyDefaults skips overlay defaulting when TF marks the field
-		// Deprecated && !Required. classifyStaleDefault must mirror this.
+		// applyDefaults skips defaulting when TF marks the field Deprecated && !Required
+		// (via the shared defaultExcluded gate). shouldStripStaleDefault must mirror this.
 		m := resource.PropertyMap{
 			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewStringProperty("legacyField"),
@@ -302,10 +302,10 @@ func TestStripStaleDefaults(t *testing.T) {
 	})
 
 	t.Run("deprecated optional field is stripped (mirrors applyDefaults gate)", func(t *testing.T) {
-		// applyDefaults at schema.go:782 skips defaulting when a field is Deprecated
-		// AND not Required. The strip mirrors this so a stale stored value isn't
-		// forwarded if the provider has tightened validation around the deprecated
-		// field on upgrade.
+		// applyDefaults skips defaulting (via defaultExcluded) when a field is
+		// Deprecated AND not Required. The strip mirrors this so a stale stored
+		// value isn't forwarded if the provider has tightened validation around
+		// the deprecated field on upgrade.
 		m := resource.PropertyMap{
 			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewStringProperty("legacyField"),

--- a/pkg/tfbridge/strip_stale_defaults_test.go
+++ b/pkg/tfbridge/strip_stale_defaults_test.go
@@ -42,7 +42,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		tfs := makeSchemaMap(map[string]shim.Schema{
 			"foo": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result)
 	})
 
@@ -54,7 +54,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		tfs := makeSchemaMap(map[string]shim.Schema{
 			"foo": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result)
 	})
 
@@ -74,7 +74,7 @@ func TestStripStaleDefaults(t *testing.T) {
 			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 			"other_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		_, hasStale := result["staleField"]
 		assert.False(t, hasStale, "stale default should be stripped when schema has no current Default")
 		assert.Equal(t, resource.NewStringProperty("keep"), result["otherField"])
@@ -97,7 +97,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				Value: "auto-default",
 			}},
 		}
-		result, _ := stripStaleDefaults(m, tfs, ps)
+		result := stripStaleDefaults(m, tfs, ps)
 		assert.Equal(t, m, result)
 	})
 
@@ -126,7 +126,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				Default:  "current-default",
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result, "field with current TF Default must be preserved")
 	})
 
@@ -149,7 +149,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				DefaultFunc: func() (any, error) { return nil, nil },
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result,
 			"field whose schema declares DefaultFunc must be preserved regardless of runtime value")
 	})
@@ -169,7 +169,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		tfs := makeSchemaMap(map[string]shim.Schema{
 			"kept_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		_, hasRemoved := result["removedField"]
 		assert.False(t, hasRemoved, "field absent from current TF schema should be stripped")
 		assert.Equal(t, resource.NewStringProperty("present"), result["keptField"])
@@ -194,7 +194,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				Removed:  "use new_field instead",
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		_, hasRetired := result["retiredField"]
 		assert.False(t, hasRetired,
 			"a Removed field must be stripped even when the schema still has a Default attached")
@@ -216,9 +216,36 @@ func TestStripStaleDefaults(t *testing.T) {
 		ps := map[string]*SchemaInfo{
 			"renamed_field": {Removed: true},
 		}
-		result, _ := stripStaleDefaults(m, tfs, ps)
+		result := stripStaleDefaults(m, tfs, ps)
 		_, hasField := result["renamedField"]
 		assert.False(t, hasField, "a bridge-Removed field must be stripped")
+	})
+
+	t.Run("bridge psi.Removed shadows current TF Default (parity with applyDefaults)", func(t *testing.T) {
+		// applyDefaults skips both branches when psi.Removed is set (overlay branch
+		// at schema.go via defaultExcluded; TF branch likewise). The strip must
+		// mirror that — even if the TF schema still has a current Default, a
+		// bridge-Removed field must not have its stale value forwarded.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("renamedField"),
+			}),
+			"renamedField": resource.NewStringProperty("old-value"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"renamed_field": (&schema.Schema{
+				Type:     shim.TypeString,
+				Optional: true,
+				Default:  "current-tf-default",
+			}).Shim(),
+		})
+		ps := map[string]*SchemaInfo{
+			"renamed_field": {Removed: true},
+		}
+		result := stripStaleDefaults(m, tfs, ps)
+		_, hasField := result["renamedField"]
+		assert.False(t, hasField,
+			"bridge psi.Removed must take precedence over current TF Default")
 	})
 
 	t.Run("TF Removed shadows bridge Default (parity with applyDefaults)", func(t *testing.T) {
@@ -243,7 +270,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		ps := map[string]*SchemaInfo{
 			"retired_field": {Default: &info.Default{EnvVars: []string{"OLD_VAR"}}},
 		}
-		result, _ := stripStaleDefaults(m, tfs, ps)
+		result := stripStaleDefaults(m, tfs, ps)
 		_, hasField := result["retiredField"]
 		assert.False(t, hasField,
 			"TF Removed must take precedence over bridge HasDefault — stale value must be stripped")
@@ -268,7 +295,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		ps := map[string]*SchemaInfo{
 			"legacy_field": {Default: &info.Default{EnvVars: []string{"OLD_VAR"}}},
 		}
-		result, _ := stripStaleDefaults(m, tfs, ps)
+		result := stripStaleDefaults(m, tfs, ps)
 		_, hasField := result["legacyField"]
 		assert.False(t, hasField,
 			"TF Deprecated&&!Required must take precedence over bridge HasDefault — stale value must be stripped")
@@ -293,7 +320,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				Deprecated: "use new_field instead",
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		_, hasField := result["legacyField"]
 		assert.False(t, hasField,
 			"a deprecated optional field must be stripped even with a Default attached")
@@ -318,7 +345,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				Deprecated: "soft warning only",
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result,
 			"a deprecated-but-required field must be preserved (strip would break validation)")
 	})
@@ -336,7 +363,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		tfs := makeSchemaMap(map[string]shim.Schema{
 			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		_, hasStale := result["staleField"]
 		assert.False(t, hasStale, "string entry should still be stripped")
 		defaultsVal, hasDefaults := result[reservedkeys.Defaults]
@@ -362,7 +389,7 @@ func TestStripStaleDefaults(t *testing.T) {
 			"missing_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 			"other_field":   (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		_, hasDefaults := result[reservedkeys.Defaults]
 		assert.False(t, hasDefaults, "__defaults should be removed when its only entry is stripped")
 		assert.Equal(t, resource.NewStringProperty("present"), result["otherField"])
@@ -384,7 +411,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		ps := map[string]*SchemaInfo{
 			"region": {Default: &info.Default{EnvVars: []string{"AWS_REGION"}}},
 		}
-		result, _ := stripStaleDefaults(m, tfs, ps)
+		result := stripStaleDefaults(m, tfs, ps)
 		assert.Equal(t, m, result, "field with EnvVars-based bridge default should be preserved")
 	})
 
@@ -405,7 +432,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				From: func(res *info.PulumiResource) (any, error) { return "computed", nil },
 			}},
 		}
-		result, _ := stripStaleDefaults(m, tfs, ps)
+		result := stripStaleDefaults(m, tfs, ps)
 		assert.Equal(t, m, result, "field with From-based bridge default should be preserved")
 	})
 
@@ -423,9 +450,14 @@ func TestStripStaleDefaults(t *testing.T) {
 			"secret_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 			"other_field":  (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		_, hasSecret := result["secretField"]
 		assert.False(t, hasSecret, "secret-wrapped scalar in __defaults should be stripped")
+		// __defaults bookkeeping must also reflect the strip — a buggy implementation
+		// that drops the value but leaves the entry in __defaults would otherwise pass.
+		_, hasDefaults := result[reservedkeys.Defaults]
+		assert.False(t, hasDefaults,
+			"__defaults must be removed when its only entry is the stripped key")
 	})
 
 	t.Run("mixed defaults: bridge default kept, TF-only default stripped", func(t *testing.T) {
@@ -447,7 +479,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		ps := map[string]*SchemaInfo{
 			"bridge_field": {Default: &info.Default{Value: "bridge-default"}},
 		}
-		result, _ := stripStaleDefaults(m, tfs, ps)
+		result := stripStaleDefaults(m, tfs, ps)
 		_, hasStale := result["staleField"]
 		assert.False(t, hasStale, "TF-only default should be stripped")
 		assert.Equal(t, resource.NewStringProperty("bridge-default"), result["bridgeField"])
@@ -470,7 +502,7 @@ func TestStripStaleDefaults(t *testing.T) {
 			"stale1": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 			"stale2": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		_, hasDefaults := result[reservedkeys.Defaults]
 		assert.False(t, hasDefaults, "__defaults should be removed entirely")
 		_, hasStale1 := result["stale1"]
@@ -504,7 +536,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		blockVal := result["block"].ObjectValue()
 		_, hasNestedStale := blockVal["nestedStale"]
 		assert.False(t, hasNestedStale, "nested stale default should be stripped")
@@ -543,7 +575,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result, "nested field with current TF Default must be preserved")
 	})
 
@@ -579,7 +611,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				"nested_name": {Default: &info.Default{Value: "bridge-generated"}},
 			}},
 		}
-		result, _ := stripStaleDefaults(m, tfs, ps)
+		result := stripStaleDefaults(m, tfs, ps)
 		assert.Equal(t, m, result, "nested field with bridge Default must be preserved")
 	})
 
@@ -610,7 +642,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		blockVal := result["block"].ObjectValue()
 		_, hasRemoved := blockVal["removedNested"]
 		assert.False(t, hasRemoved, "field absent from nested schema must be stripped")
@@ -642,7 +674,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		items := result["items"].ArrayValue()
 		assert.Len(t, items, 1)
 		elemVal := items[0].ObjectValue()
@@ -681,7 +713,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		// The TypeSet element must be untouched: the "default" field and the nested
 		// __defaults must both still be present, otherwise the set hash changes.
 		assert.Equal(t, m, result, "TypeSet element fields and nested __defaults must be preserved")
@@ -716,7 +748,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result, "MaxItemsOne TypeSet element fields must be preserved")
 	})
 
@@ -747,7 +779,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		// Result should still be a secret
 		assert.True(t, result["block"].IsSecret())
 		blockVal := result["block"].SecretValue().Element.ObjectValue()
@@ -781,7 +813,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		items := result["items"].ArrayValue()
 		assert.Len(t, items, 1)
 		assert.True(t, items[0].IsSecret(), "element should still be secret-wrapped")
@@ -826,7 +858,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		outerVal := result["outer"].ObjectValue()
 		innerList := outerVal["innerList"].ArrayValue()
 		assert.Len(t, innerList, 1)
@@ -865,7 +897,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		_, hasBlock := result["block"]
 		assert.False(t, hasBlock, "top-level stale block should be stripped, not re-inserted by nested-change handling")
 		_, hasDefaults := result[reservedkeys.Defaults]
@@ -882,7 +914,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		tfs := makeSchemaMap(map[string]shim.Schema{
 			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(m, tfs, nil)
+		result := stripStaleDefaults(m, tfs, nil)
 		// Original should still have the field
 		assert.Equal(t, resource.NewStringProperty("old-default"), m["staleField"])
 		// Result should not

--- a/pkg/tfbridge/strip_stale_defaults_test.go
+++ b/pkg/tfbridge/strip_stale_defaults_test.go
@@ -102,10 +102,16 @@ func TestStripStaleDefaults(t *testing.T) {
 	})
 
 	t.Run("field with current TF Default is preserved", func(t *testing.T) {
-		// Preserving stored values when the schema still declares a Default
-		// protects two invariants: TestUpdatePreservesLegacyFalsyTFDefaults
-		// (RawConfig presence semantics for stored falsy defaults) and the
-		// changed-default phantom-diff guard tracked by #3434.
+		// When the TF schema still has a Default for the field, the stored value is
+		// preserved (not stripped). Two reasons:
+		//   1. PR #3420 (TestUpdatePreservesLegacyFalsyTFDefaults) requires that
+		//      stored falsy values for fields whose schema has a matching Default
+		//      reach RawConfig as cty.False/0/"" rather than null — providers read
+		//      RawConfig presence as meaningful.
+		//   2. If the schema's Default value has changed (v1 → v2), preserving the
+		//      stored value avoids a phantom diff that the deeper applyDefaults
+		//      "old default" reuse path would silently undo. See issue #3434 for
+		//      the architectural fix.
 		m := resource.PropertyMap{
 			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewStringProperty("activeDefault"),

--- a/pkg/tfbridge/strip_stale_defaults_test.go
+++ b/pkg/tfbridge/strip_stale_defaults_test.go
@@ -102,16 +102,36 @@ func TestStripStaleDefaults(t *testing.T) {
 	})
 
 	t.Run("field with current TF Default is preserved", func(t *testing.T) {
-		// When the TF schema still has a Default for the field, the stored value is
-		// preserved (not stripped). Two reasons:
-		//   1. PR #3420 (TestUpdatePreservesLegacyFalsyTFDefaults) requires that
-		//      stored falsy values for fields whose schema has a matching Default
-		//      reach RawConfig as cty.False/0/"" rather than null — providers read
-		//      RawConfig presence as meaningful.
-		//   2. If the schema's Default value has changed (v1 → v2), preserving the
-		//      stored value avoids a phantom diff that the deeper applyDefaults
-		//      "old default" reuse path would silently undo. See issue #3434 for
-		//      the architectural fix.
+		// Preserve case: the stored value lives under __defaults AND the TF
+		// schema still declares a matching Default. shouldStripStaleDefault
+		// must classify this as not-stale, so stripStaleDefaults returns m
+		// verbatim.
+		//
+		// Why preservation (not stripping) is correct here, even though the
+		// value "would be re-defaulted anyway":
+		//  1. Legacy-stack falsy round-trip. Per
+		//     TestUpdatePreservesLegacyFalsyTFDefaults, fields with a schema
+		//     Default whose stored value is falsy (false, 0, "") must reach
+		//     Terraform's RawConfig as cty.False / cty.Zero / cty.EmptyString,
+		//     not cty.NullVal. Some providers branch on RawConfig presence
+		//     and treat present-but-falsy as semantically distinct from
+		//     omitted; stripping would collapse that distinction and regress
+		//     those providers.
+		//  2. Changed-default phantom-diff guard. When a provider bumps a
+		//     schema Default across versions (v1="x" → v2="y"), preserving
+		//     the stored prior value avoids a no-op user-visible diff. The
+		//     strip is not the full fix — applyDefaults' "old default reuse"
+		//     branch still re-injects stored values for any field where the
+		//     bridge's HasDefault is true, and the architectural cleanup is
+		//     tracked in #3434. The contract this test pins down is narrower:
+		//     the strip pass must not make the changed-default case worse by
+		//     removing the very value the reuse path depends on.
+		//
+		// Caveat about the assertion: assert.Equal(t, m, result) would also
+		// pass for a degenerate stripStaleDefaults that returned its input
+		// unmodified for every shape. Coverage of the stripping side comes
+		// from the sibling subtests in TestStripStaleDefaults; this case
+		// carries the preserve half of the table only.
 		m := resource.PropertyMap{
 			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewStringProperty("activeDefault"),

--- a/pkg/tfbridge/strip_stale_defaults_test.go
+++ b/pkg/tfbridge/strip_stale_defaults_test.go
@@ -102,17 +102,10 @@ func TestStripStaleDefaults(t *testing.T) {
 	})
 
 	t.Run("field with current TF Default is preserved", func(t *testing.T) {
-		// When the TF schema still has a Default for the field, the stored value is
-		// preserved (not stripped). Two reasons:
-		//   1. PR #3420 (TestUpdatePreservesLegacyFalsyTFDefaults) requires that
-		//      stored falsy values for fields whose schema has a matching Default
-		//      reach RawConfig as cty.False/0/"" rather than null — providers read
-		//      RawConfig presence as meaningful.
-		//   2. If the schema's Default value has changed (v1 → v2), stripping in Diff
-		//      alone would produce a Preview transition that Update silently fails to
-		//      apply (TF treats unstripped Update news as authoritative). Preserving
-		//      the stored value keeps the (silent) pre-PR baseline behavior intact;
-		//      see issue #3434 for the architectural fix.
+		// Preserving stored values when the schema still declares a Default
+		// protects two invariants: TestUpdatePreservesLegacyFalsyTFDefaults
+		// (RawConfig presence semantics for stored falsy defaults) and the
+		// changed-default phantom-diff guard tracked by #3434.
 		m := resource.PropertyMap{
 			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewStringProperty("activeDefault"),
@@ -131,11 +124,10 @@ func TestStripStaleDefaults(t *testing.T) {
 	})
 
 	t.Run("field with current TF DefaultFunc is preserved (even if it would return nil)", func(t *testing.T) {
-		// The strip predicate must check structural schema ownership
-		// (Default/DefaultFunc), not the runtime evaluation result. A DefaultFunc
-		// that returns nil at Diff time (e.g. a missing env var for an env-backed
-		// default) still represents a configured Default — the field is owned by
-		// the schema's default mechanism and must not be classified as stale.
+		// The predicate checks structural schema ownership (Default/DefaultFunc),
+		// not runtime evaluation. A DefaultFunc that returns nil at runtime (e.g.
+		// unset env var) still represents a configured Default and must not be
+		// classified as stale.
 		m := resource.PropertyMap{
 			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewStringProperty("envField"),

--- a/pkg/tfbridge/strip_stale_defaults_test.go
+++ b/pkg/tfbridge/strip_stale_defaults_test.go
@@ -15,7 +15,6 @@
 package tfbridge
 
 import (
-	"context"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -30,7 +29,6 @@ import (
 
 func TestStripStaleDefaults(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
 	// Helper to build a SchemaMap from a map of schema definitions.
 	makeSchemaMap := func(schemas map[string]shim.Schema) shim.SchemaMap {
@@ -44,7 +42,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		tfs := makeSchemaMap(map[string]shim.Schema{
 			"foo": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result)
 	})
 
@@ -56,7 +54,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		tfs := makeSchemaMap(map[string]shim.Schema{
 			"foo": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result)
 	})
 
@@ -76,7 +74,7 @@ func TestStripStaleDefaults(t *testing.T) {
 			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 			"other_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		_, hasStale := result["staleField"]
 		assert.False(t, hasStale, "stale default should be stripped when schema has no current Default")
 		assert.Equal(t, resource.NewStringProperty("keep"), result["otherField"])
@@ -99,7 +97,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				Value: "auto-default",
 			}},
 		}
-		result, _ := stripStaleDefaults(ctx, m, tfs, ps)
+		result, _ := stripStaleDefaults(m, tfs, ps)
 		assert.Equal(t, m, result)
 	})
 
@@ -128,7 +126,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				Default:  "current-default",
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result, "field with current TF Default must be preserved")
 	})
 
@@ -151,7 +149,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				DefaultFunc: func() (any, error) { return nil, nil },
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result,
 			"field whose schema declares DefaultFunc must be preserved regardless of runtime value")
 	})
@@ -171,7 +169,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		tfs := makeSchemaMap(map[string]shim.Schema{
 			"kept_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		_, hasRemoved := result["removedField"]
 		assert.False(t, hasRemoved, "field absent from current TF schema should be stripped")
 		assert.Equal(t, resource.NewStringProperty("present"), result["keptField"])
@@ -196,7 +194,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				Removed:  "use new_field instead",
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		_, hasRetired := result["retiredField"]
 		assert.False(t, hasRetired,
 			"a Removed field must be stripped even when the schema still has a Default attached")
@@ -218,9 +216,62 @@ func TestStripStaleDefaults(t *testing.T) {
 		ps := map[string]*SchemaInfo{
 			"renamed_field": {Removed: true},
 		}
-		result, _ := stripStaleDefaults(ctx, m, tfs, ps)
+		result, _ := stripStaleDefaults(m, tfs, ps)
 		_, hasField := result["renamedField"]
 		assert.False(t, hasField, "a bridge-Removed field must be stripped")
+	})
+
+	t.Run("TF Removed shadows bridge Default (parity with applyDefaults)", func(t *testing.T) {
+		// applyDefaults at schema.go:781-784 skips overlay defaulting when TF marks
+		// the field Removed. classifyStaleDefault must mirror this — a stale value
+		// must be stripped even when an overlay declares a Default, otherwise the
+		// strip would forward the value to PlanResourceChange where SDKv2 rejects
+		// the Removed attribute.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("retiredField"),
+			}),
+			"retiredField": resource.NewStringProperty("env-derived-value"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"retired_field": (&schema.Schema{
+				Type:     shim.TypeString,
+				Optional: true,
+				Removed:  "use new_field instead",
+			}).Shim(),
+		})
+		ps := map[string]*SchemaInfo{
+			"retired_field": {Default: &info.Default{EnvVars: []string{"OLD_VAR"}}},
+		}
+		result, _ := stripStaleDefaults(m, tfs, ps)
+		_, hasField := result["retiredField"]
+		assert.False(t, hasField,
+			"TF Removed must take precedence over bridge HasDefault — stale value must be stripped")
+	})
+
+	t.Run("TF Deprecated&&!Required shadows bridge Default (parity with applyDefaults)", func(t *testing.T) {
+		// applyDefaults skips overlay defaulting when TF marks the field
+		// Deprecated && !Required. classifyStaleDefault must mirror this.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("legacyField"),
+			}),
+			"legacyField": resource.NewStringProperty("env-derived-value"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"legacy_field": (&schema.Schema{
+				Type:       shim.TypeString,
+				Optional:   true,
+				Deprecated: "use new_field instead",
+			}).Shim(),
+		})
+		ps := map[string]*SchemaInfo{
+			"legacy_field": {Default: &info.Default{EnvVars: []string{"OLD_VAR"}}},
+		}
+		result, _ := stripStaleDefaults(m, tfs, ps)
+		_, hasField := result["legacyField"]
+		assert.False(t, hasField,
+			"TF Deprecated&&!Required must take precedence over bridge HasDefault — stale value must be stripped")
 	})
 
 	t.Run("deprecated optional field is stripped (mirrors applyDefaults gate)", func(t *testing.T) {
@@ -242,7 +293,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				Deprecated: "use new_field instead",
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		_, hasField := result["legacyField"]
 		assert.False(t, hasField,
 			"a deprecated optional field must be stripped even with a Default attached")
@@ -267,7 +318,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				Deprecated: "soft warning only",
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result,
 			"a deprecated-but-required field must be preserved (strip would break validation)")
 	})
@@ -285,7 +336,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		tfs := makeSchemaMap(map[string]shim.Schema{
 			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		_, hasStale := result["staleField"]
 		assert.False(t, hasStale, "string entry should still be stripped")
 		defaultsVal, hasDefaults := result[reservedkeys.Defaults]
@@ -311,7 +362,7 @@ func TestStripStaleDefaults(t *testing.T) {
 			"missing_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 			"other_field":   (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		_, hasDefaults := result[reservedkeys.Defaults]
 		assert.False(t, hasDefaults, "__defaults should be removed when its only entry is stripped")
 		assert.Equal(t, resource.NewStringProperty("present"), result["otherField"])
@@ -333,7 +384,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		ps := map[string]*SchemaInfo{
 			"region": {Default: &info.Default{EnvVars: []string{"AWS_REGION"}}},
 		}
-		result, _ := stripStaleDefaults(ctx, m, tfs, ps)
+		result, _ := stripStaleDefaults(m, tfs, ps)
 		assert.Equal(t, m, result, "field with EnvVars-based bridge default should be preserved")
 	})
 
@@ -354,7 +405,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				From: func(res *info.PulumiResource) (any, error) { return "computed", nil },
 			}},
 		}
-		result, _ := stripStaleDefaults(ctx, m, tfs, ps)
+		result, _ := stripStaleDefaults(m, tfs, ps)
 		assert.Equal(t, m, result, "field with From-based bridge default should be preserved")
 	})
 
@@ -372,7 +423,7 @@ func TestStripStaleDefaults(t *testing.T) {
 			"secret_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 			"other_field":  (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		_, hasSecret := result["secretField"]
 		assert.False(t, hasSecret, "secret-wrapped scalar in __defaults should be stripped")
 	})
@@ -396,7 +447,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		ps := map[string]*SchemaInfo{
 			"bridge_field": {Default: &info.Default{Value: "bridge-default"}},
 		}
-		result, _ := stripStaleDefaults(ctx, m, tfs, ps)
+		result, _ := stripStaleDefaults(m, tfs, ps)
 		_, hasStale := result["staleField"]
 		assert.False(t, hasStale, "TF-only default should be stripped")
 		assert.Equal(t, resource.NewStringProperty("bridge-default"), result["bridgeField"])
@@ -419,7 +470,7 @@ func TestStripStaleDefaults(t *testing.T) {
 			"stale1": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 			"stale2": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		_, hasDefaults := result[reservedkeys.Defaults]
 		assert.False(t, hasDefaults, "__defaults should be removed entirely")
 		_, hasStale1 := result["stale1"]
@@ -453,7 +504,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		blockVal := result["block"].ObjectValue()
 		_, hasNestedStale := blockVal["nestedStale"]
 		assert.False(t, hasNestedStale, "nested stale default should be stripped")
@@ -492,7 +543,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result, "nested field with current TF Default must be preserved")
 	})
 
@@ -528,7 +579,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				"nested_name": {Default: &info.Default{Value: "bridge-generated"}},
 			}},
 		}
-		result, _ := stripStaleDefaults(ctx, m, tfs, ps)
+		result, _ := stripStaleDefaults(m, tfs, ps)
 		assert.Equal(t, m, result, "nested field with bridge Default must be preserved")
 	})
 
@@ -559,7 +610,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		blockVal := result["block"].ObjectValue()
 		_, hasRemoved := blockVal["removedNested"]
 		assert.False(t, hasRemoved, "field absent from nested schema must be stripped")
@@ -591,7 +642,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		items := result["items"].ArrayValue()
 		assert.Len(t, items, 1)
 		elemVal := items[0].ObjectValue()
@@ -630,7 +681,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		// The TypeSet element must be untouched: the "default" field and the nested
 		// __defaults must both still be present, otherwise the set hash changes.
 		assert.Equal(t, m, result, "TypeSet element fields and nested __defaults must be preserved")
@@ -665,7 +716,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		assert.Equal(t, m, result, "MaxItemsOne TypeSet element fields must be preserved")
 	})
 
@@ -696,7 +747,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		// Result should still be a secret
 		assert.True(t, result["block"].IsSecret())
 		blockVal := result["block"].SecretValue().Element.ObjectValue()
@@ -730,7 +781,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		items := result["items"].ArrayValue()
 		assert.Len(t, items, 1)
 		assert.True(t, items[0].IsSecret(), "element should still be secret-wrapped")
@@ -775,7 +826,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		outerVal := result["outer"].ObjectValue()
 		innerList := outerVal["innerList"].ArrayValue()
 		assert.Len(t, innerList, 1)
@@ -814,7 +865,7 @@ func TestStripStaleDefaults(t *testing.T) {
 				}).Shim(),
 			}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		_, hasBlock := result["block"]
 		assert.False(t, hasBlock, "top-level stale block should be stripped, not re-inserted by nested-change handling")
 		_, hasDefaults := result[reservedkeys.Defaults]
@@ -831,7 +882,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		tfs := makeSchemaMap(map[string]shim.Schema{
 			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		result, _ := stripStaleDefaults(m, tfs, nil)
 		// Original should still have the field
 		assert.Equal(t, resource.NewStringProperty("old-default"), m["staleField"])
 		// Result should not

--- a/pkg/tfbridge/strip_stale_defaults_test.go
+++ b/pkg/tfbridge/strip_stale_defaults_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/reservedkeys"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
@@ -43,7 +44,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		tfs := makeSchemaMap(map[string]shim.Schema{
 			"foo": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
 		assert.Equal(t, m, result)
 	})
 
@@ -55,11 +56,15 @@ func TestStripStaleDefaults(t *testing.T) {
 		tfs := makeSchemaMap(map[string]shim.Schema{
 			"foo": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
 		assert.Equal(t, m, result)
 	})
 
-	t.Run("stale default stripped when TF schema has no default", func(t *testing.T) {
+	t.Run("stale default stripped when TF schema no longer has a Default", func(t *testing.T) {
+		// Field listed in __defaults whose schema no longer has a Default — the
+		// recorded value is genuinely stale and would otherwise reach
+		// PlanResourceChange. This is the original motivating case (e.g. AWS
+		// auth_token_update_strategy in v6→v7).
 		m := resource.PropertyMap{
 			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewStringProperty("staleField"),
@@ -71,30 +76,12 @@ func TestStripStaleDefaults(t *testing.T) {
 			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 			"other_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
 		_, hasStale := result["staleField"]
-		assert.False(t, hasStale, "stale default should be stripped")
+		assert.False(t, hasStale, "stale default should be stripped when schema has no current Default")
 		assert.Equal(t, resource.NewStringProperty("keep"), result["otherField"])
 		_, hasDefaults := result[reservedkeys.Defaults]
 		assert.False(t, hasDefaults, "__defaults should be removed when empty")
-	})
-
-	t.Run("field with TF Default kept", func(t *testing.T) {
-		m := resource.PropertyMap{
-			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("activeDefault"),
-			}),
-			"activeDefault": resource.NewStringProperty("default-value"),
-		}
-		tfs := makeSchemaMap(map[string]shim.Schema{
-			"active_default": (&schema.Schema{
-				Type:     shim.TypeString,
-				Optional: true,
-				Default:  "default-value",
-			}).Shim(),
-		})
-		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
-		assert.Equal(t, m, result)
 	})
 
 	t.Run("field with bridge Default kept", func(t *testing.T) {
@@ -112,49 +99,311 @@ func TestStripStaleDefaults(t *testing.T) {
 				Value: "auto-default",
 			}},
 		}
-		result := stripStaleDefaults(ctx, m, nil, tfs, ps)
+		result, _ := stripStaleDefaults(ctx, m, tfs, ps)
 		assert.Equal(t, m, result)
 	})
 
-	t.Run("field not in TF schema kept", func(t *testing.T) {
-		// When tfSchema is nil (field removed from schema), keep the field.
-		// MakeTerraformConfig will drop it during Pulumi-to-TF conversion anyway.
+	t.Run("field with current TF Default is preserved", func(t *testing.T) {
+		// When the TF schema still has a Default for the field, the stored value is
+		// preserved (not stripped). Two reasons:
+		//   1. PR #3420 (TestUpdatePreservesLegacyFalsyTFDefaults) requires that
+		//      stored falsy values for fields whose schema has a matching Default
+		//      reach RawConfig as cty.False/0/"" rather than null — providers read
+		//      RawConfig presence as meaningful.
+		//   2. If the schema's Default value has changed (v1 → v2), stripping in Diff
+		//      alone would produce a Preview transition that Update silently fails to
+		//      apply (TF treats unstripped Update news as authoritative). Preserving
+		//      the stored value keeps the (silent) pre-PR baseline behavior intact;
+		//      see issue #3434 for the architectural fix.
 		m := resource.PropertyMap{
 			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("removedField"),
+				resource.NewStringProperty("activeDefault"),
 			}),
-			"removedField": resource.NewStringProperty("old-value"),
-		}
-		tfs := makeSchemaMap(map[string]shim.Schema{})
-		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
-		assert.Equal(t, m, result)
-	})
-
-	t.Run("mixed defaults some stale some active", func(t *testing.T) {
-		m := resource.PropertyMap{
-			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("staleField"),
-				resource.NewStringProperty("activeField"),
-			}),
-			"staleField":  resource.NewStringProperty("old-default"),
-			"activeField": resource.NewStringProperty("current-default"),
+			"activeDefault": resource.NewStringProperty("some-value"),
 		}
 		tfs := makeSchemaMap(map[string]shim.Schema{
-			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
-			"active_field": (&schema.Schema{
+			"active_default": (&schema.Schema{
 				Type:     shim.TypeString,
 				Optional: true,
 				Default:  "current-default",
 			}).Shim(),
 		})
-		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		assert.Equal(t, m, result, "field with current TF Default must be preserved")
+	})
+
+	t.Run("field with current TF DefaultFunc is preserved (even if it would return nil)", func(t *testing.T) {
+		// The strip predicate must check structural schema ownership
+		// (Default/DefaultFunc), not the runtime evaluation result. A DefaultFunc
+		// that returns nil at Diff time (e.g. a missing env var for an env-backed
+		// default) still represents a configured Default — the field is owned by
+		// the schema's default mechanism and must not be classified as stale.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("envField"),
+			}),
+			"envField": resource.NewStringProperty("stored-value"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"env_field": (&schema.Schema{
+				Type:        shim.TypeString,
+				Optional:    true,
+				DefaultFunc: func() (any, error) { return nil, nil },
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		assert.Equal(t, m, result,
+			"field whose schema declares DefaultFunc must be preserved regardless of runtime value")
+	})
+
+	t.Run("field removed from TF schema is also stripped", func(t *testing.T) {
+		// makeObjectTerraformInputs does NOT drop unknown keys — it substitutes an empty
+		// schema and forwards the value to the provider. So a field listed in __defaults
+		// but no longer in the TF schema must be stripped here, otherwise its stale value
+		// would reach PlanResourceChange as an unknown attribute.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("removedField"),
+			}),
+			"removedField": resource.NewStringProperty("old-value"),
+			"keptField":    resource.NewStringProperty("present"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"kept_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		_, hasRemoved := result["removedField"]
+		assert.False(t, hasRemoved, "field absent from current TF schema should be stripped")
+		assert.Equal(t, resource.NewStringProperty("present"), result["keptField"])
+	})
+
+	t.Run("field marked Removed in TF schema is stripped even with a Default", func(t *testing.T) {
+		// A field can still appear in the TF schema with `Removed != ""` to signal
+		// "no longer accepted." applyDefaults already skips Removed fields when applying
+		// defaults; the strip mirrors that so a stale stored value cannot leak through
+		// to PlanResourceChange even if the schema author left a Default attached.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("retiredField"),
+			}),
+			"retiredField": resource.NewStringProperty("old-value"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"retired_field": (&schema.Schema{
+				Type:     shim.TypeString,
+				Optional: true,
+				Default:  "stale-default",
+				Removed:  "use new_field instead",
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		_, hasRetired := result["retiredField"]
+		assert.False(t, hasRetired,
+			"a Removed field must be stripped even when the schema still has a Default attached")
+	})
+
+	t.Run("field marked Removed in bridge SchemaInfo is stripped", func(t *testing.T) {
+		// A bridge SchemaInfo.Removed (overlay-level removal) must also strip the
+		// stored value, mirroring applyDefaults' overlay-branch skip at schema.go:772.
+		// This guards against bridge-overlay deprecation paths leaking stale values.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("renamedField"),
+			}),
+			"renamedField": resource.NewStringProperty("old-value"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"renamed_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+		})
+		ps := map[string]*SchemaInfo{
+			"renamed_field": {Removed: true},
+		}
+		result, _ := stripStaleDefaults(ctx, m, tfs, ps)
+		_, hasField := result["renamedField"]
+		assert.False(t, hasField, "a bridge-Removed field must be stripped")
+	})
+
+	t.Run("deprecated optional field is stripped (mirrors applyDefaults gate)", func(t *testing.T) {
+		// applyDefaults at schema.go:782 skips defaulting when a field is Deprecated
+		// AND not Required. The strip mirrors this so a stale stored value isn't
+		// forwarded if the provider has tightened validation around the deprecated
+		// field on upgrade.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("legacyField"),
+			}),
+			"legacyField": resource.NewStringProperty("stale-value"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"legacy_field": (&schema.Schema{
+				Type:       shim.TypeString,
+				Optional:   true,
+				Default:    "old-default",
+				Deprecated: "use new_field instead",
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		_, hasField := result["legacyField"]
+		assert.False(t, hasField,
+			"a deprecated optional field must be stripped even with a Default attached")
+	})
+
+	t.Run("deprecated required field is preserved (cannot strip a required field)", func(t *testing.T) {
+		// applyDefaults still applies defaults for deprecated-AND-required fields.
+		// The strip should not strip a required field — doing so would break
+		// PlanResourceChange's required-field validation. Verify the gate respects
+		// `!Required`.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("requiredLegacy"),
+			}),
+			"requiredLegacy": resource.NewStringProperty("stored-value"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"required_legacy": (&schema.Schema{
+				Type:       shim.TypeString,
+				Required:   true,
+				Default:    "old-default",
+				Deprecated: "soft warning only",
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		assert.Equal(t, m, result,
+			"a deprecated-but-required field must be preserved (strip would break validation)")
+	})
+
+	t.Run("non-string entry in __defaults is preserved", func(t *testing.T) {
+		// __defaults should contain only string keys, but if a non-string ever appears
+		// (serialization quirk, future code change), it must be preserved verbatim.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewNumberProperty(42),
+				resource.NewStringProperty("staleField"),
+			}),
+			"staleField": resource.NewStringProperty("old-default"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
 		_, hasStale := result["staleField"]
-		assert.False(t, hasStale, "stale field should be stripped")
-		assert.Equal(t, resource.NewStringProperty("current-default"), result["activeField"])
-		// __defaults should only contain the active field
+		assert.False(t, hasStale, "string entry should still be stripped")
+		defaultsVal, hasDefaults := result[reservedkeys.Defaults]
+		require.True(t, hasDefaults, "__defaults must remain since the non-string entry is preserved")
+		require.True(t, defaultsVal.IsArray())
+		defaults := defaultsVal.ArrayValue()
+		assert.Len(t, defaults, 1)
+		assert.True(t, defaults[0].IsNumber(), "non-string entry should be preserved")
+		assert.Equal(t, float64(42), defaults[0].NumberValue())
+	})
+
+	t.Run("__defaults listing a key absent from m is handled safely", func(t *testing.T) {
+		// __defaults can list a key that is not present in m (e.g. after a manual edit
+		// or a partial state). The function must not panic and must update __defaults
+		// to reflect the strip.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("missingField"),
+			}),
+			"otherField": resource.NewStringProperty("present"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"missing_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+			"other_field":   (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		_, hasDefaults := result[reservedkeys.Defaults]
+		assert.False(t, hasDefaults, "__defaults should be removed when its only entry is stripped")
+		assert.Equal(t, resource.NewStringProperty("present"), result["otherField"])
+	})
+
+	t.Run("bridge Default with EnvVars (no literal value) is kept", func(t *testing.T) {
+		// SchemaInfo.Default may specify EnvVars without a literal Value. HasDefault()
+		// returns true in that case, so the field should be preserved (not stripped)
+		// just like the literal-value case.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("region"),
+			}),
+			"region": resource.NewStringProperty("us-east-1"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"region": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+		})
+		ps := map[string]*SchemaInfo{
+			"region": {Default: &info.Default{EnvVars: []string{"AWS_REGION"}}},
+		}
+		result, _ := stripStaleDefaults(ctx, m, tfs, ps)
+		assert.Equal(t, m, result, "field with EnvVars-based bridge default should be preserved")
+	})
+
+	t.Run("bridge Default with From function (no literal value) is kept", func(t *testing.T) {
+		// SchemaInfo.Default with a From function (e.g. computed from other fields)
+		// also reports HasDefault() == true and must be preserved.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("derivedField"),
+			}),
+			"derivedField": resource.NewStringProperty("from-fn"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"derived_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+		})
+		ps := map[string]*SchemaInfo{
+			"derived_field": {Default: &info.Default{
+				From: func(res *info.PulumiResource) (any, error) { return "computed", nil },
+			}},
+		}
+		result, _ := stripStaleDefaults(ctx, m, tfs, ps)
+		assert.Equal(t, m, result, "field with From-based bridge default should be preserved")
+	})
+
+	t.Run("secret-wrapped scalar listed in __defaults is stripped", func(t *testing.T) {
+		// A top-level field listed in __defaults whose value is a secret-wrapped scalar
+		// (not an object) must still be removed from the result.
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("secretField"),
+			}),
+			"secretField": resource.MakeSecret(resource.NewStringProperty("hidden-default")),
+			"otherField":  resource.NewStringProperty("kept"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"secret_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+			"other_field":  (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		_, hasSecret := result["secretField"]
+		assert.False(t, hasSecret, "secret-wrapped scalar in __defaults should be stripped")
+	})
+
+	t.Run("mixed defaults: bridge default kept, TF-only default stripped", func(t *testing.T) {
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("staleField"),
+				resource.NewStringProperty("bridgeField"),
+			}),
+			"staleField":  resource.NewStringProperty("old-default"),
+			"bridgeField": resource.NewStringProperty("bridge-default"),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+			"bridge_field": (&schema.Schema{
+				Type:     shim.TypeString,
+				Optional: true,
+			}).Shim(),
+		})
+		ps := map[string]*SchemaInfo{
+			"bridge_field": {Default: &info.Default{Value: "bridge-default"}},
+		}
+		result, _ := stripStaleDefaults(ctx, m, tfs, ps)
+		_, hasStale := result["staleField"]
+		assert.False(t, hasStale, "TF-only default should be stripped")
+		assert.Equal(t, resource.NewStringProperty("bridge-default"), result["bridgeField"])
+		// __defaults should only contain the bridge-defaulted field
 		defaults := result[reservedkeys.Defaults].ArrayValue()
 		assert.Len(t, defaults, 1)
-		assert.Equal(t, "activeField", defaults[0].StringValue())
+		assert.Equal(t, "bridgeField", defaults[0].StringValue())
 	})
 
 	t.Run("all defaults stale removes __defaults key", func(t *testing.T) {
@@ -170,13 +419,406 @@ func TestStripStaleDefaults(t *testing.T) {
 			"stale1": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 			"stale2": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
 		_, hasDefaults := result[reservedkeys.Defaults]
 		assert.False(t, hasDefaults, "__defaults should be removed entirely")
 		_, hasStale1 := result["stale1"]
 		_, hasStale2 := result["stale2"]
 		assert.False(t, hasStale1)
 		assert.False(t, hasStale2)
+	})
+
+	t.Run("stale default in nested object is stripped", func(t *testing.T) {
+		// A stale default inside a nested block should be stripped from the nested object.
+		nested := resource.NewObjectProperty(resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("nestedStale"),
+			}),
+			"nestedStale": resource.NewStringProperty("old-default"),
+			"nestedKept":  resource.NewStringProperty("user-set"),
+		})
+		m := resource.PropertyMap{
+			"block": nested,
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"block": (&schema.Schema{
+				Type:     shim.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"nested_stale": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+						"nested_kept":  (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+					},
+				}).Shim(),
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		blockVal := result["block"].ObjectValue()
+		_, hasNestedStale := blockVal["nestedStale"]
+		assert.False(t, hasNestedStale, "nested stale default should be stripped")
+		assert.Equal(t, resource.NewStringProperty("user-set"), blockVal["nestedKept"])
+		_, hasDefaults := blockVal[reservedkeys.Defaults]
+		assert.False(t, hasDefaults, "nested __defaults should be removed when empty")
+	})
+
+	t.Run("nested field with current TF Default is preserved", func(t *testing.T) {
+		// Same predicate at the nested level: if the nested field's schema still has
+		// a Default, the recorded value is preserved (not stripped). This avoids the
+		// changed-default phantom diff and the PR #3420 round-trip break inside
+		// nested blocks.
+		nested := resource.NewObjectProperty(resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("nestedActive"),
+			}),
+			"nestedActive": resource.NewStringProperty("still-default"),
+		})
+		m := resource.PropertyMap{
+			"block": nested,
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"block": (&schema.Schema{
+				Type:     shim.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"nested_active": (&schema.Schema{
+							Type:     shim.TypeString,
+							Optional: true,
+							Default:  "still-default",
+						}).Shim(),
+					},
+				}).Shim(),
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		assert.Equal(t, m, result, "nested field with current TF Default must be preserved")
+	})
+
+	t.Run("nested field with bridge Default is preserved", func(t *testing.T) {
+		// Inside a MaxItemsOne block, a nested field with a SchemaInfo.Default must
+		// not be stripped — bridge defaults flow through psi.Fields recursion. This
+		// guards against a regression where the psi.HasDefault() carve-out could be
+		// dropped at the nested level, which would (e.g.) break auto-naming of
+		// fields nested inside blocks.
+		nested := resource.NewObjectProperty(resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("nestedName"),
+			}),
+			"nestedName": resource.NewStringProperty("bridge-generated"),
+		})
+		m := resource.PropertyMap{
+			"block": nested,
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"block": (&schema.Schema{
+				Type:     shim.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"nested_name": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+					},
+				}).Shim(),
+			}).Shim(),
+		})
+		ps := map[string]*SchemaInfo{
+			"block": {Fields: map[string]*SchemaInfo{
+				"nested_name": {Default: &info.Default{Value: "bridge-generated"}},
+			}},
+		}
+		result, _ := stripStaleDefaults(ctx, m, tfs, ps)
+		assert.Equal(t, m, result, "nested field with bridge Default must be preserved")
+	})
+
+	t.Run("nested field absent from nested schema is stripped", func(t *testing.T) {
+		// Inside a MaxItemsOne block, a __defaults entry naming a field that no
+		// longer exists in the nested schema must be stripped. Mirrors the
+		// top-level "field removed from TF schema" case at the nested level.
+		nested := resource.NewObjectProperty(resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("removedNested"),
+			}),
+			"removedNested": resource.NewStringProperty("orphaned-value"),
+			"keptNested":    resource.NewStringProperty("user-set"),
+		})
+		m := resource.PropertyMap{
+			"block": nested,
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"block": (&schema.Schema{
+				Type:     shim.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: (&schema.Resource{
+					Schema: schema.SchemaMap{
+						// removed_nested is gone from the schema entirely.
+						"kept_nested": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+					},
+				}).Shim(),
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		blockVal := result["block"].ObjectValue()
+		_, hasRemoved := blockVal["removedNested"]
+		assert.False(t, hasRemoved, "field absent from nested schema must be stripped")
+		assert.Equal(t, resource.NewStringProperty("user-set"), blockVal["keptNested"])
+	})
+
+	t.Run("stale default in array element nested object is stripped", func(t *testing.T) {
+		// TypeList without MaxItems=1 maps to an array of objects in Pulumi.
+		// Each element can have its own __defaults.
+		elem0 := resource.NewObjectProperty(resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("elemStale"),
+			}),
+			"elemStale": resource.NewStringProperty("old-default"),
+			"elemKept":  resource.NewStringProperty("user-set"),
+		})
+		m := resource.PropertyMap{
+			"items": resource.NewArrayProperty([]resource.PropertyValue{elem0}),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"items": (&schema.Schema{
+				Type:     shim.TypeList,
+				Optional: true,
+				Elem: (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"elem_stale": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+						"elem_kept":  (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+					},
+				}).Shim(),
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		items := result["items"].ArrayValue()
+		assert.Len(t, items, 1)
+		elemVal := items[0].ObjectValue()
+		_, hasElemStale := elemVal["elemStale"]
+		assert.False(t, hasElemStale, "stale default in array element should be stripped")
+		assert.Equal(t, resource.NewStringProperty("user-set"), elemVal["elemKept"])
+		_, hasDefaults := elemVal[reservedkeys.Defaults]
+		assert.False(t, hasDefaults, "array element __defaults should be removed when empty")
+	})
+
+	t.Run("nested __defaults inside TypeSet elements are NOT stripped", func(t *testing.T) {
+		// TypeSet membership is hash-based on all element fields. Stripping a field
+		// from a nested element changes its hash and makes TF see set reorder/add/remove
+		// diffs instead of in-place updates. The recursion must skip TypeSet entirely.
+		nestedElem := resource.NewObjectProperty(resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("default"),
+			}),
+			"default":    resource.NewStringProperty("default"),
+			"nestedProp": resource.NewStringProperty("val1"),
+		})
+		m := resource.PropertyMap{
+			"items": resource.NewArrayProperty([]resource.PropertyValue{nestedElem}),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"items": (&schema.Schema{
+				Type:     shim.TypeSet,
+				Optional: true,
+				Elem: (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"default": (&schema.Schema{
+							Type: shim.TypeString, Optional: true, Default: "default",
+						}).Shim(),
+						"nested_prop": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+					},
+				}).Shim(),
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		// The TypeSet element must be untouched: the "default" field and the nested
+		// __defaults must both still be present, otherwise the set hash changes.
+		assert.Equal(t, m, result, "TypeSet element fields and nested __defaults must be preserved")
+	})
+
+	t.Run("nested __defaults inside MaxItemsOne TypeSet are NOT stripped", func(t *testing.T) {
+		// MaxItemsOne TypeSet flattens to a single object, but TF still hashes it as
+		// a set element. Stripping nested fields would change the hash and mislead TF
+		// about set membership.
+		nested := resource.NewObjectProperty(resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("default"),
+			}),
+			"default":    resource.NewStringProperty("default"),
+			"nestedProp": resource.NewStringProperty("val1"),
+		})
+		m := resource.PropertyMap{
+			"item": nested,
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"item": (&schema.Schema{
+				Type:     shim.TypeSet,
+				MaxItems: 1,
+				Optional: true,
+				Elem: (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"default": (&schema.Schema{
+							Type: shim.TypeString, Optional: true, Default: "default",
+						}).Shim(),
+						"nested_prop": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+					},
+				}).Shim(),
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		assert.Equal(t, m, result, "MaxItemsOne TypeSet element fields must be preserved")
+	})
+
+	t.Run("stale default in secret-wrapped nested object is stripped", func(t *testing.T) {
+		// Nested blocks can be wrapped in MakeSecret(). The recursion must unwrap,
+		// strip, and re-wrap.
+		inner := resource.NewObjectProperty(resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("secretStale"),
+			}),
+			"secretStale": resource.NewStringProperty("old-default"),
+			"secretKept":  resource.NewStringProperty("user-set"),
+		})
+		m := resource.PropertyMap{
+			"block": resource.MakeSecret(inner),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"block": (&schema.Schema{
+				Type:      shim.TypeList,
+				MaxItems:  1,
+				Optional:  true,
+				Sensitive: true,
+				Elem: (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"secret_stale": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+						"secret_kept":  (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+					},
+				}).Shim(),
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		// Result should still be a secret
+		assert.True(t, result["block"].IsSecret())
+		blockVal := result["block"].SecretValue().Element.ObjectValue()
+		_, hasStale := blockVal["secretStale"]
+		assert.False(t, hasStale, "stale default inside secret should be stripped")
+		assert.Equal(t, resource.NewStringProperty("user-set"), blockVal["secretKept"])
+	})
+
+	t.Run("stale default in secret-wrapped array element is stripped", func(t *testing.T) {
+		// Array elements can be individually secret-wrapped. The recursion must
+		// unwrap each element, strip stale defaults, and re-wrap.
+		elem := resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("elemStale"),
+			}),
+			"elemStale": resource.NewStringProperty("old-default"),
+			"elemKept":  resource.NewStringProperty("user-set"),
+		}))
+		m := resource.PropertyMap{
+			"items": resource.NewArrayProperty([]resource.PropertyValue{elem}),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"items": (&schema.Schema{
+				Type:     shim.TypeList,
+				Optional: true,
+				Elem: (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"elem_stale": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+						"elem_kept":  (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+					},
+				}).Shim(),
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		items := result["items"].ArrayValue()
+		assert.Len(t, items, 1)
+		assert.True(t, items[0].IsSecret(), "element should still be secret-wrapped")
+		elemVal := items[0].SecretValue().Element.ObjectValue()
+		_, hasStale := elemVal["elemStale"]
+		assert.False(t, hasStale, "stale default in secret-wrapped array element should be stripped")
+		assert.Equal(t, resource.NewStringProperty("user-set"), elemVal["elemKept"])
+	})
+
+	t.Run("deeply nested stale default is stripped (object -> array -> object)", func(t *testing.T) {
+		// Two levels of nesting: top-level block -> array of items -> each item has __defaults
+		innerElem := resource.NewObjectProperty(resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("deepStale"),
+			}),
+			"deepStale": resource.NewStringProperty("old-default"),
+			"deepKept":  resource.NewStringProperty("user-set"),
+		})
+		m := resource.PropertyMap{
+			"outer": resource.NewObjectProperty(resource.PropertyMap{
+				"innerList": resource.NewArrayProperty([]resource.PropertyValue{innerElem}),
+			}),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"outer": (&schema.Schema{
+				Type:     shim.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"inner_list": (&schema.Schema{
+							Type:     shim.TypeList,
+							Optional: true,
+							Elem: (&schema.Resource{
+								Schema: schema.SchemaMap{
+									"deep_stale": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+									"deep_kept":  (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+								},
+							}).Shim(),
+						}).Shim(),
+					},
+				}).Shim(),
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		outerVal := result["outer"].ObjectValue()
+		innerList := outerVal["innerList"].ArrayValue()
+		assert.Len(t, innerList, 1)
+		deepVal := innerList[0].ObjectValue()
+		_, hasDeepStale := deepVal["deepStale"]
+		assert.False(t, hasDeepStale, "deeply nested stale default should be stripped")
+		assert.Equal(t, resource.NewStringProperty("user-set"), deepVal["deepKept"])
+	})
+
+	t.Run("top-level stale block with nested stale defaults is stripped, not re-inserted", func(t *testing.T) {
+		// Regression: when a top-level key is listed in __defaults (so it's a stale
+		// top-level default) AND its value also contains nested __defaults that need
+		// stripping, the recursion path must not re-insert the key after the top-level
+		// strip removes it.
+		nested := resource.NewObjectProperty(resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("nestedStale"),
+			}),
+			"nestedStale": resource.NewStringProperty("old-nested-default"),
+		})
+		m := resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("block"),
+			}),
+			"block": nested,
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"block": (&schema.Schema{
+				Type:     shim.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"nested_stale": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+					},
+				}).Shim(),
+			}).Shim(),
+		})
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
+		_, hasBlock := result["block"]
+		assert.False(t, hasBlock, "top-level stale block should be stripped, not re-inserted by nested-change handling")
+		_, hasDefaults := result[reservedkeys.Defaults]
+		assert.False(t, hasDefaults, "__defaults should be removed when empty")
 	})
 
 	t.Run("does not mutate original map", func(t *testing.T) {
@@ -189,7 +831,7 @@ func TestStripStaleDefaults(t *testing.T) {
 		tfs := makeSchemaMap(map[string]shim.Schema{
 			"stale_field": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 		})
-		result := stripStaleDefaults(ctx, m, nil, tfs, nil)
+		result, _ := stripStaleDefaults(ctx, m, tfs, nil)
 		// Original should still have the field
 		assert.Equal(t, resource.NewStringProperty("old-default"), m["staleField"])
 		// Result should not

--- a/pkg/tfbridge/strip_stale_defaults_test.go
+++ b/pkg/tfbridge/strip_stale_defaults_test.go
@@ -703,16 +703,17 @@ func TestStripStaleDefaults(t *testing.T) {
 		assert.False(t, hasDefaults, "array element __defaults should be removed when empty")
 	})
 
-	t.Run("nested __defaults inside TypeSet elements are NOT stripped", func(t *testing.T) {
-		// TypeSet membership is hash-based on all element fields. Stripping a field
-		// from a nested element changes its hash and makes TF see set reorder/add/remove
-		// diffs instead of in-place updates. The recursion must skip TypeSet entirely.
+	t.Run("stale default inside TypeSet element is stripped", func(t *testing.T) {
+		// Stripping a stale default from a Set element does change its hash, so the
+		// next plan shows a one-time membership rearrangement. That mirrors the
+		// behavior of `terraform apply` against the same provider schema change and
+		// is preferable to retaining a value the current schema can't attribute.
 		nestedElem := resource.NewObjectProperty(resource.PropertyMap{
 			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("default"),
+				resource.NewStringProperty("elemStale"),
 			}),
-			"default":    resource.NewStringProperty("default"),
-			"nestedProp": resource.NewStringProperty("val1"),
+			"elemStale": resource.NewStringProperty("old-default"),
+			"elemKept":  resource.NewStringProperty("user-set"),
 		})
 		m := resource.PropertyMap{
 			"items": resource.NewArrayProperty([]resource.PropertyValue{nestedElem}),
@@ -723,30 +724,32 @@ func TestStripStaleDefaults(t *testing.T) {
 				Optional: true,
 				Elem: (&schema.Resource{
 					Schema: schema.SchemaMap{
-						"default": (&schema.Schema{
-							Type: shim.TypeString, Optional: true, Default: "default",
-						}).Shim(),
-						"nested_prop": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+						"elem_stale": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+						"elem_kept":  (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 					},
 				}).Shim(),
 			}).Shim(),
 		})
 		result := stripStaleDefaults(m, tfs, nil)
-		// The TypeSet element must be untouched: the "default" field and the nested
-		// __defaults must both still be present, otherwise the set hash changes.
-		assert.Equal(t, m, result, "TypeSet element fields and nested __defaults must be preserved")
+		items := result["items"].ArrayValue()
+		assert.Len(t, items, 1)
+		elemVal := items[0].ObjectValue()
+		_, hasElemStale := elemVal["elemStale"]
+		assert.False(t, hasElemStale, "stale default in TypeSet element should be stripped")
+		assert.Equal(t, resource.NewStringProperty("user-set"), elemVal["elemKept"])
+		_, hasDefaults := elemVal[reservedkeys.Defaults]
+		assert.False(t, hasDefaults, "TypeSet element __defaults should be removed when empty")
 	})
 
-	t.Run("nested __defaults inside MaxItemsOne TypeSet are NOT stripped", func(t *testing.T) {
-		// MaxItemsOne TypeSet flattens to a single object, but TF still hashes it as
-		// a set element. Stripping nested fields would change the hash and mislead TF
-		// about set membership.
+	t.Run("stale default inside MaxItemsOne TypeSet element is stripped", func(t *testing.T) {
+		// MaxItemsOne TypeSet flattens to a single object. Same parity rationale as
+		// the array-of-elements case above.
 		nested := resource.NewObjectProperty(resource.PropertyMap{
 			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("default"),
+				resource.NewStringProperty("nestedStale"),
 			}),
-			"default":    resource.NewStringProperty("default"),
-			"nestedProp": resource.NewStringProperty("val1"),
+			"nestedStale": resource.NewStringProperty("old-default"),
+			"nestedKept":  resource.NewStringProperty("user-set"),
 		})
 		m := resource.PropertyMap{
 			"item": nested,
@@ -758,16 +761,19 @@ func TestStripStaleDefaults(t *testing.T) {
 				Optional: true,
 				Elem: (&schema.Resource{
 					Schema: schema.SchemaMap{
-						"default": (&schema.Schema{
-							Type: shim.TypeString, Optional: true, Default: "default",
-						}).Shim(),
-						"nested_prop": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+						"nested_stale": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+						"nested_kept":  (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
 					},
 				}).Shim(),
 			}).Shim(),
 		})
 		result := stripStaleDefaults(m, tfs, nil)
-		assert.Equal(t, m, result, "MaxItemsOne TypeSet element fields must be preserved")
+		itemVal := result["item"].ObjectValue()
+		_, hasNestedStale := itemVal["nestedStale"]
+		assert.False(t, hasNestedStale, "stale default in MaxItemsOne TypeSet should be stripped")
+		assert.Equal(t, resource.NewStringProperty("user-set"), itemVal["nestedKept"])
+		_, hasDefaults := itemVal[reservedkeys.Defaults]
+		assert.False(t, hasDefaults, "MaxItemsOne TypeSet __defaults should be removed when empty")
 	})
 
 	t.Run("stale default in secret-wrapped nested object is stripped", func(t *testing.T) {
@@ -839,6 +845,47 @@ func TestStripStaleDefaults(t *testing.T) {
 		_, hasStale := elemVal["elemStale"]
 		assert.False(t, hasStale, "stale default in secret-wrapped array element should be stripped")
 		assert.Equal(t, resource.NewStringProperty("user-set"), elemVal["elemKept"])
+	})
+
+	t.Run("stale default in fully-secret-wrapped TypeSet array is stripped", func(t *testing.T) {
+		// Sensitive Set fields can be encoded with the secret wrapping the whole
+		// array (rather than per-element). The recursion must unwrap the array,
+		// strip stale defaults from each element, and re-wrap the result as a
+		// secret. Distinct from the per-element case above and from the
+		// MaxItemsOne block-level case — three different secret shapes.
+		elem := resource.NewObjectProperty(resource.PropertyMap{
+			reservedkeys.Defaults: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("elemStale"),
+			}),
+			"elemStale": resource.NewStringProperty("old-default"),
+			"elemKept":  resource.NewStringProperty("user-set"),
+		})
+		m := resource.PropertyMap{
+			"items": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{elem})),
+		}
+		tfs := makeSchemaMap(map[string]shim.Schema{
+			"items": (&schema.Schema{
+				Type:      shim.TypeSet,
+				Optional:  true,
+				Sensitive: true,
+				Elem: (&schema.Resource{
+					Schema: schema.SchemaMap{
+						"elem_stale": (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+						"elem_kept":  (&schema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+					},
+				}).Shim(),
+			}).Shim(),
+		})
+		result := stripStaleDefaults(m, tfs, nil)
+		assert.True(t, result["items"].IsSecret(), "outer Set must remain secret-wrapped")
+		items := result["items"].SecretValue().Element.ArrayValue()
+		assert.Len(t, items, 1)
+		elemVal := items[0].ObjectValue()
+		_, hasStale := elemVal["elemStale"]
+		assert.False(t, hasStale, "stale default inside fully-secret-wrapped Set must be stripped")
+		assert.Equal(t, resource.NewStringProperty("user-set"), elemVal["elemKept"])
+		_, hasDefaults := elemVal[reservedkeys.Defaults]
+		assert.False(t, hasDefaults, "element __defaults must be cleaned when empty")
 	})
 
 	t.Run("deeply nested stale default is stripped (object -> array -> object)", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Strip stale provider defaults from inputs during Diff and Update to prevent validation errors when provider upgrades remove a default value or remove a field from the schema entirely.

## Background

### How Terraform state upgrades work

When a Terraform provider changes its resource schema, it bumps a `SchemaVersion` number and registers `StateUpgraders` — functions that migrate old state representations to the new format. For example, terraform-provider-aws v6 set `auth_token_update_strategy: "ROTATE"` as a default on ElastiCache ReplicationGroup. In the v6→v7 upgrade, a state upgrader (v2→v3) was added to remove this field from state when `auth_token` isn't configured.

The Pulumi bridge invokes these state upgraders automatically via the Terraform SDK's gRPC `UpgradeResourceState` method. When the bridge loads old state from the Pulumi state store, it checks the `schema_version` in `__meta`, and if it's lower than the current schema version, the upgraders run and clean up the state. **This part works correctly.**

### The gap: state vs inputs

In Pulumi, each resource has two stored representations:
- **Outputs** (state): the last known cloud state, stored with `__meta` containing `schema_version`
- **Inputs**: the last known desired configuration, stored with `__defaults` listing which values were injected by the provider rather than set by the user

The Terraform state upgrade mechanism only operates on **outputs/state**. There is no equivalent mechanism for **inputs**. When a provider changes or removes a default value, the state upgrader cleans it from the outputs, but the stale default persists in inputs via `__defaults`.

### How this causes failures during refresh

During `pulumi up --refresh`, the engine calls the provider's `Diff` method as part of the refresh phase. In this call:
- `olds` = old outputs → the bridge creates the TF **prior state** from this, running state upgraders (which remove the stale field) ✓
- `news` = old inputs → the bridge creates the TF **config** from this, but no upgraders run on inputs ✗

Normally, `refresh` reuses the original provider version that created the resource, however when `--run-program` is added, problems arise. This is an engine bug tracked in https://github.com/pulumi/pulumi/issues/19922.

The stale default (e.g. `authTokenUpdateStrategy: "ROTATE"`) is still in the old inputs under `__defaults`. The bridge converts it into the TF config. `PlanResourceChange` then runs `CustomizeDiff` validation, which checks `diff.GetRawConfig()` (the config, not the state). The v7 provider's validation sees `auth_token_update_strategy` in the config without `auth_token` and rejects it:

```
"auth_token_update_strategy": "auth_token" must be specified
```

The `--run-program` flag doesn't help because it only provides clean program inputs for the **update** diff — the **refresh** diff (which fires first) still uses old stored inputs.

### This is a widespread problem

Default changes happen routinely across all major Terraform providers, in both major and minor versions. A survey of the three largest bridged providers shows the scale:

**Defaults removed** — the original failure case, where a stale value reaches `PlanResourceChange` and fails validation:

| Provider | Resource | Field | Change |
|----------|----------|-------|--------|
| AWS | ElastiCache ReplicationGroup | `auth_token_update_strategy` | `Default: "ROTATE"` removed in v6 (the original bug) |
| AWS | Route53 Resolver Rule | `port`, `protocol` | `Default: 53` / `Default: "Do53"` removed, switched to Optional+Computed ([#46928](https://github.com/hashicorp/terraform-provider-aws/pull/46928)) |
| AWS | ASG instance_refresh | `max_healthy_percentage` | `Default: 100` removed — API treats omitted vs 100 differently ([#47188](https://github.com/hashicorp/terraform-provider-aws/pull/47188)) |
| Azure | Redis Cache | `data_persistence_authentication_method` | Default removed, was wrong for Basic/Standard SKUs ([#27069](https://github.com/hashicorp/terraform-provider-azurerm/pull/27069)) |
| GCP | Compute Instance Template | `disk.type`, `disk.mode`, `disk.interface` | Hardcoded defaults removed, API handles them ([#24055](https://github.com/hashicorp/terraform-provider-google/pull/24055)) |

**Defaults changed** (e.g. Azure LB `sku` going Basic → Standard, GCP `disable_on_destroy` going true → false) — these silently preserve the stored old value across the upgrade. This PR intentionally does not change that behavior; see "Why these scope decisions" below for the rationale and the architectural follow-up that addresses it.

**Hardcoded → API-computed** — providers increasingly replace `Default: X` with `Optional+Computed`, letting the API determine the value. When the field is removed from the schema (no Default and no schema entry), this PR strips the stale value, matching the field-removed case above.

The current universe of defaults is large: Azure alone has **548 files** with `Default:` values, **197 files** with StateUpgraders, and **167 files** with CustomizeDiff validators. Most default changes happen **without** state upgraders — providers rely on `PlanResourceChange` to handle it, which works for Terraform but breaks for Pulumi's stored `__defaults`.

### The fix

In the `Diff` and `Update` methods, before building the TF config from `news`, strip fields listed in `__defaults` that have neither a bridge-managed default nor a current TF schema default. Those values are genuinely stale — the schema no longer has any way to derive them — and would otherwise reach `PlanResourceChange` and could trigger validation errors.

The strip predicate is deliberately narrow:

| Field's __defaults entry has... | Action | Why |
|---|---|---|
| Bridge default (auto-naming, EnvVars, From) | preserve | Bridge owns the default; Check re-derives it. Stripping would break auto-naming stability. |
| Current TF schema Default (changed or unchanged) | preserve | Avoids the changed-default phantom diff (see below) and maintains the legacy-stack falsy round-trip from PR [#3420](https://github.com/pulumi/pulumi-terraform-bridge/pull/3420). |
| Removed/Deprecated marker on the field (`SchemaInfo.Removed`, TF `Removed`, or TF `Deprecated && !Required`) | **strip** | Mirrors `applyDefaults`' eligibility gate: if the field would not be defaulted by Check, it must not be forwarded to PlanResourceChange. |
| No bridge default AND no current TF Default | **strip** | The recorded value is genuinely stale — the field's Default was removed, or the field itself was removed from the schema. This is the case that fails validation today. |

The shared eligibility gate `defaultExcluded(sch, psi)` lives in `pkg/tfbridge/schema.go` and is called from `applyDefaults`' overlay branch, `applyDefaults`' TF branch, and `shouldStripStaleDefault` in `provider.go`. Keeping the parity invariant in one place makes future schema-marker additions land in a single function.

The strip recurses into nested objects and array elements — including TypeSet elements — since each nested block can carry its own `__defaults` with independently-stale entries. Stripping a stale field from a Set element does change the element's content hash, so the next plan surfaces a one-time membership rearrangement. That mirrors what `terraform apply` would show against the same provider schema change and is preferable to silently retaining a value the current schema can no longer attribute to a default. For Set fields whose elements back identity-keyed cloud objects (security-group rules, IAM bindings, ALB listener rules), the rearrangement may translate to a delete-then-create at the API layer; this is a one-time effect that lands the stack in a stable state matching the v2 schema, after which subsequent plans show no further churn.

### Known limitations

- **Changed TF schema default (v1 → v2)**: the field is preserved with its stale v1 value because the schema still declares a `Default`. Users silently keep the old default until they explicitly set the new value in their program. The architectural follow-up in [#3434](https://github.com/pulumi/pulumi-terraform-bridge/issues/3434) resolves this.

## Test plan

- Verified end-to-end against a real `@pulumi/aws` v6→v7 upgrade: built a custom `pulumi-resource-aws` with this bridge change and ran `pulumi up --refresh --run-program` on a stack with an ElastiCache ReplicationGroup that had `authTokenUpdateStrategy: "ROTATE"` in `__defaults` — the error is gone
- Unit tests in `pkg/tfbridge/strip_stale_defaults_test.go` covering: top-level strip/preserve classification (TF Default present/absent/removed/deprecated, bridge Default with `Value`/`EnvVars`/`From`/`ComputeDefault`, the parity carve-outs for Required-and-Deprecated and bridge `Removed` shadowing TF Default); recursion through nested objects, TypeList-of-blocks, MaxItemsOne blocks, secret-wrapped objects/arrays/scalars including fully-secret-wrapped Set arrays; TypeSet element stripping (both array-shaped and MaxItemsOne-flattened); deep nesting (object → array → object); top-level and nested simultaneous strip; non-mutation of the original map; `__defaults` listing a key absent from news; non-string `__defaults` entries
- Integration tests in `pkg/tests/strip_stale_defaults_integration_test.go` exercising the runtime SDKv2 paths through `pulcheck`: default-removed, field-removed-from-schema, nested TypeListBlock, TypeListOfBlocks, BridgeDefaultPreserved, stale-default-in-Set-element lifecycle (verifies Up succeeds, the strip lands in stable state, and a follow-up preview reports no further churn), TypeSet hash stability for the still-declared-default case, and a regression guard for strip symmetry across the Diff and Update RPCs
- Updated `TestRegress1020` and `TestRegressAws2352` to include `SchemaInfo.Default` for auto-named fields, matching real provider behavior
- Verified `TestUpdatePreservesLegacyFalsyTFDefaults` (the PR #3420 invariant) continues to pass — the strip predicate preserves any field whose schema declares a Default, so legacy-stack falsy-default round-trip semantics are unaffected

## Alternatives considered

**Run state upgraders on inputs too** — Conceptually the most "correct" fix: if inputs had the same upgrade pipeline as outputs, the problem vanishes. But state upgraders expect the full output shape (all computed fields, IDs, etc.) and inputs are a subset. Feeding inputs through `UpgradeResourceState` would fail on missing fields or corrupt data. A separate "input upgrader" mechanism doesn't exist in Terraform and would be a bridge-only invention.

**Engine fix: don't pass old inputs as `news` during refresh diff** — The most architecturally clean fix. The refresh diff currently sends `news = old stored inputs`, but it could use program inputs (from `--run-program`) or skip calling the provider's `Diff` entirely for the refresh comparison (compute it at the engine level by comparing property maps). This fixes the root cause — stale inputs never reach the provider. But it requires Pulumi engine changes (not bridge). The engine bug is tracked by https://github.com/pulumi/pulumi/issues/19922. However, even if we fix the issue there, we probably still want this default cleanup function as the first piece of #3434.

**Store `schema_version` on inputs (parallel to `__meta` on outputs)** — If inputs tracked their schema version, the bridge could detect stale inputs and run cleanup. But this requires a new metadata field with state migration for all existing stacks, and there's still no upgrader to run on inputs.

**This PR: strip stale defaults in Diff and Update** — Targeted, backward-compatible, bridge-only. Uses metadata that already exists (`__defaults`) to identify provider-injected values and strips them so `PlanResourceChange` can re-determine them with the current schema. This fix would still be useful as defense-in-depth even if the engine fix lands later.

### Why these scope decisions

**Why apply the strip in both Diff and Update?** Diff is the user-visible failure path: the engine's refresh phase calls Diff with stored inputs as `news`, and that is where stale values reach the provider unfiltered. The strip is also applied in Update for symmetry — both RPCs feed `PlanResourceChange`, both receive `news` from Pulumi's engine, and both should see the same shape. In current code Check sanitizes news upstream of Update, so the Update-path strip is defense-in-depth for paths where Check is bypassed (custom state-edit hooks, future RPC additions, refresh flows that don't pass through Check).

**Why preserve fields whose Default just changed (v1 → v2)?** The strip predicate intentionally treats "schema has any current Default or DefaultFunc" as preserve, even when the value changed across versions. Two reasons:

1. **The legacy-stack falsy round-trip invariant from PR [#3420](https://github.com/pulumi/pulumi-terraform-bridge/pull/3420).** That invariant relies on stored falsy values for fields whose schema has a matching Default reaching `RawConfig` as `cty.False/0/""` rather than null — providers read `RawConfig` presence as meaningful. A broader strip would regress this.
2. **The deeper "old default" reuse path.** Even if the strip removed a changed-default field from `news`, `applyDefaults`'s overlay branch reads `olds[__defaults]` (not news) and re-injects the stored old value via the "old default" reuse path. So a strip in this case would be silently undone for any non-empty `SchemaInfo.Default` overlay. The proper fix is to stop tracking TF schema defaults in `__defaults` at all — the architectural follow-up below.

A user who wants to migrate to a new default value can set it explicitly in their program; Check will then record it as user-set rather than provider-defaulted.

**Why not run state upgraders on inputs?** Upgraders expect the full output shape (computed fields, IDs) and would corrupt the input subset. No Terraform-side mechanism does what we'd need.

### Architectural follow-up (not in this PR)

The cleanup that fully resolves the changed-default case: `applyDefaults` should stop tracking TF schema defaults in `__defaults` at all. Then Check would re-derive TF defaults from the current schema each call, the "old default" reuse path would only fire for bridge-managed defaults (auto-naming, EnvVars, From), and a changed default would simply produce the new value in `news` — no stripping needed at runtime, no phantom diff. The strip in this PR remains as the migration path for legacy stacks with already-stored stale entries.

PR [#3398](https://github.com/pulumi/pulumi-terraform-bridge/pull/3398) took the first step (suppressing fresh falsy TF defaults from being materialized) but explicitly held off on the broader change pending evidence that it is safe across the full SDKv2 lifecycle (validation interactions, `GetRawConfig` semantics, provider Configure with `Required + DefaultFunc`, data source Invoke). Tracked as [#3434](https://github.com/pulumi/pulumi-terraform-bridge/issues/3434) and referenced by a `TODO` near `stripStaleDefaults`.

