### PR TITLE
Test PR for #3410

### DIFF
--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -94,7 +94,7 @@ func TestCustomizeDiff(t *testing.T) {
 			makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 		assert.NoError(t, err)
 
-		config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
+		config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, nil, inputsMap, sch, info)
 		assert.NoError(t, err)
 
 		tfDiff, err := provider.Diff(ctx, "resource", tfState, config, shim.DiffOptions{
@@ -138,7 +138,7 @@ func TestCustomizeDiff(t *testing.T) {
 			makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 		assert.NoError(t, err)
 
-		config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
+		config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, nil, inputsMap, sch, info)
 		assert.NoError(t, err)
 
 		tfDiff, err := provider.Diff(ctx, "resource", tfState, config, shim.DiffOptions{
@@ -193,7 +193,7 @@ func TestCustomizeDiff(t *testing.T) {
 					makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 				assert.NoError(t, err)
 
-				config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
+				config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, nil, inputsMap, sch, info)
 				assert.NoError(t, err)
 
 				// Calling Diff with the given CustomizeDiff used to panic, no more asserts needed.
@@ -300,7 +300,7 @@ func diffTest(t *testing.T, tfs map[string]*v2Schema.Schema, inputs,
 					makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 				assert.NoError(t, err)
 
-				config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
+				config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, nil, inputsMap, sch, info)
 				assert.NoError(t, err)
 				tfDiff, err := provider.Diff(ctx, "resource", tfState, config, shim.DiffOptions{
 					IgnoreChanges: newIgnoreChanges(ctx, sch, info, stateMap, inputsMap, ignoreChanges),
@@ -330,7 +330,7 @@ func diffTest(t *testing.T, tfs map[string]*v2Schema.Schema, inputs,
 					makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 				assert.NoError(t, err)
 
-				config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, inputsMap, sch, info)
+				config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, nil, inputsMap, sch, info)
 				assert.NoError(t, err)
 
 				for k := range expected {

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1153,7 +1153,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 
 	schema, fields := res.TF.Schema(), res.Schema.Fields
 
-	config, assets, err := MakeTerraformConfig(ctx, p, news, schema, fields)
+	config, assets, err := MakeTerraformConfig(ctx, p, olds, news, schema, fields)
 	if err != nil {
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
 	}
@@ -1309,7 +1309,7 @@ func (p *Provider) Create(ctx context.Context, req *pulumirpc.CreateRequest) (*p
 	// To get Terraform to create a new resource, the ID must be blank and existing state must be empty (since the
 	// resource does not exist yet), and the diff object should have no old state and all of the new state.
 	config, assets, err := MakeTerraformConfig(
-		ctx, p, props, res.TF.Schema(), res.Schema.Fields,
+		ctx, p, nil, props, res.TF.Schema(), res.Schema.Fields,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "preparing %s's new property inputs", urn)
@@ -1472,7 +1472,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 		}
 	}
 
-	config, assets, err := MakeTerraformConfig(ctx, p, oldInputs, res.TF.Schema(), res.Schema.Fields)
+	config, assets, err := MakeTerraformConfig(ctx, p, nil, oldInputs, res.TF.Schema(), res.Schema.Fields)
 	if err != nil {
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
 	}
@@ -1673,7 +1673,7 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 
 	schema, fields := res.TF.Schema(), res.Schema.Fields
 
-	config, assets, err := MakeTerraformConfig(ctx, p, news, schema, fields)
+	config, assets, err := MakeTerraformConfig(ctx, p, olds, news, schema, fields)
 	if err != nil {
 		return nil, errors.Wrapf(err, "preparing %s's new property state", urn)
 	}

--- a/pkg/tfbridge/rawstate_test.go
+++ b/pkg/tfbridge/rawstate_test.go
@@ -1133,7 +1133,7 @@ func Test_rawstate_against_MakeTerraformOutputs(t *testing.T) {
 			tfs := sdkv2.NewSchemaMap(tc.tfs)
 			prov := &Provider{tf: p}
 
-			resourceConfig, assets, err := MakeTerraformConfig(ctx, prov, tc.inputs, tfs, tc.ps)
+			resourceConfig, assets, err := MakeTerraformConfig(ctx, prov, nil, tc.inputs, tfs, tc.ps)
 			require.NoError(t, err)
 
 			instanceDiff, err := p.Diff(ctx, tok, nil /*state*/, resourceConfig, shim.DiffOptions{})

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -654,7 +654,11 @@ func (ctx *conversionContext) makeObjectTerraformInputs(
 		}
 		tfAttributesToPulumiProperties[name] = string(key)
 		var old resource.PropertyValue
-		if ctx.ApplyDefaults && olds != nil {
+		// Always pass old values when available so that makeTerraformInput can use
+		// matchSetElements for content-based TypeSet matching. Old values are only used
+		// for matching context (not for populating defaults) when ApplyDefaults is false.
+		// See https://github.com/pulumi/pulumi-terraform-bridge/issues/3383.
+		if olds != nil {
 			old = olds[key]
 		}
 
@@ -1264,10 +1268,13 @@ func MakeTerraformOutput(
 }
 
 // MakeTerraformConfig creates a Terraform config map, used in state and diff calculations, from a Pulumi property map.
-func MakeTerraformConfig(ctx context.Context, p *Provider, m resource.PropertyMap,
+// When olds is non-nil, TypeSet arrays use content-based matching (via matchSetElements) instead of
+// positional matching, preventing oneof field leakage when cloud providers reorder set elements.
+// See https://github.com/pulumi/pulumi-terraform-bridge/issues/3383.
+func MakeTerraformConfig(ctx context.Context, p *Provider, olds, news resource.PropertyMap,
 	tfs shim.SchemaMap, ps map[string]*SchemaInfo,
 ) (shim.ResourceConfig, AssetTable, error) {
-	inputs, assets, err := makeTerraformInputsWithOptions(ctx, nil, p.configValues, nil, m, tfs, ps,
+	inputs, assets, err := makeTerraformInputsWithOptions(ctx, nil, p.configValues, olds, news, tfs, ps,
 		makeTerraformInputsOptions{
 			DisableDefaults: true, DisableTFDefaults: true,
 		})
@@ -1288,7 +1295,7 @@ func UnmarshalTerraformConfig(ctx context.Context, p *Provider, m *pbstruct.Stru
 	if err != nil {
 		return nil, nil, err
 	}
-	return MakeTerraformConfig(ctx, p, props, tfs, ps)
+	return MakeTerraformConfig(ctx, p, nil, props, tfs, ps)
 }
 
 // makeConfig is a helper for MakeTerraformConfigFromInputs that performs a deep-ish copy of its input, recursively

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -4762,3 +4762,239 @@ func TestCheckMakeTerraformInputsTypeSetReorder(t *testing.T) {
 		}
 	})
 }
+
+// TestUpdateMakeTerraformConfigTypeSetReorder verifies that the Update/Create code path
+// (makeTerraformConfigWithOlds / makeTerraformInputsNoDefaults) correctly matches TypeSet
+// elements by content rather than position when old state has a different order than new inputs.
+// This is the fix for the Update/Create portion of
+// https://github.com/pulumi/pulumi-terraform-bridge/issues/3383.
+func TestUpdateMakeTerraformConfigTypeSetReorder(t *testing.T) {
+	t.Parallel()
+
+	envSetSchema := schemaMap(map[string]*schema.Schema{
+		"envs": {
+			Type:     shim.TypeSet,
+			Optional: true,
+			Elem: (&schema.Resource{
+				Schema: schemaMap(map[string]*schema.Schema{
+					"name": {
+						Type: shim.TypeString,
+					},
+					"value": {
+						Type:     shim.TypeString,
+						Optional: true,
+					},
+					"value_source": {
+						Type:     shim.TypeString,
+						Optional: true,
+					},
+				}),
+			}).Shim(),
+		},
+	})
+
+	envListSchema := schemaMap(map[string]*schema.Schema{
+		"envs": {
+			Type:     shim.TypeList,
+			Optional: true,
+			Elem: (&schema.Resource{
+				Schema: schemaMap(map[string]*schema.Schema{
+					"name": {
+						Type: shim.TypeString,
+					},
+					"value": {
+						Type:     shim.TypeString,
+						Optional: true,
+					},
+					"value_source": {
+						Type:     shim.TypeString,
+						Optional: true,
+					},
+				}),
+			}).Shim(),
+		},
+	})
+
+	t.Run("cloud_run_oneof_no_corruption_on_update", func(t *testing.T) {
+		t.Parallel()
+
+		// Old state has GCP's alphabetical order (from a previous Create/Update).
+		// APP_SECRET has both value="" (TF default) and value_source set.
+		olds := resource.PropertyMap{
+			"envs": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":        resource.NewStringProperty("APP_SECRET"),
+					"value":       resource.NewStringProperty(""),
+					"valueSource": resource.NewStringProperty("projects/p/secrets/s/versions/latest"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":  resource.NewStringProperty("DATABASE_URL"),
+					"value": resource.NewStringProperty("postgres://localhost:5432/db"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":  resource.NewStringProperty("ZOO_MODE"),
+					"value": resource.NewStringProperty("production"),
+				}),
+			}),
+		}
+
+		// User's code has a different order: ZOO_MODE, APP_SECRET (valueSource only), DATABASE_URL.
+		news := resource.PropertyMap{
+			"envs": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":  resource.NewStringProperty("ZOO_MODE"),
+					"value": resource.NewStringProperty("production"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":        resource.NewStringProperty("APP_SECRET"),
+					"valueSource": resource.NewStringProperty("projects/p/secrets/s/versions/latest"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":  resource.NewStringProperty("DATABASE_URL"),
+					"value": resource.NewStringProperty("postgres://localhost:5432/db"),
+				}),
+			}),
+		}
+
+		// makeTerraformInputsNoDefaults mirrors the MakeTerraformConfig / makeTerraformConfigWithOlds
+		// code path used during Update and Diff (defaults disabled).
+		result, _, err := makeTerraformInputsNoDefaults(olds, news, envSetSchema, nil)
+		require.NoError(t, err)
+
+		// No env var should have both "value" and "value_source" set (oneof violation).
+		envs := result["envs"]
+		envsArr, ok := envs.([]interface{})
+		require.True(t, ok, "envs should be an array")
+		require.Len(t, envsArr, 3)
+
+		for _, env := range envsArr {
+			envMap, ok := env.(map[string]interface{})
+			require.True(t, ok)
+			name := envMap["name"].(string)
+			hasValue := envMap["value"] != nil && envMap["value"] != ""
+			hasValueSource := envMap["value_source"] != nil && envMap["value_source"] != ""
+			if hasValue && hasValueSource {
+				t.Errorf("env %q has both value=%q and value_source=%q — oneof violation",
+					name, envMap["value"], envMap["value_source"])
+			}
+		}
+	})
+
+	t.Run("three_element_reorder_with_mixed_value_types", func(t *testing.T) {
+		t.Parallel()
+
+		// Old state: cloud returned alphabetically with mixed value/valueSource
+		olds := resource.PropertyMap{
+			"envs": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":        resource.NewStringProperty("API_KEY"),
+					"value":       resource.NewStringProperty(""),
+					"valueSource": resource.NewStringProperty("projects/p/secrets/api-key/versions/1"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":  resource.NewStringProperty("LOG_LEVEL"),
+					"value": resource.NewStringProperty("info"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":        resource.NewStringProperty("SESSION_SECRET"),
+					"value":       resource.NewStringProperty(""),
+					"valueSource": resource.NewStringProperty("projects/p/secrets/session/versions/1"),
+				}),
+			}),
+		}
+
+		// User's code has different order: LOG_LEVEL, SESSION_SECRET, API_KEY
+		news := resource.PropertyMap{
+			"envs": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":  resource.NewStringProperty("LOG_LEVEL"),
+					"value": resource.NewStringProperty("debug"), // changed value
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":        resource.NewStringProperty("SESSION_SECRET"),
+					"valueSource": resource.NewStringProperty("projects/p/secrets/session/versions/1"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":        resource.NewStringProperty("API_KEY"),
+					"valueSource": resource.NewStringProperty("projects/p/secrets/api-key/versions/1"),
+				}),
+			}),
+		}
+
+		result, _, err := makeTerraformInputsNoDefaults(olds, news, envSetSchema, nil)
+		require.NoError(t, err)
+
+		envs := result["envs"]
+		envsArr, ok := envs.([]interface{})
+		require.True(t, ok, "envs should be an array")
+		require.Len(t, envsArr, 3)
+
+		for _, env := range envsArr {
+			envMap, ok := env.(map[string]interface{})
+			require.True(t, ok)
+			name := envMap["name"].(string)
+			hasValue := envMap["value"] != nil && envMap["value"] != ""
+			hasValueSource := envMap["value_source"] != nil && envMap["value_source"] != ""
+			if hasValue && hasValueSource {
+				t.Errorf("env %q has both value=%q and value_source=%q — oneof violation",
+					name, envMap["value"], envMap["value_source"])
+			}
+		}
+
+		// Verify specific elements have correct fields
+		for _, env := range envsArr {
+			envMap := env.(map[string]interface{})
+			name := envMap["name"].(string)
+			switch name {
+			case "LOG_LEVEL":
+				assert.Equal(t, "debug", envMap["value"], "LOG_LEVEL should have value=debug")
+			case "SESSION_SECRET":
+				assert.Equal(t, "projects/p/secrets/session/versions/1",
+					envMap["value_source"], "SESSION_SECRET should have value_source")
+			case "API_KEY":
+				assert.Equal(t, "projects/p/secrets/api-key/versions/1",
+					envMap["value_source"], "API_KEY should have value_source")
+			}
+		}
+	})
+
+	t.Run("typelist_still_positional_on_update", func(t *testing.T) {
+		t.Parallel()
+
+		// With TypeList, positional matching should be used (order matters).
+		olds := resource.PropertyMap{
+			"envs": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":  resource.NewStringProperty("ZOO_MODE"),
+					"value": resource.NewStringProperty("production"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":        resource.NewStringProperty("APP_SECRET"),
+					"valueSource": resource.NewStringProperty("secret_ref"),
+				}),
+			}),
+		}
+
+		news := resource.PropertyMap{
+			"envs": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":  resource.NewStringProperty("ZOO_MODE"),
+					"value": resource.NewStringProperty("production"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":        resource.NewStringProperty("APP_SECRET"),
+					"valueSource": resource.NewStringProperty("secret_ref"),
+				}),
+			}),
+		}
+
+		// TypeList with same ordering should work fine
+		result, _, err := makeTerraformInputsNoDefaults(olds, news, envListSchema, nil)
+		require.NoError(t, err)
+
+		envs := result["envs"]
+		envsArr, ok := envs.([]interface{})
+		require.True(t, ok, "envs should be an array")
+		require.Len(t, envsArr, 2)
+	})
+}


### PR DESCRIPTION
Add olds parameter to MakeTerraformConfig so TypeSet arrays use
content-based matching (via matchSetElements) instead of positional
matching. This prevents oneof field leakage when cloud providers
reorder set elements (e.g., GCP Cloud Run returning env vars
alphabetically).

Also relax the ApplyDefaults gate in makeObjectTerraformInputs so
old values are passed through for matching context even when defaults
are disabled.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/3392

https://claude.ai/code/session_01LdR1vGmSc9SnfshbU9ACpY
