### PR TITLE
dynamic: retry on ETXTBSY when launching cached provider

### DIFF
--- a/dynamic/internal/shim/run/loader.go
+++ b/dynamic/internal/shim/run/loader.go
@@ -106,9 +106,9 @@ func LocalProvider(ctx context.Context, path string) (Provider, error) {
 // attempts with the default backoff is 350ms.
 const etxtbsyMaxAttempts = 4
 
-// etxtbsyBackoff is the sleep before the (attempt+1)'th attempt; attempt 0 has
-// no preceding sleep. It is a package variable so tests can override it.
-var etxtbsyBackoff = func(attempt int) time.Duration {
+// defaultETXTBSYBackoff is the sleep before the (attempt+1)'th attempt;
+// attempt 0 has no preceding sleep. Yields 50ms, 100ms, 200ms.
+func defaultETXTBSYBackoff(attempt int) time.Duration {
 	return time.Duration(50*(1<<(attempt-1))) * time.Millisecond
 }
 
@@ -151,7 +151,7 @@ func startPluginClient(
 		}
 	}
 
-	return retryOnTextFileBusy(ctx, meta.Provider.String(), func() (*plugin.Client, plugin.ClientProtocol, error) {
+	start := func() (*plugin.Client, plugin.ClientProtocol, error) {
 		client := plugin.NewClient(newConfig())
 		rpcClient, err := client.Client()
 		if err != nil {
@@ -159,7 +159,8 @@ func startPluginClient(
 			return nil, nil, err
 		}
 		return client, rpcClient, nil
-	})
+	}
+	return retryOnTextFileBusy(ctx, meta.Provider.String(), start, defaultETXTBSYBackoff)
 }
 
 // pluginStarter constructs a fresh plugin.Client and attempts to start it,
@@ -168,16 +169,18 @@ type pluginStarter func() (*plugin.Client, plugin.ClientProtocol, error)
 
 // retryOnTextFileBusy invokes start in a bounded loop, retrying only when
 // start returns an ETXTBSY error. All other errors are returned immediately.
+// backoff returns the sleep before the (attempt+1)'th attempt; attempt 0 has
+// no preceding sleep.
 //
 // Split out from startPluginClient so the retry policy can be exercised by
 // unit tests without spinning up real plugin processes.
 func retryOnTextFileBusy(
-	ctx context.Context, providerName string, start pluginStarter,
+	ctx context.Context, providerName string, start pluginStarter, backoff func(attempt int) time.Duration,
 ) (*plugin.Client, plugin.ClientProtocol, error) {
 	var lastErr error
 	for attempt := 0; attempt < etxtbsyMaxAttempts; attempt++ {
 		if attempt > 0 {
-			time.Sleep(etxtbsyBackoff(attempt))
+			time.Sleep(backoff(attempt))
 		}
 		client, rpcClient, err := start()
 		if err == nil {

--- a/dynamic/internal/shim/run/loader.go
+++ b/dynamic/internal/shim/run/loader.go
@@ -101,7 +101,6 @@ func LocalProvider(ctx context.Context, path string) (Provider, error) {
 	})
 }
 
-// defaultETXTBSYBackoff yields 50ms, 100ms, 200ms.
 func defaultETXTBSYBackoff(attempt int) time.Duration {
 	return time.Duration(50*(1<<(attempt-1))) * time.Millisecond
 }
@@ -131,7 +130,6 @@ func startPluginClient(
 		}
 	}
 
-	// One launch attempt; retryOnTextFileBusy runs this in a loop.
 	start := func() (*plugin.Client, plugin.ClientProtocol, error) {
 		client := plugin.NewClient(newConfig())
 		rpcClient, err := client.Client()

--- a/dynamic/internal/shim/run/loader.go
+++ b/dynamic/internal/shim/run/loader.go
@@ -101,34 +101,13 @@ func LocalProvider(ctx context.Context, path string) (Provider, error) {
 	})
 }
 
