### PR TITLE
Preserve required falsy default config values

### DIFF
--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -4220,7 +4220,6 @@ func TestProviderConfigMinMaxItemsOne(t *testing.T) {
 }
 
 func TestProviderCheckConfigRequiredDefaultEnvConfig(t *testing.T) {
-	t.Setenv("REQUIRED_CONFIG", "required")
 	// Note that this config should be invalid.
 	//
 	// From the Required docs: Required cannot be used with Computed Default, DefaultFunc
@@ -4229,30 +4228,58 @@ func TestProviderCheckConfigRequiredDefaultEnvConfig(t *testing.T) {
 	// From the DefaultFunc docs: For legacy reasons, DefaultFunc can be used with Required
 	//
 	// This is needed right now since some providers (e.g. Azure) depend on this.
-	p := &schemav2.Provider{
-		Schema: map[string]*schemav2.Schema{
-			"required_env": {
-				Type:        schemav2.TypeString,
-				Required:    true,
-				DefaultFunc: schemav2.EnvDefaultFunc("REQUIRED_CONFIG", nil),
+	newProvider := func(t *testing.T, envKey string, defaultValue interface{}) *Provider {
+		t.Helper()
+
+		p := &schemav2.Provider{
+			Schema: map[string]*schemav2.Schema{
+				"required_env": {
+					Type:        schemav2.TypeString,
+					Required:    true,
+					DefaultFunc: schemav2.EnvDefaultFunc(envKey, defaultValue),
+				},
+				// This is actually invalid!
+				// "required": {
+				// 	Type:     schemav2.TypeString,
+				// 	Required: true,
+				// 	Default:  "default",
+				// },
 			},
-			// This is actually invalid!
-			// "required": {
-			// 	Type:     schemav2.TypeString,
-			// 	Required: true,
-			// 	Default:  "default",
-			// },
-		},
-	}
-	shimProv := shimv2.NewProvider(p)
-	provider := &Provider{
-		tf:        shimProv,
-		config:    shimv2.NewSchemaMap(p.Schema),
-		info:      ProviderInfo{P: shimProv},
-		resources: map[tokens.Type]Resource{},
+		}
+		shimProv := shimv2.NewProvider(p)
+		return &Provider{
+			tf:     shimProv,
+			config: shimv2.NewSchemaMap(p.Schema),
+			info: ProviderInfo{
+				P: shimProv,
+				Config: map[string]*SchemaInfo{
+					"required_env": {MarkAsOptional: True()},
+				},
+			},
+			resources: map[tokens.Type]Resource{},
+		}
 	}
 
 	t.Run("No error with env config", func(t *testing.T) {
+		t.Setenv("REQUIRED_CONFIG", "required")
+		provider := newProvider(t, "REQUIRED_CONFIG", nil)
+		testutils.Replay(t, provider, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/CheckConfig",
+		  "request": {
+		    "urn": "urn:pulumi:dev::teststack::pulumi:providers:testprovider::test",
+		    "olds": {},
+		    "news": {}
+		  },
+		  "response": {
+		    "inputs": {}
+		  }
+		}`)
+	})
+
+	t.Run("No error with empty env default config", func(t *testing.T) {
+		t.Setenv("REQUIRED_EMPTY_CONFIG", "")
+		provider := newProvider(t, "REQUIRED_EMPTY_CONFIG", "")
 		testutils.Replay(t, provider, `
 		{
 		  "method": "/pulumirpc.ResourceProvider/CheckConfig",

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -956,7 +956,9 @@ func (ctx *conversionContext) applyDefaults(
 				// preserve Terraform raw-config semantics for freshly synthesized falsy
 				// TF schema defaults. Replayed defaults from prior state still need to
 				// round-trip through unchanged updates for legacy stacks.
-				if source == "Terraform schema" && shouldSuppressTFSchemaDefaultValue(dv) {
+				if source == "Terraform schema" &&
+					(!sch.Required() || sch.DefaultFunc() == nil) &&
+					shouldSuppressTFSchemaDefaultValue(dv) {
 					return true
 				}
 


### PR DESCRIPTION
## Summary
- Keep suppressing freshly synthesized falsy Terraform defaults for optional schema entries so omitted raw config remains omitted.
- Preserve falsy Terraform defaults for `Required` schema entries so legacy provider config using `Required + DefaultFunc` still satisfies Terraform validation.
- Add regression coverage for the AzureAD-shaped provider config case where an overlay marks a required Terraform field optional and `EnvDefaultFunc` falls back to an empty string.

## Context
Bridge v3.127.0 started suppressing omitted falsy Terraform schema defaults like `""`, `false`, and `0` to preserve Terraform raw-config omission semantics. That is correct for optional fields, but it regressed providers with legacy Terraform provider config shaped like:

```go
"metadata_host": {
    Type:        schema.TypeString,
    Required:    true,
    DefaultFunc: schema.EnvDefaultFunc("ARM_METADATA_HOSTNAME", ""),
}
```

Pulumi AzureAD overlays this field as optional, but Terraform validation still sees the upstream field as required. Suppressing the empty-string default makes the key absent, so `CheckConfig` reports missing required config before the provider can accept the empty value.

## Verification
```bash
go test ./pkg/tfbridge ./pkg/tests -run 'TestProviderCheckConfigRequiredDefaultEnvConfig|TestCheckSuppressesOmittedFalsyTFDefaults|TestSDKv1CheckConfigSuppressesOmittedFalsyTFDefaults|TestConfigureCrossTest' -count=1
```