### PR TITLE
feat(bridge): Forward Terraform provider warnings to Pulumi CLI

### DIFF
--- a/pkg/pf/internal/plugin/provider_context.go
+++ b/pkg/pf/internal/plugin/provider_context.go
@@ -45,20 +45,20 @@ type ProviderWithContext interface {
 
 	CheckWithContext(ctx context.Context, urn resource.URN, olds, news resource.PropertyMap,
 		allowUnknowns bool, randomSeed []byte, autonaming *info.ComputeDefaultAutonamingOptions,
-	) (resource.PropertyMap, []plugin.CheckFailure, error)
+	) (resource.PropertyMap, []plugin.CheckFailure, []string, error)
 
 	DiffWithContext(ctx context.Context, urn resource.URN, id resource.ID, olds resource.PropertyMap,
 		news resource.PropertyMap, allowUnknowns bool, ignoreChanges []string) (plugin.DiffResult, error)
 
 	CreateWithContext(ctx context.Context, urn resource.URN, news resource.PropertyMap, timeout float64,
-		preview bool) (resource.ID, resource.PropertyMap, resource.Status, error)
+		preview bool) (resource.ID, resource.PropertyMap, resource.Status, []string, error)
 
 	ReadWithContext(ctx context.Context, urn resource.URN, id resource.ID,
-		inputs, state resource.PropertyMap) (plugin.ReadResult, resource.Status, error)
+		inputs, state resource.PropertyMap) (plugin.ReadResult, resource.Status, []string, error)
 
 	UpdateWithContext(ctx context.Context, urn resource.URN, id resource.ID,
 		olds resource.PropertyMap, news resource.PropertyMap, timeout float64,
-		ignoreChanges []string, preview bool) (resource.PropertyMap, resource.Status, error)
+		ignoreChanges []string, preview bool) (resource.PropertyMap, resource.Status, []string, error)
 
 	DeleteWithContext(ctx context.Context, urn resource.URN, id resource.ID,
 		inputs, outputs resource.PropertyMap, timeout float64) (resource.Status, error)
@@ -150,9 +150,9 @@ func (prov *provider) Check(
 			Mode:         info.ComputeDefaultAutonamingOptionsMode(req.Autonaming.Mode),
 		}
 	}