-// etxtbsyMaxAttempts is the maximum number of times startPluginClient will
-// retry plugin start in the face of ETXTBSY. Worst-case total wait between
-// attempts with the default backoff is 350ms.
-const etxtbsyMaxAttempts = 4
-
-// defaultETXTBSYBackoff is the sleep before the (attempt+1)'th attempt;
-// attempt 0 has no preceding sleep. Yields 50ms, 100ms, 200ms.
+// defaultETXTBSYBackoff yields 50ms, 100ms, 200ms.
 func defaultETXTBSYBackoff(attempt int) time.Duration {
 	return time.Duration(50*(1<<(attempt-1))) * time.Millisecond
 }
 
-// startPluginClient launches the cached provider via go-plugin, retrying when
-// the kernel returns ETXTBSY ("text file busy") at fork+exec.
-//
-// On Linux, execve fails with ETXTBSY if any process holds the binary open for
-// write at the moment of exec. The dynamic bridge writes each provider binary
-// to its cache directory and then immediately exec's it; under concurrent
-// pulumi install (parallel >= 2 packages) the install path occasionally leaves
-// a brief open-for-write window that overlaps the exec, surfacing as
-//
-//	fork/exec <provider>: text file busy
-//
-// see https://github.com/pulumi/pulumi-terraform-bridge/issues/3425. The race
-// is sub-millisecond, so a small bounded retry resolves it cleanly. macOS does
-// not enforce ETXTBSY, so this path is effectively a no-op there.
-//
-// plugin.ClientConfig must be rebuilt on each attempt because exec.Cmd is
-// single-use after Start, and plugin.NewClient takes ownership of the Cmd.
+// startPluginClient launches the cached provider via go-plugin, retrying on
+// ETXTBSY. See https://github.com/pulumi/pulumi-terraform-bridge/issues/3425.
 func startPluginClient(
 	ctx context.Context, meta *providercache.CachedProvider, execFile string,
 ) (*plugin.Client, plugin.ClientProtocol, error) {
@@ -138,19 +117,21 @@ func startPluginClient(
 			Logger:           logging.NewProviderLogger(""),
 			AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 			Managed:          true,
-			// We intentionally use [context.Background] so the lifetime of the
-			// provider can escape the lifetime of the parameterize call.
+			// context.Background so the launched provider isn't killed when
+			// the caller's context (typically Parameterize) is cancelled.
 			Cmd:              exec.CommandContext(context.Background(), execFile),
 			AutoMTLS:         true,
 			VersionedPlugins: tfplugin.VersionedPlugins,
 			SyncStdout:       logging.PluginOutputMonitor(fmt.Sprintf("%s:stdout", meta.Provider)),
 			SyncStderr:       logging.PluginOutputMonitor(fmt.Sprintf("%s:stderr", meta.Provider)),
 			GRPCDialOptions: []grpc.DialOption{
+				// Appends plugin-side panic stack traces to gRPC errors.
 				grpc.WithUnaryInterceptor(includePanic),
 			},
 		}
 	}
 
+	// One launch attempt; retryOnTextFileBusy runs this in a loop.
 	start := func() (*plugin.Client, plugin.ClientProtocol, error) {
 		client := plugin.NewClient(newConfig())
 		rpcClient, err := client.Client()
@@ -163,47 +144,35 @@ func startPluginClient(
 	return retryOnTextFileBusy(ctx, meta.Provider.String(), start, defaultETXTBSYBackoff)
 }
 
-// pluginStarter constructs a fresh plugin.Client and attempts to start it,
-// returning the running client + protocol on success, or an error.
-type pluginStarter func() (*plugin.Client, plugin.ClientProtocol, error)
-
-// retryOnTextFileBusy invokes start in a bounded loop, retrying only when
-// start returns an ETXTBSY error. All other errors are returned immediately.
-// backoff returns the sleep before the (attempt+1)'th attempt; attempt 0 has
-// no preceding sleep.
-//
-// Split out from startPluginClient so the retry policy can be exercised by
-// unit tests without spinning up real plugin processes.
 func retryOnTextFileBusy(
-	ctx context.Context, providerName string, start pluginStarter, backoff func(attempt int) time.Duration,
+	ctx context.Context, providerName string,
+	start func() (*plugin.Client, plugin.ClientProtocol, error),
+	backoff func(attempt int) time.Duration,
 ) (*plugin.Client, plugin.ClientProtocol, error) {
-	var lastErr error
-	for attempt := 0; attempt < etxtbsyMaxAttempts; attempt++ {
+	const maxAttempts = 4
+	var (
+		client    *plugin.Client
+		rpcClient plugin.ClientProtocol
+		err       error
+	)
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if attempt > 0 {
 			time.Sleep(backoff(attempt))
 		}
-		client, rpcClient, err := start()
+		client, rpcClient, err = start()
 		if err == nil {
 			return client, rpcClient, nil
 		}
-		if !isTextFileBusy(err) {
+		if !strings.Contains(err.Error(), "text file busy") {
 			return nil, nil, err
 		}
-		lastErr = err
 		slog.InfoContext(ctx, "provider exec hit ETXTBSY, retrying",
 			slog.String("provider", providerName),
 			slog.Int("attempt", attempt+1),
 			slog.String("error", err.Error()))
 	}
 	return nil, nil, fmt.Errorf("provider %s exec failed with ETXTBSY after %d attempts: %w",
-		providerName, etxtbsyMaxAttempts, lastErr)
-}
-
-// isTextFileBusy reports whether err originated from execve returning ETXTBSY.
-// We match on the string because go-plugin wraps the underlying *exec.Error
-// from cmd.Start, losing the typed syscall errno.
-func isTextFileBusy(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "text file busy")
+		providerName, maxAttempts, err)
 }
 
 func cutLast(s, sep string) (string, string, bool) {

--- a/dynamic/internal/shim/run/loader.go
+++ b/dynamic/internal/shim/run/loader.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/apparentlymart/go-versions/versions"
 	plugin "github.com/hashicorp/go-plugin"
@@ -98,6 +99,108 @@ func LocalProvider(ctx context.Context, path string) (Provider, error) {
 		Version:    versions.Version{},
 		PackageDir: dir,
 	})