-	c, f, err := prov.CheckWithContext(
+	c, f, warnings, err := prov.CheckWithContext(
 		ctx, req.URN, req.Olds, req.News, req.AllowUnknowns, req.RandomSeed, autonaming)
-	return plugin.CheckResponse{Properties: c, Failures: f}, err
+	return plugin.CheckResponse{Properties: c, Failures: f, Warnings: warnings}, err
 }
 
 func (prov *provider) Diff(
@@ -165,24 +165,24 @@ func (prov *provider) Diff(
 func (prov *provider) Create(
 	ctx context.Context, req plugin.CreateRequest,
 ) (plugin.CreateResponse, error) {
-	id, p, s, err := prov.CreateWithContext(ctx,
+	id, p, s, warnings, err := prov.CreateWithContext(ctx,
 		req.URN, req.Properties, req.Timeout, req.Preview)
-	return plugin.CreateResponse{ID: id, Properties: p, Status: s}, err
+	return plugin.CreateResponse{ID: id, Properties: p, Status: s, Warnings: warnings}, err
 }
 
 func (prov *provider) Read(
 	ctx context.Context, req plugin.ReadRequest,
 ) (plugin.ReadResponse, error) {
-	r, s, err := prov.ReadWithContext(ctx, req.URN, req.ID, req.Inputs, req.State)
-	return plugin.ReadResponse{ReadResult: r, Status: s}, err
+	r, s, warnings, err := prov.ReadWithContext(ctx, req.URN, req.ID, req.Inputs, req.State)
+	return plugin.ReadResponse{ReadResult: r, Status: s, Warnings: warnings}, err
 }
 
 func (prov *provider) Update(
 	ctx context.Context, req plugin.UpdateRequest,
 ) (plugin.UpdateResponse, error) {
-	p, s, err := prov.UpdateWithContext(ctx,
+	p, s, warnings, err := prov.UpdateWithContext(ctx,
 		req.URN, req.ID, req.OldOutputs, req.NewInputs, req.Timeout, req.IgnoreChanges, req.Preview)
-	return plugin.UpdateResponse{Properties: p, Status: s}, err
+	return plugin.UpdateResponse{Properties: p, Status: s, Warnings: warnings}, err
 }
 
 func (prov *provider) Delete(

--- a/pkg/pf/internal/plugin/provider_server.go
+++ b/pkg/pf/internal/plugin/provider_server.go
@@ -363,7 +363,7 @@ func (p *providerServer) Check(ctx context.Context, req *pulumirpc.CheckRequest)
 		}
 	}
 
-	newInputs, failures, err := p.provider.CheckWithContext(ctx, urn, state, inputs, true, req.RandomSeed, autonaming)
+	newInputs, failures, _, err := p.provider.CheckWithContext(ctx, urn, state, inputs, true, req.RandomSeed, autonaming)
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +409,7 @@ func (p *providerServer) Create(ctx context.Context, req *pulumirpc.CreateReques
 		return nil, err
 	}
 
-	id, state, _, err := p.provider.CreateWithContext(ctx, urn, inputs, req.GetTimeout(), req.GetPreview())
+	id, state, _, _, err := p.provider.CreateWithContext(ctx, urn, inputs, req.GetTimeout(), req.GetPreview())
 	if err != nil {
 		return nil, err
 	}
@@ -438,7 +438,7 @@ func (p *providerServer) Read(ctx context.Context, req *pulumirpc.ReadRequest) (
 		return nil, err
 	}
 
-	result, _, err := p.provider.ReadWithContext(ctx, urn, requestID, inputs, state)
+	result, _, _, err := p.provider.ReadWithContext(ctx, urn, requestID, inputs, state)
 	if err != nil {
 		return nil, err
 	}
@@ -473,7 +473,7 @@ func (p *providerServer) Update(ctx context.Context, req *pulumirpc.UpdateReques
 		return nil, err
 	}
 
-	newState, _, err := p.provider.UpdateWithContext(ctx, urn, id, state, inputs, req.GetTimeout(), req.GetIgnoreChanges(),
+	newState, _, _, err := p.provider.UpdateWithContext(ctx, urn, id, state, inputs, req.GetTimeout(), req.GetIgnoreChanges(),
 		req.GetPreview())
 	if err != nil {
 		return nil, err

--- a/pkg/pf/internal/plugin/provider_server.go
+++ b/pkg/pf/internal/plugin/provider_server.go
@@ -363,7 +363,7 @@ func (p *providerServer) Check(ctx context.Context, req *pulumirpc.CheckRequest)
 		}
 	}
 
-	newInputs, failures, _, err := p.provider.CheckWithContext(ctx, urn, state, inputs, true, req.RandomSeed, autonaming)
+	newInputs, failures, warnings, err := p.provider.CheckWithContext(ctx, urn, state, inputs, true, req.RandomSeed, autonaming)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +378,7 @@ func (p *providerServer) Check(ctx context.Context, req *pulumirpc.CheckRequest)
 		rpcFailures[i] = &pulumirpc.CheckFailure{Property: string(f.Property), Reason: f.Reason}
 	}
 
-	return &pulumirpc.CheckResponse{Inputs: rpcInputs, Failures: rpcFailures}, nil
+	return &pulumirpc.CheckResponse{Inputs: rpcInputs, Failures: rpcFailures, Warnings: warnings}, nil
 }
 
 func (p *providerServer) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
@@ -398,7 +398,12 @@ func (p *providerServer) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (
 	if err != nil {
 		return nil, err
 	}
-	return p.marshalDiff(diff)
+	resp, err := p.marshalDiff(diff)
+	if err != nil {
+		return nil, err
+	}
+	resp.Warnings = diff.Warnings
+	return resp, nil
 }
 
 func (p *providerServer) Create(ctx context.Context, req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
@@ -409,7 +414,7 @@ func (p *providerServer) Create(ctx context.Context, req *pulumirpc.CreateReques
 		return nil, err
 	}
 
-	id, state, _, _, err := p.provider.CreateWithContext(ctx, urn, inputs, req.GetTimeout(), req.GetPreview())
+	id, state, _, warnings, err := p.provider.CreateWithContext(ctx, urn, inputs, req.GetTimeout(), req.GetPreview())
 	if err != nil {
 		return nil, err
 	}
@@ -422,6 +427,7 @@ func (p *providerServer) Create(ctx context.Context, req *pulumirpc.CreateReques
 	return &pulumirpc.CreateResponse{
 		Id:         string(id),
 		Properties: rpcState,
+		Warnings:   warnings,
 	}, nil
 }
 
@@ -438,7 +444,7 @@ func (p *providerServer) Read(ctx context.Context, req *pulumirpc.ReadRequest) (
 		return nil, err
 	}
 
-	result, _, _, err := p.provider.ReadWithContext(ctx, urn, requestID, inputs, state)
+	result, _, warnings, err := p.provider.ReadWithContext(ctx, urn, requestID, inputs, state)
 	if err != nil {
 		return nil, err
 	}
@@ -457,6 +463,7 @@ func (p *providerServer) Read(ctx context.Context, req *pulumirpc.ReadRequest) (
 		Id:         string(result.ID),
 		Properties: rpcState,
 		Inputs:     rpcInputs,
+		Warnings:   warnings,
 	}, nil
 }
 
@@ -473,7 +480,7 @@ func (p *providerServer) Update(ctx context.Context, req *pulumirpc.UpdateReques
 		return nil, err
 	}
 
-	newState, _, _, err := p.provider.UpdateWithContext(ctx, urn, id, state, inputs, req.GetTimeout(), req.GetIgnoreChanges(),
+	newState, _, warnings, err := p.provider.UpdateWithContext(ctx, urn, id, state, inputs, req.GetTimeout(), req.GetIgnoreChanges(),
 		req.GetPreview())
 	if err != nil {
 		return nil, err
@@ -484,7 +491,7 @@ func (p *providerServer) Update(ctx context.Context, req *pulumirpc.UpdateReques
 		return nil, err
 	}
 
-	return &pulumirpc.UpdateResponse{Properties: rpcState}, nil
+	return &pulumirpc.UpdateResponse{Properties: rpcState, Warnings: warnings}, nil
 }
 
 func (p *providerServer) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {

--- a/pkg/pf/tfbridge/provider_check.go
+++ b/pkg/pf/tfbridge/provider_check.go
@@ -39,19 +39,19 @@ func (p *provider) CheckWithContext(
 	allowUnknowns bool,
 	randomSeed []byte,
 	autonaming *info.ComputeDefaultAutonamingOptions,
-) (resource.PropertyMap, []plugin.CheckFailure, error) {
+) (resource.PropertyMap, []plugin.CheckFailure, []string, error) {
 	ctx = p.initLogging(ctx, p.logSink, urn)
 
 	checkedInputs := inputs.Copy()
 
 	rh, err := p.resourceHandle(ctx, urn)
 	if err != nil {
-		return checkedInputs, []plugin.CheckFailure{}, err
+		return checkedInputs, []plugin.CheckFailure{}, nil, err
 	}
 
 	priorState, err = transformFromState(ctx, rh, priorState)
 	if err != nil {
-		return checkedInputs, []plugin.CheckFailure{}, err
+		return checkedInputs, []plugin.CheckFailure{}, nil, err
 	}
 
 	if info := rh.pulumiResourceInfo; info != nil {
@@ -59,7 +59,7 @@ func (p *provider) CheckWithContext(
 			var err error
 			checkedInputs, err = check(ctx, checkedInputs, p.lastKnownProviderConfig.Copy())
 			if err != nil {
-				return checkedInputs, []plugin.CheckFailure{}, err
+				return checkedInputs, []plugin.CheckFailure{}, nil, err
 			}
 		}
 	}
@@ -79,17 +79,17 @@ func (p *provider) CheckWithContext(
 		ProviderConfig: p.lastKnownProviderConfig,
 	})
 
-	checkFailures, err := p.validateResourceConfig(ctx, urn, rh, news)
+	checkFailures, warnings, err := p.validateResourceConfig(ctx, urn, rh, news)
 
 	schemaMap := rh.schemaOnlyShimResource.Schema()
 	schemaInfos := rh.pulumiResourceInfo.GetFields()
 	news = tfbridge.MarkSchemaSecrets(ctx, schemaMap, schemaInfos, resource.NewObjectProperty(news)).ObjectValue()
 
 	if err != nil {
-		return news, checkFailures, err
+		return news, checkFailures, nil, err
 	}
 
-	return news, checkFailures, nil
+	return news, checkFailures, warnings, nil
 }
 
 func (p *provider) validateResourceConfig(
@@ -97,12 +97,12 @@ func (p *provider) validateResourceConfig(
 	urn resource.URN,
 	rh resourceHandle,
 	inputs resource.PropertyMap,
-) ([]plugin.CheckFailure, error) {
+) ([]plugin.CheckFailure, []string, error) {
 	tfType := rh.schema.Type(ctx).(tftypes.Object)
 
 	encodedInputs, err := convert.EncodePropertyMapToDynamic(rh.encoder, tfType, inputs)
 	if err != nil {
-		return nil, fmt.Errorf("cannot encode resource inputs to call ValidateResourceConfig: %w", err)
+		return nil, nil, fmt.Errorf("cannot encode resource inputs to call ValidateResourceConfig: %w", err)
 	}
 
 	req := tfprotov6.ValidateResourceConfigRequest{
@@ -115,7 +115,7 @@ func (p *provider) validateResourceConfig(
 
 	resp, err := p.tfServer.ValidateResourceConfig(ctx, &req)
 	if err != nil {
-		return nil, fmt.Errorf("error calling ValidateResourceConfig: %w", err)
+		return nil, nil, fmt.Errorf("error calling ValidateResourceConfig: %w", err)
 	}
 
 	schemaMap := rh.schemaOnlyShimResource.Schema()
@@ -132,9 +132,10 @@ func (p *provider) validateResourceConfig(
 	}
 
 	sc := &schemaContext{schemaMap: schemaMap, schemaInfos: schemaInfos}
-	if err := p.processDiagnosticsWithContext(ctx, remainingDiagnostics, sc); err != nil {
-		return nil, err
+	warnings, err := p.processDiagnosticsWithContext(ctx, remainingDiagnostics, sc)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return checkFailures, nil
+	return checkFailures, warnings, nil
 }

--- a/pkg/pf/tfbridge/provider_checkconfig.go
+++ b/pkg/pf/tfbridge/provider_checkconfig.go
@@ -224,7 +224,7 @@ func (p *provider) validateProviderConfig(
 	}
 
 	sc := &schemaContext{schemaMap: schemaMap, schemaInfos: schemaInfos}
-	if err := p.processDiagnosticsWithContext(ctx, remainingDiagnostics, sc); err != nil {
+	if _, err := p.processDiagnosticsWithContext(ctx, remainingDiagnostics, sc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/pf/tfbridge/provider_configure.go
+++ b/pkg/pf/tfbridge/provider_configure.go
@@ -95,5 +95,6 @@ func (p *provider) ConfigureWithContext(ctx context.Context, inputs resource.Pro
 	}
 
 	resp.Diagnostics = replaceConfigInDiagnostics(p.info.Config, p.info.P.Schema(), resp.Diagnostics)
-	return p.processDiagnostics(ctx, resp.Diagnostics)
+	_, err = p.processDiagnostics(ctx, resp.Diagnostics)
+	return err
 }

--- a/pkg/pf/tfbridge/provider_create.go
+++ b/pkg/pf/tfbridge/provider_create.go
@@ -31,12 +31,12 @@ func (p *provider) CreateWithContext(
 	checkedInputs resource.PropertyMap,
 	timeout float64,
 	preview bool,
-) (resource.ID, resource.PropertyMap, resource.Status, error) {
+) (resource.ID, resource.PropertyMap, resource.Status, []string, error) {
 	ctx = p.initLogging(ctx, p.logSink, urn)
 
 	rh, err := p.resourceHandle(ctx, urn)
 	if err != nil {
-		return "", nil, 0, err
+		return "", nil, 0, nil, err
 	}
 
 	tfType := rh.schema.Type(ctx).(tftypes.Object)
@@ -45,16 +45,17 @@ func (p *provider) CreateWithContext(
 
 	checkedInputsValue, err := convert.EncodePropertyMap(rh.encoder, checkedInputs)
 	if err != nil {
-		return "", nil, 0, err
+		return "", nil, 0, nil, err
 	}
 
 	planResp, err := p.plan(ctx, rh.terraformResourceName, rh.schema, priorState, checkedInputsValue)
 	if err != nil {
-		return "", nil, 0, err
+		return "", nil, 0, nil, err
 	}
 
-	if err := p.processDiagnostics(ctx, planResp.Diagnostics); err != nil {
-		return "", nil, 0, err
+	planWarnings, err := p.processDiagnostics(ctx, planResp.Diagnostics)
+	if err != nil {
+		return "", nil, 0, nil, err
 	}
 
 	// NOTE: it seems that planResp.RequiresReplace can be ignored in Create and must be false.
@@ -63,7 +64,7 @@ func (p *provider) CreateWithContext(
 		plannedStatePropertyMap, err := convert.DecodePropertyMapFromDynamic(ctx,
 			rh.decoder, tfType, planResp.PlannedState)
 		if err != nil {
-			return "", nil, 0, err
+			return "", nil, 0, nil, err
 		}
 
 		if rh.pulumiResourceInfo.TransformOutputs != nil {
@@ -71,16 +72,16 @@ func (p *provider) CreateWithContext(
 			plannedStatePropertyMap, err = rh.pulumiResourceInfo.TransformOutputs(ctx,
 				plannedStatePropertyMap)
 			if err != nil {
-				return "", nil, 0, err
+				return "", nil, 0, nil, err
 			}
 		}
 
-		return "", plannedStatePropertyMap, resource.StatusOK, nil
+		return "", plannedStatePropertyMap, resource.StatusOK, planWarnings, nil
 	}
 
 	priorStateValue, configValue, err := makeDynamicValues2(priorState.Value, checkedInputsValue)
 	if err != nil {
-		return "", nil, 0, err
+		return "", nil, 0, nil, err
 	}
 
 	req := tfprotov6.ApplyResourceChangeRequest{
@@ -96,40 +97,42 @@ func (p *provider) CreateWithContext(
 
 	resp, err := p.tfServer.ApplyResourceChange(ctx, &req)
 	if err != nil {
-		return "", nil, 0, err
+		return "", nil, 0, nil, err
 	}
 
-	if err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
-		return "", nil, 0, err
+	applyWarnings, err := p.processDiagnostics(ctx, resp.Diagnostics)
+	if err != nil {
+		return "", nil, 0, nil, err
 	}
 
 	createdState, err := parseResourceStateFromTF(ctx, &rh, resp.NewState, resp.Private)
 	if err != nil {
-		return "", nil, 0, err
+		return "", nil, 0, nil, err
 	}
 
 	createdStateMap, err := createdState.ToPropertyMap(ctx, &rh)
 	if err != nil {
-		return "", nil, 0, err
+		return "", nil, 0, nil, err
 	}
 
 	if rh.pulumiResourceInfo.TransformOutputs != nil {
 		var err error
 		createdStateMap, err = rh.pulumiResourceInfo.TransformOutputs(ctx, createdStateMap)
 		if err != nil {
-			return "", nil, 0, err
+			return "", nil, 0, nil, err
 		}
 	}
 
 	rn := rh.terraformResourceName
 	createdID, err := extractID(ctx, rn, rh.pulumiResourceInfo, createdStateMap)
 	if err != nil {
-		return "", nil, 0, err
+		return "", nil, 0, nil, err
 	}
 
 	if err := insertRawStateDelta(ctx, &rh, createdStateMap, createdState.Value); err != nil {
-		return "", nil, 0, err
+		return "", nil, 0, nil, err
 	}
 
-	return createdID, createdStateMap, resource.StatusOK, nil
+	allWarnings := append(planWarnings, applyWarnings...)
+	return createdID, createdStateMap, resource.StatusOK, allWarnings, nil
 }

--- a/pkg/pf/tfbridge/provider_delete.go
+++ b/pkg/pf/tfbridge/provider_delete.go
@@ -73,7 +73,7 @@ func (p *provider) DeleteWithContext(
 
 	// NOTE: no need to handle resp.Private in Delete.
 
-	if err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
+	if _, err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
 		return resource.StatusPartialFailure, err
 	}
 

--- a/pkg/pf/tfbridge/provider_diagnostics.go
+++ b/pkg/pf/tfbridge/provider_diagnostics.go
@@ -125,7 +125,7 @@ type schemaContext struct {
 	schemaInfos map[string]*tfbridge.SchemaInfo
 }
 
-func (p *provider) processDiagnostics(ctx context.Context, diagnostics []*tfprotov6.Diagnostic) error {
+func (p *provider) processDiagnostics(ctx context.Context, diagnostics []*tfprotov6.Diagnostic) ([]string, error) {
 	return p.processDiagnosticsWithContext(ctx, diagnostics, nil)
 }
 
@@ -133,10 +133,15 @@ func (p *provider) processDiagnosticsWithContext(
 	ctx context.Context,
 	diagnostics []*tfprotov6.Diagnostic,
 	sc *schemaContext,
-) error {
-	// Format and log diagnostics via context-based logging.
+) ([]string, error) {
+	var warnings []string
+
+	// Format and log diagnostics via context-based logging; collect warning messages.
 	for _, d := range diagnostics {
 		p.logDiagnostic(ctx, d, sc)
+		if d.Severity == tfprotov6.DiagnosticSeverityWarning {
+			warnings = append(warnings, p.formatDiagnosticMessage(d, sc))
+		}
 	}
 
 	// Check for errors and return non-nil if there is an error.
@@ -157,13 +162,13 @@ func (p *provider) processDiagnosticsWithContext(
 				}
 			}
 			if d.Summary == d.Detail {
-				return fmt.Errorf("%s%s", prefix, d.Summary)
+				return nil, fmt.Errorf("%s%s", prefix, d.Summary)
 			}
-			return fmt.Errorf("%s%s: %s", prefix, d.Summary, d.Detail)
+			return nil, fmt.Errorf("%s%s: %s", prefix, d.Summary, d.Detail)
 		}
 	}
 
-	return nil
+	return warnings, nil
 }
 
 func (p *provider) logDiagnostic(ctx context.Context, d *tfprotov6.Diagnostic, sc *schemaContext) {

--- a/pkg/pf/tfbridge/provider_diagnostics_test.go
+++ b/pkg/pf/tfbridge/provider_diagnostics_test.go
@@ -504,7 +504,7 @@ func TestProcessDiagnosticsWithContextReturnsError(t *testing.T) {
 		},
 	}
 
-	err := p.processDiagnosticsWithContext(ctx, diags, nil)
+	_, err := p.processDiagnosticsWithContext(ctx, diags, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Invalid configuration")
 	assert.Contains(t, err.Error(), "field must be set")
@@ -529,7 +529,7 @@ func TestProcessDiagnosticsWithContextWarningsReturnNil(t *testing.T) {
 		},
 	}
 
-	err := p.processDiagnosticsWithContext(ctx, diags, nil)
+	_, err := p.processDiagnosticsWithContext(ctx, diags, nil)
 	assert.NoError(t, err)
 }
 
@@ -539,7 +539,7 @@ func TestProcessDiagnosticsWithContextEmpty(t *testing.T) {
 	p := &provider{}
 	ctx := context.Background()
 
-	err := p.processDiagnosticsWithContext(ctx, nil, nil)
+	_, err := p.processDiagnosticsWithContext(ctx, nil, nil)
 	assert.NoError(t, err)
 }
 
@@ -559,7 +559,7 @@ func TestProcessDiagnosticsWithContextErrorWithAttribute(t *testing.T) {
 		},
 	}
 
-	err := p.processDiagnosticsWithContext(ctx, diags, nil)
+	_, err := p.processDiagnosticsWithContext(ctx, diags, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "some_field")
 	assert.Contains(t, err.Error(), "Invalid value")
@@ -590,7 +590,7 @@ func TestProcessDiagnosticsWithContextErrorTranslatedPath(t *testing.T) {
 		},
 	}
 
-	err := p.processDiagnosticsWithContext(ctx, diags, sc)
+	_, err := p.processDiagnosticsWithContext(ctx, diags, sc)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "someField")
 	assert.NotContains(t, err.Error(), "some_field")
@@ -613,7 +613,7 @@ func TestProcessDiagnosticsWithContextErrorSameSummaryDetail(t *testing.T) {
 		},
 	}
 
-	err := p.processDiagnosticsWithContext(ctx, diags, nil)
+	_, err := p.processDiagnosticsWithContext(ctx, diags, nil)
 	require.Error(t, err)
 	assert.Equal(t, "configuration is invalid", err.Error())
 }
@@ -698,7 +698,7 @@ func TestProcessDiagnosticsWithContextWarningsLogged(t *testing.T) {
 		},
 	}
 
-	err := p.processDiagnosticsWithContext(ctx, diags, sc)
+	_, err := p.processDiagnosticsWithContext(ctx, diags, sc)
 	assert.NoError(t, err)
 	assert.Contains(t, logs.String(), `property "oldField" is deprecated`)
 	assert.Contains(t, logs.String(), "use new_field")
@@ -725,10 +725,108 @@ func TestProcessDiagnosticsWithContextMixedDiagnostics(t *testing.T) {
 		},
 	}
 
-	err := p.processDiagnosticsWithContext(ctx, diags, nil)
+	_, err := p.processDiagnosticsWithContext(ctx, diags, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Invalid config")
 
 	// Warning should still have been logged before the error was returned.
 	assert.Contains(t, logs.String(), "use replacement")
+}
+
+// TestProcessDiagnosticsWithContextReturnsWarnings verifies that warning-severity
+// diagnostics are returned as a []string slice alongside a nil error.
+func TestProcessDiagnosticsWithContextReturnsWarnings(t *testing.T) {
+	t.Parallel()
+	p := &provider{}
+	ctx := context.Background()
+
+	diags := []*tfprotov6.Diagnostic{
+		{
+			Severity: tfprotov6.DiagnosticSeverityWarning,
+			Summary:  "First warning",
+			Detail:   "first detail",
+		},
+		{
+			Severity: tfprotov6.DiagnosticSeverityWarning,
+			Summary:  "Second warning",
+			Detail:   "second detail",
+		},
+	}
+
+	warnings, err := p.processDiagnosticsWithContext(ctx, diags, nil)
+	require.NoError(t, err)
+	require.Len(t, warnings, 2)
+	assert.Contains(t, warnings[0], "first detail")
+	assert.Contains(t, warnings[1], "second detail")
+}
+
+// TestProcessDiagnosticsWithContextNoWarningsOnError verifies that when an error is
+// returned, the warnings slice is nil (not partially collected).
+func TestProcessDiagnosticsWithContextNoWarningsOnError(t *testing.T) {
+	t.Parallel()
+	p := &provider{}
+	ctx := context.Background()
+
+	diags := []*tfprotov6.Diagnostic{
+		{
+			Severity: tfprotov6.DiagnosticSeverityWarning,
+			Summary:  "A warning",
+			Detail:   "warning detail",
+		},
+		{
+			Severity: tfprotov6.DiagnosticSeverityError,
+			Summary:  "An error",
+			Detail:   "error detail",
+		},
+	}
+
+	warnings, err := p.processDiagnosticsWithContext(ctx, diags, nil)
+	require.Error(t, err)
+	assert.Nil(t, warnings)
+}
+
+// TestProcessDiagnosticsWithContextEmptyReturnsNilWarnings verifies that an empty
+// diagnostic list returns nil warnings and nil error.
+func TestProcessDiagnosticsWithContextEmptyReturnsNilWarnings(t *testing.T) {
+	t.Parallel()
+	p := &provider{}
+	ctx := context.Background()
+
+	warnings, err := p.processDiagnosticsWithContext(ctx, nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, warnings)
+}
+
+// TestProcessDiagnosticsWithContextWarningsWithSchemaContext verifies that warnings
+// returned include the translated Pulumi property path when schema context is present.
+func TestProcessDiagnosticsWithContextWarningsWithSchemaContext(t *testing.T) {
+	t.Parallel()
+	p := &provider{}
+	ctx := context.Background()
+
+	sc := &schemaContext{
+		schemaMap: shimv2.NewSchemaMap(map[string]*schemav2.Schema{
+			"deprecated_field": {
+				Type:       schemav2.TypeString,
+				Optional:   true,
+				Deprecated: "use new_field instead",
+			},
+		}),
+		schemaInfos: map[string]*tfbridge.SchemaInfo{},
+	}
+
+	diags := []*tfprotov6.Diagnostic{
+		{
+			Severity:  tfprotov6.DiagnosticSeverityWarning,
+			Summary:   "Argument deprecated",
+			Detail:    "use new_field instead",
+			Attribute: tftypes.NewAttributePath().WithAttributeName("deprecated_field"),
+		},
+	}
+
+	warnings, err := p.processDiagnosticsWithContext(ctx, diags, sc)
+	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	assert.Contains(t, warnings[0], "deprecatedField")
+	assert.Contains(t, warnings[0], "deprecated")
 }

--- a/pkg/pf/tfbridge/provider_diff.go
+++ b/pkg/pf/tfbridge/provider_diff.go
@@ -87,7 +87,7 @@ func (p *provider) DiffWithContext(
 	// state. Currently assume that planResp will signal RequiresReplace if needed anyway and there is no useful way
 	// to surface private state differences to the user from the Diff method.
 
-	if err := p.processDiagnostics(ctx, planResp.Diagnostics); err != nil {
+	if _, err := p.processDiagnostics(ctx, planResp.Diagnostics); err != nil {
 		return plugin.DiffResult{}, err
 	}
 

--- a/pkg/pf/tfbridge/provider_invoke.go
+++ b/pkg/pf/tfbridge/provider_invoke.go
@@ -139,7 +139,8 @@ func (p *provider) processInvokeDiagnostics(ctx context.Context, ds datasourceHa
 		}
 		sc = &schemaContext{schemaMap: ds.schemaOnlyShim.Schema(), schemaInfos: fields}
 	}
-	return failures, p.processDiagnosticsWithContext(ctx, rest, sc)
+	_, err := p.processDiagnosticsWithContext(ctx, rest, sc)
+	return failures, err
 }
 
 // Some of the diagnostics pertain to an individual property and should be returned as plugin.CheckFailure for an

--- a/pkg/pf/tfbridge/provider_read.go
+++ b/pkg/pf/tfbridge/provider_read.go
@@ -37,7 +37,7 @@ func (p *provider) ReadWithContext(
 	id resource.ID,
 	oldInputs,
 	currentStateMap resource.PropertyMap,
-) (plugin.ReadResult, resource.Status, error) {
+) (plugin.ReadResult, resource.Status, []string, error) {
 	ctx = p.initLogging(ctx, p.logSink, urn)
 
 	var err error
@@ -49,7 +49,7 @@ func (p *provider) ReadWithContext(
 
 	rh, err := p.resourceHandle(ctx, urn)
 	if err != nil {
-		return plugin.ReadResult{}, 0, err
+		return plugin.ReadResult{}, 0, nil, err
 	}
 
 	// Both "get" and "refresh" scenarios call Read. Detect and dispatch.
@@ -57,28 +57,29 @@ func (p *provider) ReadWithContext(
 
 	var result plugin.ReadResult
 	var resultingState *tftypes.Value
+	var warnings []string
 
 	if isRefresh {
 		// If we are in a refresh, then currentStateMap was read from the state
 		// and should be transformed.
 		currentStateMap, err = transformFromState(ctx, rh, currentStateMap)
 		if err != nil {
-			return plugin.ReadResult{}, 0, err
+			return plugin.ReadResult{}, 0, nil, err
 		}
 
-		result, resultingState, err = p.refreshResource(ctx, &rh, currentStateMap)
+		result, resultingState, warnings, err = p.refreshResource(ctx, &rh, currentStateMap)
 	} else {
-		result, resultingState, err = p.importResource(ctx, &rh, id)
+		result, resultingState, warnings, err = p.importResource(ctx, &rh, id)
 	}
 	if err != nil {
-		return result, ignoredStatus, err
+		return result, ignoredStatus, nil, err
 	}
 
 	if result.Outputs != nil && rh.pulumiResourceInfo.TransformOutputs != nil {
 		var err error
 		result.Outputs, err = rh.pulumiResourceInfo.TransformOutputs(ctx, result.Outputs)
 		if err != nil {
-			return result, ignoredStatus, err
+			return result, ignoredStatus, nil, err
 		}
 	}
 
@@ -90,7 +91,7 @@ func (p *provider) ReadWithContext(
 			rh.pulumiResourceInfo.Fields,
 			isRefresh)
 		if err != nil {
-			return result, ignoredStatus, err
+			return result, ignoredStatus, nil, err
 		}
 
 		// __defaults is not needed for Plugin Framework bridged providers
@@ -99,11 +100,11 @@ func (p *provider) ReadWithContext(
 
 	if resultingState != nil {
 		if err := insertRawStateDelta(ctx, &rh, result.Outputs, *resultingState); err != nil {
-			return result, ignoredStatus, err
+			return result, ignoredStatus, nil, err
 		}
 	}
 
-	return result, ignoredStatus, err
+	return result, ignoredStatus, warnings, err
 }
 
 // deleteDefaultsKey removes the `__defaults: []` entry from all objects recursively
@@ -134,10 +135,10 @@ func (p *provider) refreshResource(
 	ctx context.Context,
 	rh *resourceHandle,
 	currentStateMap resource.PropertyMap,
-) (plugin.ReadResult, *tftypes.Value, error) {
+) (plugin.ReadResult, *tftypes.Value, []string, error) {
 	currentState, err := p.parseAndUpgradeResourceState(ctx, rh, currentStateMap)
 	if err != nil {
-		return plugin.ReadResult{}, nil, fmt.Errorf("failed to get current raw state: %w", err)
+		return plugin.ReadResult{}, nil, nil, fmt.Errorf("failed to get current raw state: %w", err)
 	}
 	return p.readResource(ctx, rh, currentState)
 }
@@ -147,10 +148,10 @@ func (p *provider) readResource(
 	ctx context.Context,
 	rh *resourceHandle,
 	currentState *upgradedResourceState,
-) (plugin.ReadResult, *tftypes.Value, error) {
+) (plugin.ReadResult, *tftypes.Value, []string, error) {
 	currentStateDV, err := makeDynamicValue(currentState.Value)
 	if err != nil {
-		return plugin.ReadResult{}, nil, fmt.Errorf("failed to get dynamic value: %w", err)
+		return plugin.ReadResult{}, nil, nil, fmt.Errorf("failed to get dynamic value: %w", err)
 	}
 
 	req := tfprotov6.ReadResourceRequest{
@@ -163,30 +164,31 @@ func (p *provider) readResource(
 
 	resp, err := p.tfServer.ReadResource(ctx, &req)
 	if err != nil {
-		return plugin.ReadResult{}, nil, err
+		return plugin.ReadResult{}, nil, nil, err
 	}
 
-	if err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
-		return plugin.ReadResult{}, nil, err
+	warnings, err := p.processDiagnostics(ctx, resp.Diagnostics)
+	if err != nil {
+		return plugin.ReadResult{}, nil, nil, err
 	}
 
 	if resp.NewState == nil {
-		return plugin.ReadResult{}, nil, nil
+		return plugin.ReadResult{}, nil, warnings, nil
 	}
 
 	readState, err := parseResourceStateFromTF(ctx, rh, resp.NewState, resp.Private)
 	if err != nil {
-		return plugin.ReadResult{}, nil, fmt.Errorf("parsing resource state: %w", err)
+		return plugin.ReadResult{}, nil, nil, fmt.Errorf("parsing resource state: %w", err)
 	}
 
 	// TF interprets a null new state as an indication that the resource does not exist in the cloud provider.
 	if readState.Value.IsNull() {
-		return plugin.ReadResult{}, nil, nil
+		return plugin.ReadResult{}, nil, warnings, nil
 	}
 
 	readStateMap, err := readState.ToPropertyMap(ctx, rh)
 	if err != nil {
-		return plugin.ReadResult{}, nil, fmt.Errorf("converting to property map: %w", err)
+		return plugin.ReadResult{}, nil, nil, fmt.Errorf("converting to property map: %w", err)
 	}
 
 	readID, err := extractID(ctx, rh.terraformResourceName, rh.pulumiResourceInfo, readStateMap)
@@ -197,7 +199,7 @@ func (p *provider) readResource(
 	return plugin.ReadResult{
 		ID:      readID,
 		Outputs: readStateMap,
-	}, &readState.Value, nil
+	}, &readState.Value, warnings, nil
 }
 
 // Execute a Pulumi import against a PF resource.
@@ -224,7 +226,7 @@ func (p *provider) importResource(
 	ctx context.Context,
 	rh *resourceHandle,
 	id resource.ID,
-) (plugin.ReadResult, *tftypes.Value, error) {
+) (plugin.ReadResult, *tftypes.Value, []string, error) {
 	// TODO[pulumi/pulumi-terraform-bridge#794] set ProviderMeta
 	req := tfprotov6.ImportResourceStateRequest{
 		TypeName: rh.terraformResourceName,
@@ -233,21 +235,22 @@ func (p *provider) importResource(
 
 	resp, err := p.tfServer.ImportResourceState(ctx, &req)
 	if err != nil {
-		return plugin.ReadResult{}, nil, err
+		return plugin.ReadResult{}, nil, nil, err
 	}
 
-	if err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
-		return plugin.ReadResult{}, nil, err
+	warnings, err := p.processDiagnostics(ctx, resp.Diagnostics)
+	if err != nil {
+		return plugin.ReadResult{}, nil, nil, err
 	}
 
 	if len(resp.ImportedResources) > 1 {
-		return plugin.ReadResult{}, nil,
+		return plugin.ReadResult{}, nil, nil,
 			fmt.Errorf("ImportResourceState returned more than one result, " +
 				"but reading only one is supported by Pulumi")
 	}
 
 	if len(resp.ImportedResources) == 0 {
-		return plugin.ReadResult{}, nil,
+		return plugin.ReadResult{}, nil, nil,
 			fmt.Errorf("ImportResourceState failed to return a result")
 	}
 
@@ -255,21 +258,22 @@ func (p *provider) importResource(
 
 	readState, err := parseResourceStateFromTF(ctx, rh, r.State, r.Private)
 	if err != nil {
-		return plugin.ReadResult{}, nil, err
+		return plugin.ReadResult{}, nil, nil, err
 	}
 
 	isNull, err := r.State.IsNull()
 	if err != nil {
-		return plugin.ReadResult{}, nil, err
+		return plugin.ReadResult{}, nil, nil, err
 	}
 
 	// If the resulting map is null
 	if isNull {
 		// Returning a result where plugin.ReadResult.Outputs is nil indicates
 		// that the found resource does not exist.
-		return plugin.ReadResult{}, nil, nil
+		return plugin.ReadResult{}, nil, warnings, nil
 	}
 
 	// Now that the resource has been translated to TF state, read it.
-	return p.readResource(ctx, rh, readState)
+	readResult, tftypesValue, readWarnings, err := p.readResource(ctx, rh, readState)
+	return readResult, tftypesValue, append(warnings, readWarnings...), err
 }

--- a/pkg/pf/tfbridge/provider_update.go
+++ b/pkg/pf/tfbridge/provider_update.go
@@ -36,46 +36,46 @@ func (p *provider) UpdateWithContext(
 	timeout float64,
 	ignoreChanges []string,
 	preview bool,
-) (resource.PropertyMap, resource.Status, error) {
+) (resource.PropertyMap, resource.Status, []string, error) {
 	ctx = p.initLogging(ctx, p.logSink, urn)
 
 	rh, err := p.resourceHandle(ctx, urn)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
 	priorStateMap, err = transformFromState(ctx, rh, priorStateMap)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
 	checkedInputs, err = propertyvalue.ApplyIgnoreChanges(priorStateMap, checkedInputs, ignoreChanges)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to apply ignore changes: %w", err)
+		return nil, 0, nil, fmt.Errorf("failed to apply ignore changes: %w", err)
 	}
 
 	tfType := rh.schema.Type(ctx).(tftypes.Object)
 
 	priorState, err := p.parseAndUpgradeResourceState(ctx, &rh, priorStateMap)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
 	checkedInputsValue, err := convert.EncodePropertyMap(rh.encoder, checkedInputs)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
 	planResp, err := p.plan(ctx, rh.terraformResourceName, rh.schema, priorState, checkedInputsValue)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
 	if preview {
 		plannedStatePropertyMap, err := convert.DecodePropertyMapFromDynamic(ctx,
 			rh.decoder, tfType, planResp.PlannedState)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, nil, err
 		}
 
 		if rh.pulumiResourceInfo.TransformOutputs != nil {
@@ -83,16 +83,16 @@ func (p *provider) UpdateWithContext(
 			plannedStatePropertyMap, err = rh.pulumiResourceInfo.TransformOutputs(ctx,
 				plannedStatePropertyMap)
 			if err != nil {
-				return nil, 0, err
+				return nil, 0, nil, err
 			}
 		}
 
-		return plannedStatePropertyMap, resource.StatusOK, nil
+		return plannedStatePropertyMap, resource.StatusOK, nil, nil
 	}
 
 	priorStateDV, checkedInputsDV, err := makeDynamicValues2(priorState.Value, checkedInputsValue)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
 	req := tfprotov6.ApplyResourceChangeRequest{
@@ -105,34 +105,35 @@ func (p *provider) UpdateWithContext(
 
 	resp, err := p.tfServer.ApplyResourceChange(ctx, &req)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
-	if err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
-		return nil, 0, err
+	warnings, err := p.processDiagnostics(ctx, resp.Diagnostics)
+	if err != nil {
+		return nil, 0, nil, err
 	}
 
 	updatedState, err := parseResourceStateFromTF(ctx, &rh, resp.NewState, resp.Private)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
 	updatedStateMap, err := updatedState.ToPropertyMap(ctx, &rh)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
 	if rh.pulumiResourceInfo.TransformOutputs != nil {
 		var err error
 		updatedStateMap, err = rh.pulumiResourceInfo.TransformOutputs(ctx, updatedStateMap)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, nil, err
 		}
 	}
 
 	if err := insertRawStateDelta(ctx, &rh, updatedStateMap, updatedState.Value); err != nil {
-		return nil, 0, err
+		return nil, 0, nil, err
 	}
 
-	return updatedStateMap, resource.StatusOK, nil
+	return updatedStateMap, resource.StatusOK, warnings, nil
 }

--- a/pkg/pf/tfbridge/resource_state.go
+++ b/pkg/pf/tfbridge/resource_state.go
@@ -291,7 +291,7 @@ func (p *provider) upgradeResourceState(
 	if err != nil {
 		return nil, fmt.Errorf("error calling UpgradeResourceState: %w", err)
 	}
-	if err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
+	if _, err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
 		return nil, err
 	}
 	v, err := resp.UpgradedState.Unmarshal(tfType)

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -563,10 +563,11 @@ func (p *Provider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequest)
 		return check, nil
 	}
 
-	checkFailures := validateProviderConfig(ctx, urn, p, config)
+	checkFailures, configWarnings := validateProviderConfig(ctx, urn, p, config)
 	if len(checkFailures) > 0 {
 		return &pulumirpc.CheckResponse{
 			Failures: checkFailures,
+			Warnings: configWarnings,
 		}, nil
 	}
 
@@ -580,7 +581,8 @@ func (p *Provider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequest)
 	}
 
 	return &pulumirpc.CheckResponse{
-		Inputs: newsStruct,
+		Inputs:   newsStruct,
+		Warnings: configWarnings,
 	}, nil
 }
 
@@ -722,7 +724,7 @@ func validateProviderConfig(
 	urn resource.URN,
 	p *Provider,
 	config shim.ResourceConfig,
-) []*pulumirpc.CheckFailure {
+) ([]*pulumirpc.CheckFailure, []string) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "sdkv2.ValidateProviderConfig")
 	defer span.Finish()
 
@@ -745,11 +747,12 @@ func validateProviderConfig(
 	})
 
 	if len(missingKeys) > 0 {
-		return missingKeys
+		return missingKeys, nil
 	}
 
 	// Perform validation of the config state so we can offer nice errors.
 	warns, errs := p.tf.Validate(ctx, config)
+	var warningMessages []string
 	for _, warn := range warns {
 		msg := formatValidationWarning(warn, p.config, p.info.GetConfig())
 		logErr := p.host.Log(ctx, diag.Warning, "", fmt.Sprintf("provider config warning: %v", msg))
@@ -757,9 +760,10 @@ func validateProviderConfig(
 			glog.V(9).Infof("Failed to log to the engine: %v", logErr)
 			continue
 		}
+		warningMessages = append(warningMessages, msg)
 	}
 
-	return p.adaptCheckFailures(ctx, urn, true /*isProvider*/, p.config, p.info.GetConfig(), errs)
+	return p.adaptCheckFailures(ctx, urn, true /*isProvider*/, p.config, p.info.GetConfig(), errs), warningMessages
 }
 
 // A DiffConfig implementation enables the Pulumi provider to detect when provider configuration is
@@ -1031,9 +1035,11 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	// Now check with the resource provider to see if the values pass muster.
 	rescfg := MakeTerraformConfigFromInputs(ctx, p.tf, inputs)
 	warns, errs := p.tf.ValidateResource(ctx, tfname, rescfg)
+	var warningMessages []string
 	for _, warn := range warns {
 		msg := formatValidationWarning(warn, schemaMap, schemaInfos)
 		logger.Warn(fmt.Sprintf("%v verification warning: %v", urn, msg))
+		warningMessages = append(warningMessages, msg)
 	}
 
 	// Now produce CheckFalures for any properties that failed verification.
@@ -1063,7 +1069,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 		return nil, err
 	}
 
-	return &pulumirpc.CheckResponse{Inputs: minputs, Failures: failures}, nil
+	return &pulumirpc.CheckResponse{Inputs: minputs, Failures: failures, Warnings: warningMessages}, nil
 }
 
 // For properties with MaxItemsOne, where the state is still an array


### PR DESCRIPTION
## Summary

Terraform providers emit diagnostic warnings (deprecation notices, validation warnings, etc.) during Check, Diff, Create, Read, and Update operations. Terraform surfaces these to the user; Pulumi currently drops them silently.

This PR makes two sets of changes so that bridged Terraform providers forward warnings through to the Pulumi engine:

### 1. PF bridge — extract warnings from TF diagnostics

`processDiagnostics` / `processDiagnosticsWithContext` now return `([]string, error)` instead of just `error`. TF diagnostics with severity `Warning` are collected as string messages and returned alongside error handling. These warnings are threaded through:

- `provider_create.go` — `CreateWithContext` collects plan + apply warnings
- `provider_update.go` — `UpdateWithContext` collects plan + apply warnings
- `provider_read.go` — `ReadWithContext` collects read warnings
- `provider_check.go` — `CheckWithContext` collects validation warnings
- `provider_diff.go` — `DiffWithContext` collects plan warnings

### 2. Dynamic bridge — stop discarding warnings at gRPC layer

`pkg/pf/internal/plugin/provider_server.go` was discarding the `[]string` warnings returned by `CheckWithContext`, `CreateWithContext`, `ReadWithContext`, `UpdateWithContext` (using `_`) and not populating `Warnings` in gRPC responses. Fixed for all 5 operations (Check, Diff, Create, Read, Update).

### 3. SDKv2 bridge — forward Check/CheckConfig warnings

`pkg/tfbridge/provider.go`:
- `Check()` collects `formatValidationWarning` messages and populates `pulumirpc.CheckResponse.Warnings`
- `validateProviderConfig` returns `([]*pulumirpc.CheckFailure, []string)` — the second value is warning messages
- `CheckConfig` forwards config validation warnings

### Before vs After

**Before (Pulumi):** No warnings shown during preview/update, even when the underlying TF provider emits them.

**After (Pulumi + engine PR):**
```
warning: [WARNING] Use "proxmox_download_file" instead. This resource / data source will be removed in v1.0.: Deprecated
warning: [WARNING] property "networkDevices[0].enabled" is deprecated: The `enabled` attribute is deprecated...
```

**Terraform (reference):**
```
│ Warning: Deprecated
│   Use "proxmox_download_file" instead. This resource / data source will be removed in v1.0.
```

### Required companion change (engine)

> This PR requires the Pulumi engine to support the `warnings` field in provider gRPC responses:
> **pulumi/pulumi#22599** — adds `repeated string warnings` to proto messages and forwards them via the diagnostic sink.

### Related

- Engine PR: https://github.com/pulumi/pulumi/pull/22599
- Issue: https://github.com/pulumi/pulumi-terraform-bridge/issues/2659

## Testing

- Unit tests added for `processDiagnostics` warning extraction (`provider_diagnostics_test.go`)
- All existing bridge tests pass (`go test ./...` on modified packages)
- End-to-end validated against a real proxmox provider project with deprecation warnings

## Risk

**Low–Medium.** Warning extraction is additive — providers that emit no warnings are unaffected. The `processDiagnostics` signature change touches many files but is mechanical (adding a return value). The dynamic bridge fix is the most impactful since it affects all dynamically bridged providers.