+}
+
+// etxtbsyMaxAttempts is the maximum number of times startPluginClient will
+// retry plugin start in the face of ETXTBSY. Worst-case total wait between
+// attempts with the default backoff is 350ms.
+const etxtbsyMaxAttempts = 4
+
+// etxtbsyBackoff is the sleep before the (attempt+1)'th attempt; attempt 0 has
+// no preceding sleep. It is a package variable so tests can override it.
+var etxtbsyBackoff = func(attempt int) time.Duration {
+	return time.Duration(50*(1<<(attempt-1))) * time.Millisecond
+}
+
+// startPluginClient launches the cached provider via go-plugin, retrying when
+// the kernel returns ETXTBSY ("text file busy") at fork+exec.
+//
+// On Linux, execve fails with ETXTBSY if any process holds the binary open for
+// write at the moment of exec. The dynamic bridge writes each provider binary
+// to its cache directory and then immediately exec's it; under concurrent
+// pulumi install (parallel >= 2 packages) the install path occasionally leaves
+// a brief open-for-write window that overlaps the exec, surfacing as
+//
+//	fork/exec <provider>: text file busy
+//
+// see https://github.com/pulumi/pulumi-terraform-bridge/issues/3425. The race
+// is sub-millisecond, so a small bounded retry resolves it cleanly. macOS does
+// not enforce ETXTBSY, so this path is effectively a no-op there.
+//
+// plugin.ClientConfig must be rebuilt on each attempt because exec.Cmd is
+// single-use after Start, and plugin.NewClient takes ownership of the Cmd.
+func startPluginClient(
+	ctx context.Context, meta *providercache.CachedProvider, execFile string,
+) (*plugin.Client, plugin.ClientProtocol, error) {
+	newConfig := func() *plugin.ClientConfig {
+		return &plugin.ClientConfig{
+			HandshakeConfig:  tfplugin.Handshake,
+			Logger:           logging.NewProviderLogger(""),
+			AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
+			Managed:          true,
+			// We intentionally use [context.Background] so the lifetime of the
+			// provider can escape the lifetime of the parameterize call.
+			Cmd:              exec.CommandContext(context.Background(), execFile),
+			AutoMTLS:         true,
+			VersionedPlugins: tfplugin.VersionedPlugins,
+			SyncStdout:       logging.PluginOutputMonitor(fmt.Sprintf("%s:stdout", meta.Provider)),
+			SyncStderr:       logging.PluginOutputMonitor(fmt.Sprintf("%s:stderr", meta.Provider)),
+			GRPCDialOptions: []grpc.DialOption{
+				grpc.WithUnaryInterceptor(includePanic),
+			},
+		}
+	}
+
+	return retryOnTextFileBusy(ctx, meta.Provider.String(), func() (*plugin.Client, plugin.ClientProtocol, error) {
+		client := plugin.NewClient(newConfig())
+		rpcClient, err := client.Client()
+		if err != nil {
+			client.Kill()
+			return nil, nil, err
+		}
+		return client, rpcClient, nil
+	})
+}
+
+// pluginStarter constructs a fresh plugin.Client and attempts to start it,
+// returning the running client + protocol on success, or an error.
+type pluginStarter func() (*plugin.Client, plugin.ClientProtocol, error)
+
+// retryOnTextFileBusy invokes start in a bounded loop, retrying only when
+// start returns an ETXTBSY error. All other errors are returned immediately.
+//
+// Split out from startPluginClient so the retry policy can be exercised by
+// unit tests without spinning up real plugin processes.
+func retryOnTextFileBusy(
+	ctx context.Context, providerName string, start pluginStarter,
+) (*plugin.Client, plugin.ClientProtocol, error) {
+	var lastErr error
+	for attempt := 0; attempt < etxtbsyMaxAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(etxtbsyBackoff(attempt))
+		}
+		client, rpcClient, err := start()
+		if err == nil {
+			return client, rpcClient, nil
+		}
+		if !isTextFileBusy(err) {
+			return nil, nil, err
+		}
+		lastErr = err
+		slog.InfoContext(ctx, "provider exec hit ETXTBSY, retrying",
+			slog.String("provider", providerName),
+			slog.Int("attempt", attempt+1),
+			slog.String("error", err.Error()))
+	}
+	return nil, nil, fmt.Errorf("provider %s exec failed with ETXTBSY after %d attempts: %w",
+		providerName, etxtbsyMaxAttempts, lastErr)
+}
+
+// isTextFileBusy reports whether err originated from execve returning ETXTBSY.
+// We match on the string because go-plugin wraps the underlying *exec.Error
+// from cmd.Start, losing the typed syscall errno.
+func isTextFileBusy(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "text file busy")
 }
 
 func cutLast(s, sep string) (string, string, bool) {
@@ -222,25 +325,7 @@ func runProvider(ctx context.Context, meta *providercache.CachedProvider) (Provi
 		return nil, err
 	}
 
-	config := &plugin.ClientConfig{
-		HandshakeConfig:  tfplugin.Handshake,
-		Logger:           logging.NewProviderLogger(""),
-		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
-		Managed:          true,
-		// We intentionally use [context.Background] so the lifetime of the
-		// provider can escape the lifetime of the parameterize call.
-		Cmd:              exec.CommandContext(context.Background(), execFile),
-		AutoMTLS:         true,
-		VersionedPlugins: tfplugin.VersionedPlugins,
-		SyncStdout:       logging.PluginOutputMonitor(fmt.Sprintf("%s:stdout", meta.Provider)),
-		SyncStderr:       logging.PluginOutputMonitor(fmt.Sprintf("%s:stderr", meta.Provider)),
-		GRPCDialOptions: []grpc.DialOption{
-			grpc.WithUnaryInterceptor(includePanic),
-		},
-	}
-
-	client := plugin.NewClient(config)
-	rpcClient, err := client.Client()
+	client, rpcClient, err := startPluginClient(ctx, meta, execFile)
 	if err != nil {
 		return nil, err
 	}

--- a/dynamic/internal/shim/run/loader.go
+++ b/dynamic/internal/shim/run/loader.go
@@ -106,7 +106,7 @@ func defaultETXTBSYBackoff(attempt int) time.Duration {
 }
 
 // startPluginClient launches the cached provider via go-plugin, retrying on
-// ETXTBSY. See https://github.com/pulumi/pulumi-terraform-bridge/issues/3425.
+// ETXTBSY.
 func startPluginClient(
 	ctx context.Context, meta *providercache.CachedProvider, execFile string,
 ) (*plugin.Client, plugin.ClientProtocol, error) {

--- a/dynamic/internal/shim/run/loader_test.go
+++ b/dynamic/internal/shim/run/loader_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// See https://github.com/pulumi/pulumi-terraform-bridge/issues/3425.
-
 func TestRetryOnTextFileBusy_NonRetryableErrorReturnsImmediately(t *testing.T) {
 	t.Parallel()
 

--- a/dynamic/internal/shim/run/loader_test.go
+++ b/dynamic/internal/shim/run/loader_test.go
@@ -28,17 +28,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// noBackoff replaces etxtbsyBackoff with a zero-sleep variant so retry tests
-// run in microseconds rather than seconds. Returns a restorer.
-func noBackoff(t *testing.T) {
-	t.Helper()
-	prev := etxtbsyBackoff
-	etxtbsyBackoff = func(int) time.Duration { return 0 }
-	t.Cleanup(func() { etxtbsyBackoff = prev })
-}
+// noBackoff is a backoff function that always returns zero, so retry tests
+// don't sleep.
+func noBackoff(int) time.Duration { return 0 }
 
 func TestIsTextFileBusy(t *testing.T) {
-	t.Parallel() // only reads the function, never mutates package state
+	t.Parallel()
 	cases := []struct {
 		err  error
 		want bool
@@ -59,12 +54,9 @@ func TestIsTextFileBusy(t *testing.T) {
 //
 // Issue #3425: under concurrent `pulumi install`, the bridge sporadically hits
 // "text file busy" from execve. The fix retries up to etxtbsyMaxAttempts.
-//
-// These tests overwrite the package-level etxtbsyBackoff variable, so they
-// cannot run in parallel with each other.
 
-func TestRetryOnTextFileBusy_SucceedsFirstTry(t *testing.T) { //nolint:paralleltest
-	noBackoff(t)
+func TestRetryOnTextFileBusy_SucceedsFirstTry(t *testing.T) {
+	t.Parallel()
 
 	var calls int
 	start := func() (*plugin.Client, plugin.ClientProtocol, error) {
@@ -72,13 +64,13 @@ func TestRetryOnTextFileBusy_SucceedsFirstTry(t *testing.T) { //nolint:parallelt
 		return nil, nil, nil
 	}
 
-	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start)
+	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start, noBackoff)
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls)
 }
 
-func TestRetryOnTextFileBusy_RecoversAfterRetry(t *testing.T) { //nolint:paralleltest
-	noBackoff(t)
+func TestRetryOnTextFileBusy_RecoversAfterRetry(t *testing.T) {
+	t.Parallel()
 
 	var calls int
 	busy := errors.New("fork/exec /cache/terraform-provider-x: text file busy")
@@ -90,13 +82,13 @@ func TestRetryOnTextFileBusy_RecoversAfterRetry(t *testing.T) { //nolint:paralle
 		return nil, nil, nil
 	}
 
-	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start)
+	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start, noBackoff)
 	require.NoError(t, err)
 	assert.Equal(t, 3, calls, "should have retried twice before succeeding")
 }
 
-func TestRetryOnTextFileBusy_NonRetryableErrorReturnsImmediately(t *testing.T) { //nolint:paralleltest
-	noBackoff(t)
+func TestRetryOnTextFileBusy_NonRetryableErrorReturnsImmediately(t *testing.T) {
+	t.Parallel()
 
 	other := errors.New("permission denied")
 	var calls int
@@ -105,13 +97,13 @@ func TestRetryOnTextFileBusy_NonRetryableErrorReturnsImmediately(t *testing.T) {
 		return nil, nil, other
 	}
 
-	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start)
+	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start, noBackoff)
 	require.ErrorIs(t, err, other)
 	assert.Equal(t, 1, calls, "non-ETXTBSY errors must not retry")
 }
 
-func TestRetryOnTextFileBusy_GivesUpAfterMaxAttempts(t *testing.T) { //nolint:paralleltest
-	noBackoff(t)
+func TestRetryOnTextFileBusy_GivesUpAfterMaxAttempts(t *testing.T) {
+	t.Parallel()
 
 	busy := errors.New("text file busy")
 	var calls int
@@ -120,27 +112,25 @@ func TestRetryOnTextFileBusy_GivesUpAfterMaxAttempts(t *testing.T) { //nolint:pa
 		return nil, nil, busy
 	}
 
-	_, _, err := retryOnTextFileBusy(context.Background(), "registry.opentofu.org/hashicorp/random", start)
+	_, _, err := retryOnTextFileBusy(context.Background(), "registry.opentofu.org/hashicorp/random", start, noBackoff)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, busy)
 	assert.Contains(t, err.Error(), "registry.opentofu.org/hashicorp/random")
 	assert.Equal(t, etxtbsyMaxAttempts, calls)
 }
 
-func TestRetryOnTextFileBusy_BackoffIsCalledBeforeRetries(t *testing.T) { //nolint:paralleltest
-	var (
-		calls         int
-		backoffCalls  []int
-		busy          = errors.New("text file busy")
-		prevBackoff   = etxtbsyBackoff
-		recordBackoff = func(attempt int) time.Duration {
-			backoffCalls = append(backoffCalls, attempt)
-			return 0
-		}
-	)
-	etxtbsyBackoff = recordBackoff
-	t.Cleanup(func() { etxtbsyBackoff = prevBackoff })
+func TestRetryOnTextFileBusy_BackoffIsCalledBeforeRetries(t *testing.T) {
+	t.Parallel()
 
+	var (
+		calls        int
+		backoffCalls []int
+		busy         = errors.New("text file busy")
+	)
+	recordBackoff := func(attempt int) time.Duration {
+		backoffCalls = append(backoffCalls, attempt)
+		return 0
+	}
 	start := func() (*plugin.Client, plugin.ClientProtocol, error) {
 		calls++
 		if calls < 2 {
@@ -149,7 +139,7 @@ func TestRetryOnTextFileBusy_BackoffIsCalledBeforeRetries(t *testing.T) { //noli
 		return nil, nil, nil
 	}
 
-	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start)
+	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start, recordBackoff)
 	require.NoError(t, err)
 	// First attempt has no backoff; second attempt is preceded by one backoff call with attempt=1.
 	assert.Equal(t, []int{1}, backoffCalls)

--- a/dynamic/internal/shim/run/loader_test.go
+++ b/dynamic/internal/shim/run/loader_test.go
@@ -28,64 +28,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// noBackoff is a backoff function that always returns zero, so retry tests
-// don't sleep.
-func noBackoff(int) time.Duration { return 0 }
-
-func TestIsTextFileBusy(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		err  error
-		want bool
-	}{
-		{nil, false},
-		{errors.New("permission denied"), false},
-		{errors.New("fork/exec /foo/bar: text file busy"), true},
-		{errors.New("text file busy"), true},
-		{errors.New("Unrecognized remote plugin message"), false},
-	}
-	for _, c := range cases {
-		assert.Equal(t, c.want, isTextFileBusy(c.err), "for err=%v", c.err)
-	}
-}
-
 // retryOnTextFileBusy is the unit under test. It is exercised here without
 // spinning up real plugin processes by injecting a fake pluginStarter.
 //
 // Issue #3425: under concurrent `pulumi install`, the bridge sporadically hits
 // "text file busy" from execve. The fix retries up to etxtbsyMaxAttempts.
-
-func TestRetryOnTextFileBusy_SucceedsFirstTry(t *testing.T) {
-	t.Parallel()
-
-	var calls int
-	start := func() (*plugin.Client, plugin.ClientProtocol, error) {
-		calls++
-		return nil, nil, nil
-	}
-
-	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start, noBackoff)
-	require.NoError(t, err)
-	assert.Equal(t, 1, calls)
-}
-
-func TestRetryOnTextFileBusy_RecoversAfterRetry(t *testing.T) {
-	t.Parallel()
-
-	var calls int
-	busy := errors.New("fork/exec /cache/terraform-provider-x: text file busy")
-	start := func() (*plugin.Client, plugin.ClientProtocol, error) {
-		calls++
-		if calls < 3 {
-			return nil, nil, busy
-		}
-		return nil, nil, nil
-	}
-
-	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start, noBackoff)
-	require.NoError(t, err)
-	assert.Equal(t, 3, calls, "should have retried twice before succeeding")
-}
 
 func TestRetryOnTextFileBusy_NonRetryableErrorReturnsImmediately(t *testing.T) {
 	t.Parallel()
@@ -96,27 +43,11 @@ func TestRetryOnTextFileBusy_NonRetryableErrorReturnsImmediately(t *testing.T) {
 		calls++
 		return nil, nil, other
 	}
+	noBackoff := func(int) time.Duration { return 0 }
 
 	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start, noBackoff)
 	require.ErrorIs(t, err, other)
 	assert.Equal(t, 1, calls, "non-ETXTBSY errors must not retry")
-}
-
-func TestRetryOnTextFileBusy_GivesUpAfterMaxAttempts(t *testing.T) {
-	t.Parallel()
-
-	busy := errors.New("text file busy")
-	var calls int
-	start := func() (*plugin.Client, plugin.ClientProtocol, error) {
-		calls++
-		return nil, nil, busy
-	}
-
-	_, _, err := retryOnTextFileBusy(context.Background(), "registry.opentofu.org/hashicorp/random", start, noBackoff)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, busy)
-	assert.Contains(t, err.Error(), "registry.opentofu.org/hashicorp/random")
-	assert.Equal(t, etxtbsyMaxAttempts, calls)
 }
 
 func TestRetryOnTextFileBusy_BackoffIsCalledBeforeRetries(t *testing.T) {

--- a/dynamic/internal/shim/run/loader_test.go
+++ b/dynamic/internal/shim/run/loader_test.go
@@ -28,11 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// retryOnTextFileBusy is the unit under test. It is exercised here without
-// spinning up real plugin processes by injecting a fake pluginStarter.
-//
-// Issue #3425: under concurrent `pulumi install`, the bridge sporadically hits
-// "text file busy" from execve. The fix retries up to etxtbsyMaxAttempts.
+// See https://github.com/pulumi/pulumi-terraform-bridge/issues/3425.
 
 func TestRetryOnTextFileBusy_NonRetryableErrorReturnsImmediately(t *testing.T) {
 	t.Parallel()

--- a/dynamic/internal/shim/run/loader_test.go
+++ b/dynamic/internal/shim/run/loader_test.go
@@ -16,14 +16,144 @@ package run
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"testing"
+	"time"
 
+	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// noBackoff replaces etxtbsyBackoff with a zero-sleep variant so retry tests
+// run in microseconds rather than seconds. Returns a restorer.
+func noBackoff(t *testing.T) {
+	t.Helper()
+	prev := etxtbsyBackoff
+	etxtbsyBackoff = func(int) time.Duration { return 0 }
+	t.Cleanup(func() { etxtbsyBackoff = prev })
+}
+
+func TestIsTextFileBusy(t *testing.T) {
+	t.Parallel() // only reads the function, never mutates package state
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errors.New("permission denied"), false},
+		{errors.New("fork/exec /foo/bar: text file busy"), true},
+		{errors.New("text file busy"), true},
+		{errors.New("Unrecognized remote plugin message"), false},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, isTextFileBusy(c.err), "for err=%v", c.err)
+	}
+}
+
+// retryOnTextFileBusy is the unit under test. It is exercised here without
+// spinning up real plugin processes by injecting a fake pluginStarter.
+//
+// Issue #3425: under concurrent `pulumi install`, the bridge sporadically hits
+// "text file busy" from execve. The fix retries up to etxtbsyMaxAttempts.
+//
+// These tests overwrite the package-level etxtbsyBackoff variable, so they
+// cannot run in parallel with each other.
+
+func TestRetryOnTextFileBusy_SucceedsFirstTry(t *testing.T) { //nolint:paralleltest
+	noBackoff(t)
+
+	var calls int
+	start := func() (*plugin.Client, plugin.ClientProtocol, error) {
+		calls++
+		return nil, nil, nil
+	}
+
+	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start)
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryOnTextFileBusy_RecoversAfterRetry(t *testing.T) { //nolint:paralleltest
+	noBackoff(t)
+
+	var calls int
+	busy := errors.New("fork/exec /cache/terraform-provider-x: text file busy")
+	start := func() (*plugin.Client, plugin.ClientProtocol, error) {
+		calls++
+		if calls < 3 {
+			return nil, nil, busy
+		}
+		return nil, nil, nil
+	}
+
+	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start)
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls, "should have retried twice before succeeding")
+}
+
+func TestRetryOnTextFileBusy_NonRetryableErrorReturnsImmediately(t *testing.T) { //nolint:paralleltest
+	noBackoff(t)
+
+	other := errors.New("permission denied")
+	var calls int
+	start := func() (*plugin.Client, plugin.ClientProtocol, error) {
+		calls++
+		return nil, nil, other
+	}
+
+	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start)
+	require.ErrorIs(t, err, other)
+	assert.Equal(t, 1, calls, "non-ETXTBSY errors must not retry")
+}
+
+func TestRetryOnTextFileBusy_GivesUpAfterMaxAttempts(t *testing.T) { //nolint:paralleltest
+	noBackoff(t)
+
+	busy := errors.New("text file busy")
+	var calls int
+	start := func() (*plugin.Client, plugin.ClientProtocol, error) {
+		calls++
+		return nil, nil, busy
+	}
+
+	_, _, err := retryOnTextFileBusy(context.Background(), "registry.opentofu.org/hashicorp/random", start)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, busy)
+	assert.Contains(t, err.Error(), "registry.opentofu.org/hashicorp/random")
+	assert.Equal(t, etxtbsyMaxAttempts, calls)
+}
+
+func TestRetryOnTextFileBusy_BackoffIsCalledBeforeRetries(t *testing.T) { //nolint:paralleltest
+	var (
+		calls         int
+		backoffCalls  []int
+		busy          = errors.New("text file busy")
+		prevBackoff   = etxtbsyBackoff
+		recordBackoff = func(attempt int) time.Duration {
+			backoffCalls = append(backoffCalls, attempt)
+			return 0
+		}
+	)
+	etxtbsyBackoff = recordBackoff
+	t.Cleanup(func() { etxtbsyBackoff = prevBackoff })
+
+	start := func() (*plugin.Client, plugin.ClientProtocol, error) {
+		calls++
+		if calls < 2 {
+			return nil, nil, busy
+		}
+		return nil, nil, nil
+	}
+
+	_, _, err := retryOnTextFileBusy(context.Background(), "p/q", start)
+	require.NoError(t, err)
+	// First attempt has no backoff; second attempt is preceded by one backoff call with attempt=1.
+	assert.Equal(t, []int{1}, backoffCalls)
+}
 
 func Integration(t *testing.T) {
 	t.Helper()


### PR DESCRIPTION
Fixes #3425.

On Linux, execve returns ETXTBSY ("text file busy") if any process holds the target binary open for write at the moment of exec. The dynamic bridge writes each Terraform provider binary to its cache directory and immediately exec's it via go-plugin. Under concurrent `pulumi install` (parallel >= 2 packages), the bridge sporadically hits a brief open-for-write window that overlaps the exec, and the install fails with `fork/exec /root/.pulumi/dynamic_tf_plugins/.../terraform-provider-<name>: text file busy`. The race is sub-millisecond, and macOS does not enforce ETXTBSY, so it's Linux-only.

This wraps the go-plugin start in a bounded retry: 4 attempts with 50/100/200 ms backoff, 350 ms worst-case total wait.  exec.Cmd is single-use after Start() so plugin.ClientConfig is rebuilt on each attempt.

Two unit tests cover the retry policy: non-retryable errors return immediately without sleeping, and the backoff function is invoked between retries. Both inject a fake start closure and so run deterministically on any platform.