### PR TITLE
Implement Terraform list runtime semantics

### DIFF
--- a/docs/specs/terraform-list-identity-review.md
+++ b/docs/specs/terraform-list-identity-review.md
@@ -169,20 +169,23 @@ single-parameter identity on `bucket` imports from the bucket name, and an ARN
 identity imports from the ARN string. That is AWS implementation behavior, not
 a Terraform protocol guarantee.
 
-Therefore a generic bridge implementation can safely use identity schemas for
-classification and for identity-aware import. It should treat "extract the only
-required identity attribute and use it as the Pulumi list result ID" as a
-temporary compatibility shortcut, not the end-state model.
+Therefore a generic bridge implementation can safely use identity schemas to
+decode list identity data and construct deterministic Pulumi list result IDs.
+Those IDs are not guaranteed Terraform string import IDs because Terraform does
+not expose a generic provider-defined import-ID formatter.
 
-If such a shortcut is used before identity-aware `Read` exists, it should be
-guarded narrowly:
+Before identity-aware `Read` exists, the bridge should still return useful list
+results when it can decode identity data:
 
-1. exactly one required identity attribute;
-2. value is a primitive scalar that can be stringified predictably;
-3. no provider-specific compound import handler is needed;
-4. failures are clear and fail closed; and
-5. tests cover both a working single-parameter case and a compound-identity
-   case that must not guess.
+1. prefer a concrete top-level resource object `id` when Terraform returns one;
+2. prefer an identity attribute named `id` when present;
+3. for a single identity attribute, stringify that value;
+4. for multiple identity attributes, sort by attribute name, stringify each
+   value, and join the values with `,`;
+5. treat the result as a Pulumi-owned list ID format, not proof that Terraform
+   import accepts the same string; and
+6. fail only when identity data is missing, cannot be decoded, or cannot be
+   stringified deterministically.
 
 ## SDKv2 Resource State Versus SDKv2 List Identity
 
@@ -248,33 +251,34 @@ resource has no usable `id`, the bridge may synthesize a Pulumi ID through
 `ComputeID` or `MissingIDComputeID`. That keeps Pulumi state valid, but it does
 not automatically provide the string Terraform import expects.
 
-## What Would Be Safe For The First Version
+## First-Version ID Rules
 
-The first version should fail closed unless it can produce an ID that the
-current bridge `Read` path can actually import.
+The first version should fail open when it can infer a useful deterministic ID
+from Terraform result data. The bridge cannot know every provider's Terraform
+string import-ID format, but returning the listed identity values is better than
+hiding otherwise usable results.
 
 Recommended first-version rules:
 
 1. Request `IncludeResource: true` so Terraform returns resource objects when
    it can.
-2. Do not accept identity-only results by synthesizing `identity:<base64>` IDs.
-3. For identity-only results, support only the narrow single-required-scalar
-   shortcut:
-   - fetch the Terraform resource identity schema;
-   - require exactly one required identity attribute;
-   - require the decoded identity value to be a primitive scalar;
-   - stringify that value as `ListResponse.Result.Id`; and
-   - fail closed for compound identity, missing schemas, decode failures, or
-     non-scalar values.
-4. Treat this as a compatibility shortcut, not proof that Terraform identity
-   attributes are generally string import IDs.
-5. Treat `extractID` as Pulumi-ID extraction, not import-ID extraction.
+2. If the resource object has a concrete top-level `id`, stringify that value as
+   `ListResponse.Result.Id`.
+3. Do not call `extractID` or `ComputeID`; those produce Pulumi state IDs, not
+   necessarily Terraform import IDs.
+4. If no top-level `id` is available, decode Terraform identity data with the
+   resource identity schema.
+5. If the decoded identity has an attribute named `id`, stringify that value.
+6. If the decoded identity has one attribute, stringify that value.
+7. If the decoded identity has multiple attributes, sort attributes by name,
+   stringify each value, and join the values with `,`.
+8. Fail only when there is no resource-object `id` and the identity data is
+   missing, cannot be decoded, or cannot be stringified deterministically.
 
-For AWS Framework list resources, this covers the `10` resources whose identity
-attribute is named `id` plus `16` more resources with a single non-`id` identity
-parameter or ARN. The remaining `6` Framework list resources have compound
-identity and should fail closed until the bridge has identity-aware import/read
-support or explicit provider metadata for formatting import IDs.
+For AWS Framework list resources, this means the `10` resources whose identity
+attribute is named `id` use their `id` value, the `16` resources with a single
+non-`id` identity parameter or ARN use that value, and the remaining `6`
+compound-identity resources use the sorted comma-joined Pulumi ID format.
 
 ## Deferred Design: Identity-Aware Read
 
@@ -292,18 +296,6 @@ That would require:
 - deciding how this interacts with existing Pulumi import strings and provider
   `ComputeID` behavior.
 
-Until that design exists, identity-only list results outside the
-single-required-scalar shortcut should be reported as unsupported instead of
-appearing to work with an opaque ID that later fails on `Read`.
-
-## Open Review Questions
-
-1. Should Phase 1 require explicit metadata for importable list IDs, or is it
-   acceptable to use the current Pulumi `id` extraction for Framework resources
-   whose providers conventionally use the same value for import?
-2. If we keep using Pulumi `id` extraction temporarily, what test fixture proves
-   the failure mode where Pulumi ID and import ID differ?
-3. Should identity-aware import be part of the same feature stack, or should it
-   be a separate follow-up after resource-object list support lands?
-4. Do we need a provider-facing escape hatch such as `ListID`, or should this
-   reuse existing `ComputeID` with clearer documentation about importability?
+Until that design exists, identity-derived list result IDs remain best-effort
+Pulumi-owned strings. They should be deterministic and inspectable, but they
+are not guaranteed to be accepted unchanged by Terraform string import.

--- a/docs/specs/terraform-list-identity-review.md
+++ b/docs/specs/terraform-list-identity-review.md
@@ -1,0 +1,309 @@
+# Terraform List Identity Review
+
+## Purpose
+
+This note explains the identity issue behind Terraform list-resource support in
+the bridge. It is intentionally less normative than
+`terraform-list-runtime-semantics.md`: the goal is to give reviewers enough
+context to decide what the first implementation should support and what must be
+deferred.
+
+## The ID Terms Are Overloaded
+
+Pulumi and Terraform use similar words for different concepts:
+
+- Pulumi resources require a top-level `id` property in state.
+- Pulumi `Read` and import operations pass an import ID string to the provider.
+- Terraform Plugin Framework resources may expose structured resource identity.
+- Terraform list resources return identity data, and may optionally return a
+  full resource object.
+
+These values can coincide, but they are not the same contract. In particular,
+the bridge's existing Pulumi `id` extraction path is not proof that the result
+can be fed back into Terraform import.
+
+## Current Bridge Behavior
+
+The current PF `Read` import path calls Terraform with a string ID:
+
+- `pkg/pf/tfbridge/provider_read.go` builds
+  `tfprotov6.ImportResourceStateRequest{ID: string(id)}`.
+
+Terraform protocol also supports identity-based import:
+
+- `tfprotov6.ImportResourceStateRequest` has an `Identity` field that is
+  mutually exclusive with `ID`.
+
+The bridge does not currently use that identity field.
+
+The current list conversion has two paths:
+
+- If Terraform returns a resource object, the bridge decodes it as resource
+  state and calls `extractID`.
+- If Terraform returns only identity, the bridge synthesizes an opaque
+  `identity:<base64>` ID.
+
+Both paths are problematic for importability:
+
+- `extractID` extracts the Pulumi resource ID. It uses `ResourceInfo.ComputeID`
+  when configured, otherwise it reads the Pulumi top-level `id` property.
+- `ComputeID` exists to satisfy Pulumi's required `id` property. It is often
+  compatible with import IDs, but it does not have to be.
+- The opaque `identity:` value is not currently decoded by `Read`, so it cannot
+  be consumed by Terraform import.
+
+Therefore a list result ID is only correct when it is the same value that the
+bridge's `Read` import path expects. A Pulumi state ID or opaque Terraform
+identity blob is not enough by itself.
+
+## Terraform List Results
+
+Terraform Plugin Framework list resources receive `ListRequest.IncludeResource`.
+
+When `IncludeResource: false`, Framework converts each result to protocol data
+containing:
+
+- display name
+- resource identity
+- diagnostics
+
+It does not include the resource object.
+
+When `IncludeResource: true`, Framework includes both:
+
+- resource identity
+- resource object
+
+The identity is typed by the resource identity schema. It can contain an
+attribute named `id`, but there is no general rule that it must. It can also
+contain multiple fields such as `account_id`, `region`, names, ARNs, or
+provider-specific key fields.
+
+## AWS Provider Evidence
+
+The AWS provider has both SDK-backed and Framework-native list resources.
+Current counts from `~/work/pulumi-aws/upstream`:
+
+- `127` total list resources
+- `95` `@SDKListResource`
+- `32` `@FrameworkListResource`
+
+For the initial bridge version, the important subset is the `32`
+Framework-native list resources.
+
+AWS builds Framework resource identity schemas from
+`internal/provider/framework/identity/schema.go`, which iterates
+`identitySpec.Attributes`. Duplicate attributes such as
+`WithIdentityDuplicateAttrs(names.AttrID)` are importer helper behavior, not
+fields in the identity data itself.
+
+Among the `32` `FrameworkListResource` entries:
+
+- `10` have an actual `id` attribute in the identity data.
+- `22` do not.
+
+Framework list resources whose identity data contains `id`:
+
+- `aws_ec2_network_insights_access_scope`
+- `aws_ec2_secondary_network`
+- `aws_ec2_secondary_subnet`
+- `aws_vpc_security_group_egress_rule`
+- `aws_vpc_security_group_ingress_rule`
+- `aws_opensearchserverless_collection`
+- `aws_opensearchserverless_collection_group`
+- `aws_s3files_access_point`
+- `aws_s3files_file_system`
+- `aws_s3files_mount_target`
+
+Two Framework list resources mention `id` only as a duplicate attribute and
+should not be counted as identity data containing `id`:
+
+- `aws_batch_job_queue`
+- `aws_s3_directory_bucket`
+
+This means an `identity.id` heuristic would miss most Framework list resources
+even in the initial AWS-only evidence set.
+
+## Can The Bridge Detect A Single Identity Parameter?
+
+Partially.
+
+Terraform protocol exposes resource identity schemas separately from normal
+resource schemas:
+
+- `GetProviderSchemaResponse.ListResourceSchemas` contains list config schemas.
+- `GetResourceIdentitySchemasResponse.IdentitySchemas` contains resource
+  identity schemas keyed by Terraform resource name.
+- Each `ResourceIdentitySchema` has `IdentityAttributes`.
+- Each identity attribute has a name, type, and import requirement flags such
+  as `RequiredForImport` and `OptionalForImport`.
+
+That means the bridge can generically inspect the identity schema for a
+Terraform resource and classify simple cases:
+
+- If exactly one non-context identity attribute is required for import, the
+  bridge can decode the list result identity and extract that value.
+- For AWS this identifies cases such as `name`, `bucket`,
+  `service_principal`, `file_system_id`, `resource_arn`, or `id`.
+- If multiple resource-specific identity attributes are required, the bridge can
+  identify that the result is compound and avoid guessing.
+
+This is useful, but it does not prove string import compatibility.
+
+Terraform identity schema tells the bridge which structured identity attributes
+are sufficient for identity-based import. It does not say that one of those
+attributes is the provider-defined string accepted by
+`ImportResourceStateRequest.ID`. The string import format remains
+provider-defined.
+
+The distinction is:
+
+- A single required identity attribute proves the provider can identify the
+  resource from that structured identity field.
+- It does not generically prove that passing that field as the string import ID
+  is valid.
+
+For AWS, the shortcut often works because its generic single-parameter and ARN
+import helpers accept the same value as `request.ID`. For example, a
+single-parameter identity on `bucket` imports from the bucket name, and an ARN
+identity imports from the ARN string. That is AWS implementation behavior, not
+a Terraform protocol guarantee.
+
+Therefore a generic bridge implementation can safely use identity schemas for
+classification and for identity-aware import. It should treat "extract the only
+required identity attribute and use it as the Pulumi list result ID" as a
+temporary compatibility shortcut, not the end-state model.
+
+If such a shortcut is used before identity-aware `Read` exists, it should be
+guarded narrowly:
+
+1. exactly one required identity attribute;
+2. value is a primitive scalar that can be stringified predictably;
+3. no provider-specific compound import handler is needed;
+4. failures are clear and fail closed; and
+5. tests cover both a working single-parameter case and a compound-identity
+   case that must not guess.
+
+## SDKv2 Resource State Versus SDKv2 List Identity
+
+SDKv2 resources add another easy-to-miss distinction.
+
+Terraform SDKv2 resource state has a special resource ID channel:
+
+- `ResourceData.Id()` reads from `InstanceState.ID` and falls back to the
+  top-level `id` state attribute.
+- `ResourceData.SetId(...)` sets `InstanceState.ID` and writes the top-level
+  `id` state attribute.
+- `Resource.CoreConfigSchema()` adds an implicit top-level `id` attribute when
+  the provider schema does not define one.
+
+So for SDKv2 resource *objects*, the top-level `id` is effectively always
+present as part of the SDKv2 state model.
+
+That does not mean SDKv2-backed *list identity* always contains `id`.
+
+In terraform-provider-aws, SDK-backed list resources are wrapped by
+`ListResourceWithSDKv2Resource`. The wrapper builds a Terraform resource
+identity schema from the AWS `identitySpec.Attributes`, not from the SDKv2
+implicit state `id`. The AWS SDK identity interceptor only reads
+`ResourceData.Id()` when the identity attribute maps to resource attribute
+`id`; otherwise it reads whatever resource attribute the identity spec names.
+
+Current AWS evidence:
+
+- `95` `@SDKListResource` entries.
+- `22` have an actual `id` attribute in identity data.
+- `73` do not.
+
+Examples of SDK-backed list identities without `id`:
+
+- `aws_appflow_flow` uses `name`.
+- `aws_cloudwatch_metric_alarm` uses `alarm_name`.
+- `aws_dynamodb_table` uses `name`.
+- `aws_ecr_repository` uses `name`.
+- `aws_api_gateway_integration` uses compound identity fields.
+- `aws_route` uses compound identity fields.
+- `aws_volume_attachment` uses compound identity fields.
+
+The practical implication is:
+
+- With `IncludeResource: true`, SDK-backed list results can provide a resource
+  object with top-level SDKv2 state `id`.
+- With `IncludeResource: false`, SDK-backed list results still have the same
+  identity-schema problem as Framework-native list results.
+
+## Why Resource Objects Do Not Fully Solve It
+
+Requesting `IncludeResource: true` is still useful because it lets the bridge
+decode a resource-shaped result. That avoids some identity-only limitations and
+lets the bridge reuse existing resource decoding and state transforms.
+
+However, resource objects still only expose Pulumi state. The current bridge
+then calls `extractID`, which extracts the Pulumi resource ID. That value might
+be the import ID, but it is not guaranteed to be.
+
+This distinction matters most for Plugin Framework resources because Terraform
+Framework does not require a resource field named `id`. When the upstream
+resource has no usable `id`, the bridge may synthesize a Pulumi ID through
+`ComputeID` or `MissingIDComputeID`. That keeps Pulumi state valid, but it does
+not automatically provide the string Terraform import expects.
+
+## What Would Be Safe For The First Version
+
+The first version should fail closed unless it can produce an ID that the
+current bridge `Read` path can actually import.
+
+Recommended first-version rules:
+
+1. Request `IncludeResource: true` so Terraform returns resource objects when
+   it can.
+2. Do not accept identity-only results by synthesizing `identity:<base64>` IDs.
+3. For identity-only results, support only the narrow single-required-scalar
+   shortcut:
+   - fetch the Terraform resource identity schema;
+   - require exactly one required identity attribute;
+   - require the decoded identity value to be a primitive scalar;
+   - stringify that value as `ListResponse.Result.Id`; and
+   - fail closed for compound identity, missing schemas, decode failures, or
+     non-scalar values.
+4. Treat this as a compatibility shortcut, not proof that Terraform identity
+   attributes are generally string import IDs.
+5. Treat `extractID` as Pulumi-ID extraction, not import-ID extraction.
+
+For AWS Framework list resources, this covers the `10` resources whose identity
+attribute is named `id` plus `16` more resources with a single non-`id` identity
+parameter or ARN. The remaining `6` Framework list resources have compound
+identity and should fail closed until the bridge has identity-aware import/read
+support or explicit provider metadata for formatting import IDs.
+
+## Deferred Design: Identity-Aware Read
+
+The cleaner long-term design is to preserve Terraform identity data from
+identity-only list results and teach `Read` to consume it.
+
+That would require:
+
+- encoding the Terraform identity data into the Pulumi list result ID or another
+  stable continuation/import carrier;
+- decoding that value in the bridge `Read` path;
+- calling `ImportResourceStateRequest{Identity: ...}` instead of `ID: ...`;
+- preserving enough schema/version information to make the identity dynamic
+  value meaningful; and
+- deciding how this interacts with existing Pulumi import strings and provider
+  `ComputeID` behavior.
+
+Until that design exists, identity-only list results outside the
+single-required-scalar shortcut should be reported as unsupported instead of
+appearing to work with an opaque ID that later fails on `Read`.
+
+## Open Review Questions
+
+1. Should Phase 1 require explicit metadata for importable list IDs, or is it
+   acceptable to use the current Pulumi `id` extraction for Framework resources
+   whose providers conventionally use the same value for import?
+2. If we keep using Pulumi `id` extraction temporarily, what test fixture proves
+   the failure mode where Pulumi ID and import ID differ?
+3. Should identity-aware import be part of the same feature stack, or should it
+   be a separate follow-up after resource-object list support lands?
+4. Do we need a provider-facing escape hatch such as `ListID`, or should this
+   reuse existing `ComputeID` with clearer documentation about importability?

--- a/docs/specs/terraform-list-runtime-rollout.md
+++ b/docs/specs/terraform-list-runtime-rollout.md
@@ -1,0 +1,185 @@
+# Terraform List Runtime Rollout
+
+## Purpose
+
+This document tracks the branch-local and stacked-PR work needed to reach the
+end-state semantics in `docs/specs/terraform-list-runtime-semantics.md`.
+
+The semantics spec is intentionally durable and includes muxed-provider support.
+This rollout document is allowed to be temporary: it names the current branch
+state, the known implementation gaps, and the order in which the work should
+land.
+
+## Current Branch State
+
+Branch `chall/list-runtime-spec` is a specs-only planning branch. The
+implementation work should start by cherry-picking the existing commits from
+`fraser/list`, then repairing and staging that implementation against the
+semantics in this spec set.
+
+The `fraser/list` code has the right broad shape for a single PF provider:
+
+- schema-only list-resource discovery
+- `listInputs` generation
+- PF provider `ListWithContext`
+- provider-owned continuation sessions
+- panic recovery for the streaming `List` RPC
+
+Those commits do not yet satisfy the end-state semantics. The next work should
+be framed as implementation repair and staging, not greenfield design.
+
+## Phase 1: Single-Provider PF Support
+
+Goal: land coherent list support for a non-muxed PF provider, with unsupported
+cases failing closed.
+
+Recommended v1 identity scope:
+
+- Support identity-only results only when the Terraform resource identity schema
+  has exactly one required scalar identity attribute.
+- Decode the Terraform identity value and use that single attribute value as
+  `ListResponse.Result.Id`.
+- Treat this as a narrow string-ID compatibility shortcut, not the end-state
+  identity model.
+- Fail closed for compound identities, missing identity schemas, non-scalar
+  identity values, and identity-only results that cannot be decoded.
+
+AWS evidence for this v1 scope:
+
+- The initial non-muxed scope only reaches `@FrameworkListResource`
+  implementations.
+- AWS currently has `32` `@FrameworkListResource` entries.
+- `10` have an identity attribute named `id`.
+- `16` more have a single non-`id` identity parameter or ARN.
+- This v1 rule covers `26 / 32` AWS Framework list resources.
+- The remaining `6` AWS Framework list resources have compound identities and
+  should fail closed:
+  - `aws_dynamodb_global_secondary_index`
+  - `aws_msk_topic`
+  - `aws_wafv2_web_acl_rule`
+  - `aws_workmail_domain`
+  - `aws_workmail_group`
+  - `aws_workmail_user`
+
+Required fixes:
+
+- Make providers without `ProviderWithListResources` safe. `GatherListResources`
+  should return an empty collection or `newSchemaOnlyListResourceMap` should be
+  nil-safe.
+- Remove runtime fallback from Terraform list schemas to managed resource
+  schemas. Runtime `List` should only accept resources with real list-resource
+  schemas.
+- Replace `query.AsMap()` conversion with Pulumi property unmarshalling that
+  preserves unknowns.
+- Return exactly one `ListResponse.Computed` for query values containing
+  unknowns or computed values, without calling Terraform validation or list.
+- Call `ValidateListResourceConfig` before creating or exposing a continuation
+  session.
+- Bind continuation tokens to the original Pulumi token, normalized query, and
+  limit.
+- Support the narrow single-required-scalar identity-only result path described
+  above, and fail closed for other identity-only Terraform list results unless
+  the read/import path gains identity-aware support.
+- Return terminal errors after partial results instead of sending a successful
+  empty continuation.
+- Bound provider-side buffering for unbounded Pulumi `limit`.
+
+Minimum tests:
+
+- PF provider without list resources constructs successfully.
+- `listInputs` is emitted for list resources and omitted for non-list resources.
+- Empty list config schema emits empty non-nil `listInputs`.
+- Unknown query returns `Computed` and does not call Terraform.
+- Concrete query calls `ValidateListResourceConfig` before `ListResource`.
+- Validation diagnostics fail before session creation.
+- Continuation token rejects changed token, query, or limit.
+- Identity-only result with one required scalar identity attribute produces a
+  list result ID from that attribute value.
+- Identity-only result with compound identity fails closed.
+- Resource-object result extracts the importable ID used by `Read`.
+- Terminal error after partial results returns an error.
+- `limit` and `page_size` boundary cases cover overproduction and unbounded
+  limit behavior.
+
+Suggested verification:
+
+```bash
+mise exec -- go test -count=1 ./pkg/pf/internal/schemashim ./pkg/pf/tfgen ./pkg/pf/tfbridge -run 'Test.*List|Test.*ListResource'
+mise exec -- go test -count=1 ./pkg/pf/tests -run 'TestPFCheckConfig|TestCallWithTerraformConfig'
+mise exec -- go test -count=1 ./pkg/providerserver -run TestPanicRecoveringProviderServer_List
+git diff --check origin/main..HEAD
+```
+
+## Phase 2: Mux Schema And Dispatch Metadata
+
+Goal: represent list-resource ownership separately from managed-resource CRUD
+ownership.
+
+Required work:
+
+- Extend PF mux schema discovery to carry list-resource maps from each
+  subprovider.
+- Extend dispatch metadata with a list-resource owner map keyed by Pulumi
+  resource token.
+- Preserve `listInputs` from the list owner when the CRUD owner differs from
+  the list owner.
+- Keep SDKv2-only resources without Terraform list resources unlistable.
+
+Minimum tests:
+
+- Muxed resource whose CRUD owner and list owner differ emits `listInputs` from
+  the list owner on the final Pulumi resource spec.
+- Existing resource and function dispatch remains unchanged.
+- Missing list owner produces nil `listInputs`, not accidental listability.
+
+## Phase 3: Mux Runtime List Dispatch
+
+Goal: route Pulumi `List` to the subprovider that owns Terraform list support.
+
+Required work:
+
+- Add streaming `List` forwarding to `pkg/x/muxer`.
+- Route by list dispatch table, not by managed-resource dispatch.
+- Return `Unimplemented` when a resource token has no list owner.
+- Prove an SDKv2-managed resource exposed through a framework list wrapper can
+  be listed through the mux path.
+
+Minimum tests:
+
+- SDKv2-only resource without Terraform list support returns `Unimplemented`.
+- Muxed SDK-backed list resource dispatches to the PF/framework list owner.
+- CRUD dispatch and list dispatch may target different subproviders for the
+  same Pulumi resource token.
+
+## Deferred: Identity-Aware Import Or Read
+
+General and compound identity-only Terraform list results remain out of scope
+until the bridge has a read/import path that can decode Terraform identity data
+and call the correct identity-aware Terraform protocol. Until then, compound
+identity-only list results must fail closed with a clear error.
+
+See `docs/specs/terraform-list-identity-review.md` for the current identity
+findings, AWS provider evidence, and open review questions.
+
+## Current Known Mismatches
+
+These are known gaps between the current implementation commits and the
+end-state spec:
+
+- Non-list PF providers can panic during schema-only shim construction.
+- The muxer has no `List` method and no list-owner dispatch table.
+- Identity-only results currently synthesize `identity:` IDs.
+- Continuation tokens are looked up by opaque token only.
+- Query conversion uses `structpb.Struct.AsMap()` and loses Pulumi unknowns.
+- `ValidateListResourceConfig` is not called before session creation.
+- Terminal errors after partial results can be swallowed.
+- Runtime can fall back from `ListResourceSchemas` to managed
+  `ResourceSchemas`.
+- Unbounded `limit` can allow unbounded provider-side buffering.
+
+## Review Rule
+
+Before merging any phase, compare the final diff against
+`docs/specs/terraform-list-runtime-semantics.md`. If the phase intentionally
+does not implement part of the end-state, the code should fail closed for that
+case and this rollout document should say which follow-up phase owns it.

--- a/docs/specs/terraform-list-runtime-rollout.md
+++ b/docs/specs/terraform-list-runtime-rollout.md
@@ -12,10 +12,8 @@ land.
 
 ## Current Branch State
 
-Branch `chall/list-runtime-spec` is a specs-only planning branch. The
-implementation work should start by cherry-picking the existing commits from
-`fraser/list`, then repairing and staging that implementation against the
-semantics in this spec set.
+Branch `chall/list-runtime-spec` is staging the first implementation slice from
+the `fraser/list` work, repaired against the semantics in this spec set.
 
 The `fraser/list` code has the right broad shape for a single PF provider:
 
@@ -28,10 +26,15 @@ The `fraser/list` code has the right broad shape for a single PF provider:
 Those commits do not yet satisfy the end-state semantics. The next work should
 be framed as implementation repair and staging, not greenfield design.
 
-## Phase 1: Single-Provider PF Support
+## Phase 1: PF Runtime And PF-Owned Mux Support
 
-Goal: land coherent list support for a non-muxed PF provider, with unsupported
+Goal: land coherent list support for PF-owned resources, including the normal
+muxed-provider path used by providers such as `pulumi-aws`, with unsupported
 cases failing closed.
+
+Phase 1 is done only when a live `pulumi-aws` test can call Pulumi `List`
+through the provider's normal muxed server for a PF-owned resource. A direct
+non-muxed PF provider test is useful but is not sufficient.
 
 Recommended v1 ID scope:
 
@@ -50,8 +53,9 @@ Recommended v1 ID scope:
 
 AWS evidence for this v1 scope:
 
-- The initial non-muxed scope only reaches `@FrameworkListResource`
-  implementations.
+- The initial scope reaches PF-owned resources through the normal muxed
+  provider path. It does not yet reach SDKv2-owned resources whose list
+  implementation is exposed by the framework sidecar.
 - AWS currently has `32` `@FrameworkListResource` entries.
 - `10` have an identity attribute named `id`.
 - `16` more have a single non-`id` identity parameter or ARN.
@@ -87,6 +91,10 @@ Required fixes:
 - Return terminal errors after partial results instead of sending a successful
   empty continuation.
 - Bound provider-side buffering for unbounded Pulumi `limit`.
+- Add mux `List` forwarding for resources already owned by the PF subprovider
+  according to the existing resource dispatch table.
+- Keep SDKv2-owned resources whose list support lives on the PF side
+  unimplemented until list-specific mux ownership metadata exists.
 
 Minimum tests:
 
@@ -107,6 +115,13 @@ Minimum tests:
 - Terminal error after partial results returns an error.
 - `limit` and `page_size` boundary cases cover overproduction and unbounded
   limit behavior.
+- Muxed `List` routes a PF-owned resource token through the existing resource
+  dispatch table.
+- Live downstream proof: `pulumi-aws` can call `List` through
+  `testProviderServer()` for a PF-owned resource token.
+- SDKv2-owned list resources in muxed providers still fail closed rather than
+  accidentally routing by Terraform list ownership that Phase 1 does not yet
+  model.
 
 Suggested verification:
 
@@ -114,6 +129,7 @@ Suggested verification:
 mise exec -- go test -count=1 ./pkg/pf/internal/schemashim ./pkg/pf/tfgen ./pkg/pf/tfbridge -run 'Test.*List|Test.*ListResource'
 mise exec -- go test -count=1 ./pkg/pf/tests -run 'TestPFCheckConfig|TestCallWithTerraformConfig'
 mise exec -- go test -count=1 ./pkg/providerserver -run TestPanicRecoveringProviderServer_List
+mise exec -- go test -count=1 ./pkg/x/muxer/... -run 'TestList|TestSimpleDispatch'
 git diff --check origin/main..HEAD
 ```
 
@@ -141,11 +157,11 @@ Minimum tests:
 
 ## Phase 3: Mux Runtime List Dispatch
 
-Goal: route Pulumi `List` to the subprovider that owns Terraform list support.
+Goal: route Pulumi `List` to the subprovider that owns Terraform list support
+when that owner differs from the managed-resource CRUD owner.
 
 Required work:
 
-- Add streaming `List` forwarding to `pkg/x/muxer`.
 - Route by list dispatch table, not by managed-resource dispatch.
 - Return `Unimplemented` when a resource token has no list owner.
 - Prove an SDKv2-managed resource exposed through a framework list wrapper can
@@ -173,7 +189,8 @@ These are known gaps between the current implementation commits and the
 end-state spec:
 
 - Non-list PF providers can panic during schema-only shim construction.
-- The muxer has no `List` method and no list-owner dispatch table.
+- The muxer has no list-owner dispatch table for resources whose CRUD owner and
+  Terraform list owner differ.
 - Identity-only results currently synthesize `identity:` IDs.
 - Continuation tokens are looked up by opaque token only.
 - Query conversion uses `structpb.Struct.AsMap()` and loses Pulumi unknowns.

--- a/docs/specs/terraform-list-runtime-rollout.md
+++ b/docs/specs/terraform-list-runtime-rollout.md
@@ -33,16 +33,20 @@ be framed as implementation repair and staging, not greenfield design.
 Goal: land coherent list support for a non-muxed PF provider, with unsupported
 cases failing closed.
 
-Recommended v1 identity scope:
+Recommended v1 ID scope:
 
-- Support identity-only results only when the Terraform resource identity schema
-  has exactly one required scalar identity attribute.
-- Decode the Terraform identity value and use that single attribute value as
-  `ListResponse.Result.Id`.
-- Treat this as a narrow string-ID compatibility shortcut, not the end-state
-  identity model.
-- Fail closed for compound identities, missing identity schemas, non-scalar
-  identity values, and identity-only results that cannot be decoded.
+- Request resource-object list results with `IncludeResource: true`.
+- Use a concrete top-level resource object `id` when Terraform returns one.
+- If no resource object `id` is available, decode Terraform identity data with
+  the resource identity schema.
+- If the identity data has an attribute named `id`, stringify that value.
+- For one identity attribute, stringify that value as `ListResponse.Result.Id`.
+- For multiple identity attributes, sort attributes by name, stringify each
+  value, and join the values with `,`.
+- Treat identity-derived IDs as a deterministic Pulumi-owned list result format,
+  not as proof that Terraform import accepts the same string.
+- Fail only when no resource object `id` is available and identity data is
+  missing, cannot be decoded, or cannot be stringified deterministically.
 
 AWS evidence for this v1 scope:
 
@@ -51,9 +55,10 @@ AWS evidence for this v1 scope:
 - AWS currently has `32` `@FrameworkListResource` entries.
 - `10` have an identity attribute named `id`.
 - `16` more have a single non-`id` identity parameter or ARN.
-- This v1 rule covers `26 / 32` AWS Framework list resources.
+- This v1 rule uses a single identity value for `26 / 32` AWS Framework list
+  resources.
 - The remaining `6` AWS Framework list resources have compound identities and
-  should fail closed:
+  use the sorted comma-joined Pulumi ID format:
   - `aws_dynamodb_global_secondary_index`
   - `aws_msk_topic`
   - `aws_wafv2_web_acl_rule`
@@ -77,9 +82,8 @@ Required fixes:
   session.
 - Bind continuation tokens to the original Pulumi token, normalized query, and
   limit.
-- Support the narrow single-required-scalar identity-only result path described
-  above, and fail closed for other identity-only Terraform list results unless
-  the read/import path gains identity-aware support.
+- Support the identity-derived ID path described above, including the sorted
+  comma-joined format for compound identities.
 - Return terminal errors after partial results instead of sending a successful
   empty continuation.
 - Bound provider-side buffering for unbounded Pulumi `limit`.
@@ -93,10 +97,13 @@ Minimum tests:
 - Concrete query calls `ValidateListResourceConfig` before `ListResource`.
 - Validation diagnostics fail before session creation.
 - Continuation token rejects changed token, query, or limit.
-- Identity-only result with one required scalar identity attribute produces a
-  list result ID from that attribute value.
-- Identity-only result with compound identity fails closed.
-- Resource-object result extracts the importable ID used by `Read`.
+- Resource-object result with a top-level `id` uses that value without
+  `extractID` or `ComputeID`.
+- Identity-only result with an `id` attribute uses that value.
+- Identity-only result with one attribute produces a list result ID from that
+  attribute value.
+- Identity-only result with compound identity uses the sorted comma-joined
+  Pulumi ID format.
 - Terminal error after partial results returns an error.
 - `limit` and `page_size` boundary cases cover overproduction and unbounded
   limit behavior.
@@ -153,13 +160,12 @@ Minimum tests:
 
 ## Deferred: Identity-Aware Import Or Read
 
-General and compound identity-only Terraform list results remain out of scope
-until the bridge has a read/import path that can decode Terraform identity data
-and call the correct identity-aware Terraform protocol. Until then, compound
-identity-only list results must fail closed with a clear error.
+Identity-aware import/read remains out of scope. Phase 1 returns deterministic
+Pulumi-owned list IDs for decoded Terraform identities, but those strings are
+not guaranteed to match a provider's Terraform string import-ID format.
 
 See `docs/specs/terraform-list-identity-review.md` for the current identity
-findings, AWS provider evidence, and open review questions.
+findings and AWS provider evidence.
 
 ## Current Known Mismatches
 

--- a/docs/specs/terraform-list-runtime-semantics.md
+++ b/docs/specs/terraform-list-runtime-semantics.md
@@ -1,0 +1,423 @@
+# Terraform List Runtime Semantics
+
+## Summary
+
+This spec defines the end-state semantics for exposing Terraform protocol list
+resources through Pulumi `List`. The target scope is all Terraform protocol
+list resources exposed by an upstream provider server, not only resources whose
+CRUD implementation is Plugin Framework-native.
+
+Plain SDKv2 `helper/schema` providers do not expose a real list-resource
+implementation, but muxed providers can expose list resources for SDKv2-managed
+resources through a Plugin Framework sidecar. For example,
+terraform-provider-aws registers `@SDKListResource` implementations that wrap
+SDKv2 `ResourceData` and are served from its framework provider in a
+protocol-v5 mux. The bridge must support those list resources too.
+
+The implementation may land in stacked phases. Earlier phases may implement a
+strict subset of this spec, but they must fail closed for unsupported cases and
+must not ship behavior that contradicts the end-state contract.
+
+## Current Flow
+
+### Build-Time Schema Generation
+
+PF schema discovery gathers list resources separately from managed resources:
+
+- `pkg/pf/internal/pfutils/listresources.go` calls
+  `provider.ProviderWithListResources.ListResources` when available.
+- `pkg/pf/internal/schemashim/schemashim.go` stores those schemas in
+  `SchemaOnlyProvider`.
+- `pkg/pf/internal/schemashim/provider.go` exposes them through
+  `ListResourcesMap`.
+
+The shared tfgen path then asks the shim provider for a list-resource schema:
+
+- `pkg/tfgen/generate.go` finds a list schema for the Terraform resource name
+  and records list input variables.
+- `pkg/tfgen/generate_schema.go` emits `ResourceSpec.ListInputs` when
+  `listprops` is non-nil.
+- `pkg/tfgen/internal/paths/paths.go` adds a `listInputs` path kind so nested
+  types get stable schema paths.
+
+This means generated `listInputs` are derived from the Terraform list resource
+config schema, not from managed resource inputs. A resource with a list
+resource and an empty list config schema should still emit an empty, non-nil
+`listInputs` object. A provider without list resources should emit no
+`listInputs` and must not panic.
+
+Muxed providers complicate ownership. CRUD for a Pulumi resource may be served
+by one subprovider while the Terraform list resource for the same Terraform
+type is exposed by another subprovider. In terraform-provider-aws, many managed
+resources remain SDKv2 resources, but their list resources are exposed by the
+framework side of the upstream mux. The bridge schema path therefore needs
+list-resource ownership, not only managed-resource ownership.
+
+### Runtime Startup
+
+`pkg/pf/tfbridge/provider.go` constructs the runtime provider from the PF shim
+provider. The provider records:
+
+- managed resource schemas in `p.resources`
+- data source schemas in `p.datasources`
+- PF protocol v6 server in `p.tfServer`
+- list continuation state in `p.listSessions`
+
+The runtime resolves the Pulumi token to the Terraform list resource owner and
+uses the Terraform list resource config schema for query conversion and
+validation. It must not infer a list config schema from the managed resource
+schema merely because the Terraform type names match.
+
+The bridge muxer computes dispatch for managed resources and functions. List
+support needs additional list-specific dispatch state so `List` can route to
+the subprovider that exposes `ListResource`, even when CRUD routes to a
+different subprovider.
+
+### Per-RPC Runtime
+
+`pkg/pf/internal/plugin/provider_server.go` forwards Pulumi `List` to
+`ProviderWithContext.ListWithContext`.
+
+For a first page, the bridge should:
+
+1. Validate non-negative `limit` and `page_size`.
+2. Map the Pulumi token to the Terraform list resource owner and name.
+3. Find the Terraform list config schema.
+4. Convert `ListRequest.query` with Pulumi unknown preservation.
+5. Return `Computed` without calling Terraform when query contains unknowns.
+6. Validate concrete config with Terraform `ValidateListResourceConfig`.
+7. Start a provider-owned session and continuation token.
+8. Call Terraform `ListResource` with `IncludeResource: true`.
+9. Convert each Terraform list result into a Pulumi `ListResponse.Result`.
+10. Stream up to `page_size` results and then a continuation marker.
+
+For continuation pages, the bridge must validate that the continuation token is
+being used with the same Pulumi token, normalized query, and `limit` as the
+first request.
+
+### Panic Recovery
+
+`pkg/providerserver/panic_recovering_provider.go` wraps the streaming `List`
+RPC so provider panics are logged with method context before being re-thrown.
+
+## Desired Semantics
+
+1. Providers that do not expose Terraform list resources are valid. They expose
+   no listable resources and must not fail schema generation, provider
+   construction, or unrelated tests.
+
+2. `listInputs` is generated only for Pulumi resources whose Terraform resource
+   has a matching Terraform list resource. Empty list config schemas produce an
+   empty non-nil `listInputs` object. Missing list resources produce nil
+   `listInputs`.
+
+3. The Terraform list config schema is the source of truth for the Pulumi query
+   shape. Managed resource schemas are only used to decode resource-object list
+   results and extract Pulumi IDs.
+
+4. A first `List` call with unknown or computed values anywhere in `query`
+   returns exactly one `ListResponse.Computed` and does not call Terraform
+   `ValidateListResourceConfig` or `ListResource`.
+
+5. Concrete `query` values are converted through Pulumi property unmarshalling
+   with unknown preservation, then encoded to the Terraform list config type.
+   Direct `structpb.Struct.AsMap` conversion is not sufficient because it loses
+   Pulumi computed markers.
+
+6. Concrete first-page requests call Terraform `ValidateListResourceConfig`
+   before starting a list session. Validation diagnostics with errors fail the
+   Pulumi request before any session token is exposed.
+
+7. A continuation token is bound to the original Pulumi `token`, normalized
+   query, and `limit`. A continuation request that changes any of those fields
+   fails with `InvalidArgument`.
+
+8. `page_size` bounds the number of result messages in a single Pulumi `List`
+   RPC response. A provider may return fewer. It must not return more.
+
+9. `limit` bounds the total number of results across all continuation requests.
+   `limit < 1` means no Pulumi limit. The bridge may pass an implementation
+   limit to Terraform, but must enforce Pulumi `limit` itself and keep provider
+   buffering bounded.
+
+10. Results are streamed as zero or more `ListResponse.Result` messages
+    followed by exactly one `ListResponse.Continuation` marker. The final
+    marker has an empty token.
+
+11. Terminal Terraform diagnostics, conversion failures, or ID extraction
+    failures are not silently swallowed. If an error occurs after some results
+    have been produced, the current Pulumi RPC returns the error rather than a
+    successful empty continuation.
+
+12. Resource-object Terraform list results extract the same importable Pulumi
+    ID that `Read` expects. The bridge should request resource-object results
+    from Terraform by setting `IncludeResource: true`.
+
+13. Identity-only Terraform list results are an explicit compatibility boundary.
+    The bridge must not invent an opaque `identity:` ID unless the import/read
+    path is extended to decode it and call an identity-aware Terraform
+    read/import protocol. A phased implementation may support a narrowly
+    guarded string-ID shortcut for identity schemas with exactly one required
+    scalar identity attribute, but compound identity-only results should fail
+    closed until identity-aware import/read support exists.
+
+14. Muxed providers use list-specific dispatch. A Pulumi resource's `List` RPC
+    routes to the subprovider that owns the Terraform list resource and list
+    config schema, not necessarily the subprovider that owns CRUD for that
+    managed resource.
+
+15. Plain SDKv2 `helper/schema` resources remain unlistable unless an upstream
+    provider exposes a Terraform protocol list resource for them, for example
+    through a framework wrapper in a muxed provider.
+
+16. Session cleanup cancels the Terraform list context, marks waiting sessions
+    done, broadcasts waiters, and removes the token. Provider shutdown, session
+    expiration, RPC cancellation, and send failure must not leave waiters
+    blocked indefinitely.
+
+## Validation Boundary
+
+Build time:
+
+- Discover Terraform list resources from schema-only provider shims and muxed
+  provider subproviders.
+- Generate `listInputs` from Terraform list config schemas.
+- Ensure providers without list resources produce empty list-resource maps, not
+  nil dereferences.
+- Preserve list-resource ownership separately from CRUD ownership in muxed
+  providers.
+
+Runtime startup:
+
+- Initialize the list session store for list-capable providers.
+- Do not require list schemas to exist for providers that never receive a
+  `List` request.
+- Initialize muxed list dispatch from the same generated metadata source used
+  for resource/function dispatch, extended with list-resource ownership.
+
+Per `List` request:
+
+- Reject invalid request bounds.
+- Resolve Pulumi token to the Terraform list resource owner and list schema.
+- Detect unknown/computed query values before Terraform calls.
+- Validate concrete list config with Terraform.
+- Start and track a provider-owned session for first pages.
+- Validate continuation request identity for continuation pages.
+- Stream result and continuation messages in protocol order.
+- Propagate terminal errors.
+
+## Design
+
+### Schema Discovery
+
+Make `GatherListResources` return an empty `listResources` collection when the
+PF provider does not implement `ProviderWithListResources`. Alternatively make
+`newSchemaOnlyListResourceMap` nil-safe, but the preferred ownership is to keep
+the gatherer result non-nil whenever discovery succeeded.
+
+Keep list resource schemas separate from managed resource schemas. Do not infer
+listability from managed resource inputs, data sources, or Terraform naming
+alone.
+
+For muxed providers, carry list-resource maps through the mux shim in addition
+to managed resource and data source maps. If a list resource and managed
+resource share a Terraform type but come from different subproviders, schema
+generation must use the list-resource schema from the list owner and the
+managed resource schema from the CRUD owner.
+
+For protocol-v5 providers, list discovery is possible only when the upstream
+provider server exposes Terraform protocol list resources. SDKv2
+`helper/schema` by itself is not enough; terraform-provider-aws works because
+its framework provider exposes `@SDKListResource` wrappers through
+`ProviderWithListResources`.
+
+### Query Conversion
+
+Replace direct `query.AsMap()` conversion with the same Pulumi property
+unmarshal model used by other RPCs, with `KeepUnknowns` enabled. Walk the
+resulting property map for computed values before converting to Terraform.
+
+If any query value is computed, send:
+
+```text
+ListResponse{Computed: {}}
+```
+
+and return without creating a session.
+
+For concrete values, encode the query into the Terraform list config schema
+type. Conversion failures are `InvalidArgument`.
+
+### Terraform Validation
+
+Before storing the session token, call:
+
+```text
+ValidateListResourceConfig(TypeName, Config)
+```
+
+Process diagnostics using the existing PF diagnostic path. Error diagnostics
+fail the Pulumi request and no background list goroutine is started.
+
+When calling Terraform `ListResource`, request resource-object results with
+`IncludeResource: true`. Pulumi needs an importable result ID, and
+resource-object results can use the existing state decode and `extractID`
+paths. Providers may still return identity-only results; those remain governed
+by the identity-only policy below.
+
+### Session Identity
+
+Extend `listSession` with immutable request identity:
+
+- Pulumi token
+- normalized query fingerprint
+- limit
+
+The query fingerprint should be derived after Pulumi unmarshalling and before
+Terraform dynamic encoding so equivalent Pulumi query values compare stably.
+Continuation calls must compare against that identity before acquiring the
+session.
+
+### Result IDs
+
+Prefer Terraform resource-object results because they can be decoded through
+the existing bridge state decoder and `extractID`. This is important for
+SDK-backed list resources such as terraform-provider-aws
+`aws_lb_target_group_attachment`, where the list implementation formats the
+provider-specific import ID into SDKv2 `ResourceData` before returning a
+resource object.
+
+For identity-only results, do not invent an opaque `identity:` ID unless the
+read/import path is extended to decode it and call the correct Terraform
+identity-aware read/import protocol. Until that compatibility exists, the only
+acceptable string-ID shortcut is a guarded single-required-scalar identity
+schema path: decode the identity with the Terraform resource identity schema,
+extract the one required scalar identity attribute, and use that value as the
+Pulumi list result ID. Compound identities, missing identity schemas, non-scalar
+identity values, and decode failures should fail with an error that names the
+Terraform resource and explains that no importable ID was available.
+
+### Muxed Providers
+
+Add list-specific mux dispatch. The current muxer dispatches resource CRUD by
+Pulumi resource token and function calls by function token. `List` also uses a
+resource token, but its owner can differ from the CRUD owner. The dispatch
+table therefore needs to record which subprovider owns list support for each
+Pulumi resource token.
+
+Runtime `List` handling in the muxer should route to that list owner. If no
+subprovider exposes a list resource for the token, return `Unimplemented`. Do
+not route `List` to a CRUD owner merely because it serves the managed resource.
+
+Generated schema merging must preserve `listInputs` from the list owner. If
+the managed resource owner and list owner disagree about the resource token,
+the generated Pulumi schema should still attach the list inputs to the final
+Pulumi resource spec for that token.
+
+### Error And Cancellation Handling
+
+Treat list sessions as owned by the provider runtime, not by a single RPC.
+Closing a session should:
+
+- cancel the Terraform list context
+- set `done`
+- store a cancellation or expiration error when appropriate
+- broadcast the condition variable
+
+`ListWithContext` should return terminal errors even if the page already
+contains results. It must not convert a terminal error into an empty successful
+continuation.
+
+## Compatibility Risks
+
+- **Generated schema stability:** Adding `listInputs` changes provider package
+  schemas for providers with list resources. Providers without list resources
+  must have no generated schema drift.
+- **SDKv2/PF parity:** Plain SDKv2 `helper/schema` resources remain unlistable,
+  but SDKv2-managed resources exposed through framework list wrappers in muxed
+  providers are listable. The docs and errors need to preserve that
+  distinction.
+- **Muxed providers:** A muxed provider may combine SDKv2 CRUD resources and PF
+  list resources for the same Terraform type. `List` must dispatch by list
+  ownership, not CRUD ownership.
+- **Dynamic bridge:** Dynamic providers consuming generated schema need stable
+  `listInputs` output. Add dynamic/golden coverage before changing dynamic
+  schema behavior.
+- **Imports and refresh:** `ListResponse.Result.Id` must be accepted by the
+  existing `Read` path. Identity-only Terraform results are risky until proven
+  against PF import/read support.
+- **Secrets and unknowns:** Query conversion must preserve Pulumi unknowns and
+  should reject or unwrap secrets consistently with other request inputs.
+- **Diagnostics timing:** Terraform validation diagnostics should fail before a
+  session token exists; list-stream diagnostics should fail the active RPC and
+  clean up the session.
+- **Resource consumption:** Terraform list APIs are streaming, while Pulumi
+  exposes page-oriented continuations. Provider-owned sessions may prefetch.
+  The implementation must enforce Pulumi `page_size` and `limit` even when
+  Terraform produces more results, and it must avoid unbounded buffering when
+  Pulumi `limit` is unset.
+
+## Test Plan
+
+Build-time schema tests:
+
+- `pkg/pf/internal/schemashim`: provider without `ProviderWithListResources`
+  returns an empty list map and does not panic.
+- `pkg/pf/tfgen`: list resource with required and optional config fields emits
+  cased `listInputs`.
+- `pkg/pf/tfgen`: empty list config schema emits empty non-nil `listInputs`.
+- `pkg/pf/tfgen`: no list resource emits nil `listInputs`.
+- `pkg/pf/tfgen`: list resource without a matching managed resource is ignored
+  or fails with a documented error.
+- PF mux/tfgen: muxed resource whose CRUD owner and list owner differ emits
+  `listInputs` from the list owner on the final Pulumi resource spec.
+
+Runtime tests:
+
+- First-call `List` path covers token mapping, query conversion,
+  `ValidateListResourceConfig`, `ListResource`, result streaming, and final
+  continuation.
+- Unknown/computed query returns one `Computed` response and does not call
+  Terraform.
+- Invalid concrete query returns `InvalidArgument`.
+- Terraform validation diagnostics fail before session creation.
+- Changed continuation `token`, `query`, or `limit` is rejected.
+- `page_size` and `limit` combinations: `limit < page_size`, exact boundary,
+  multi-page limit exhaustion, and provider overproduction.
+- Resource-object result decodes through state conversion and extracts the same
+  importable ID used by `Read`.
+- Identity-only result either proves a readable/importable ID path or fails
+  closed.
+- Terraform `ListResource` is called with `IncludeResource: true`.
+- Terminal error after partial results returns an error, not a successful empty
+  continuation.
+- Session close/expiration wakes `preparePage` waiters.
+- Send failure cancels or removes the session consistently.
+
+Provider server tests:
+
+- `pkg/pf/internal/plugin`: gRPC `List` forwarding preserves stream behavior.
+- `pkg/providerserver`: panic recovery wraps streaming `List` and logs method
+  context.
+
+Integration and compatibility tests:
+
+- `pkg/pf/tests`: ordinary PF providers without list resources continue to
+  construct and pass existing tests.
+- `pkg/x/muxer` or PF mux tests: SDKv2-only resources without a Terraform list
+  resource return `Unimplemented`; muxed SDK-backed list resources dispatch to
+  the PF/framework list owner.
+- `pkg/x/muxer` or PF mux tests: CRUD dispatch and list dispatch may target
+  different subproviders for the same Pulumi resource token.
+- Dynamic bridge schema/golden tests if generated schema output for dynamic
+  providers changes.
+
+Suggested focused commands:
+
+```bash
+mise exec -- go test -count=1 ./pkg/pf/internal/schemashim ./pkg/pf/tfgen ./pkg/pf/tfbridge -run 'Test.*List|Test.*ListResource'
+mise exec -- go test -count=1 ./pkg/pf/tests -run TestCallWithTerraformConfig
+mise exec -- go test -count=1 ./pkg/providerserver -run TestPanicRecoveringProviderServer_List
+mise exec -- make test_assets
+mise exec -- make lint
+```

--- a/docs/specs/terraform-list-runtime-semantics.md
+++ b/docs/specs/terraform-list-runtime-semantics.md
@@ -149,17 +149,16 @@ RPC so provider panics are logged with method context before being re-thrown.
     have been produced, the current Pulumi RPC returns the error rather than a
     successful empty continuation.
 
-12. Resource-object Terraform list results extract the same importable Pulumi
-    ID that `Read` expects. The bridge should request resource-object results
-    from Terraform by setting `IncludeResource: true`.
+12. The bridge should request resource-object results from Terraform by setting
+    `IncludeResource: true`.
 
-13. Identity-only Terraform list results are an explicit compatibility boundary.
-    The bridge must not invent an opaque `identity:` ID unless the import/read
-    path is extended to decode it and call an identity-aware Terraform
-    read/import protocol. A phased implementation may support a narrowly
-    guarded string-ID shortcut for identity schemas with exactly one required
-    scalar identity attribute, but compound identity-only results should fail
-    closed until identity-aware import/read support exists.
+13. `ListResponse.Result.Id` is a best-effort string handle for the listed
+    resource. Terraform does not expose a generic string import-ID format for
+    structured identity data, so the bridge should fail open with deterministic
+    Pulumi-owned formatting instead of hiding otherwise useful list results.
+    Prefer an explicit `id` when Terraform returns one. If no `id` is
+    available, derive an ID from Terraform identity data as described in "Result
+    IDs" below.
 
 14. Muxed providers use list-specific dispatch. A Pulumi resource's `List` RPC
     routes to the subprovider that owns the Terraform list resource and list
@@ -261,9 +260,9 @@ fail the Pulumi request and no background list goroutine is started.
 
 When calling Terraform `ListResource`, request resource-object results with
 `IncludeResource: true`. Pulumi needs an importable result ID, and
-resource-object results can use the existing state decode and `extractID`
-paths. Providers may still return identity-only results; those remain governed
-by the identity-only policy below.
+resource-object results may contain a provider-populated top-level `id`.
+Providers may still return identity-only results; those remain governed by the
+identity policy below.
 
 ### Session Identity
 
@@ -280,22 +279,29 @@ session.
 
 ### Result IDs
 
-Prefer Terraform resource-object results because they can be decoded through
-the existing bridge state decoder and `extractID`. This is important for
-SDK-backed list resources such as terraform-provider-aws
-`aws_lb_target_group_attachment`, where the list implementation formats the
-provider-specific import ID into SDKv2 `ResourceData` before returning a
-resource object.
+Prefer Terraform resource-object results because they can contain the provider's
+normal state shape. If the decoded resource object has a concrete top-level
+`id` value, stringify that value as `ListResponse.Result.Id`. Do not call
+`extractID` or `ResourceInfo.ComputeID` for list results; those paths produce
+Pulumi state IDs and are not proof of Terraform string import-ID compatibility.
 
-For identity-only results, do not invent an opaque `identity:` ID unless the
-read/import path is extended to decode it and call the correct Terraform
-identity-aware read/import protocol. Until that compatibility exists, the only
-acceptable string-ID shortcut is a guarded single-required-scalar identity
-schema path: decode the identity with the Terraform resource identity schema,
-extract the one required scalar identity attribute, and use that value as the
-Pulumi list result ID. Compound identities, missing identity schemas, non-scalar
-identity values, and decode failures should fail with an error that names the
-Terraform resource and explains that no importable ID was available.
+If the resource object has no usable top-level `id`, or if Terraform returns an
+identity-only result, decode the Terraform identity data with the Terraform
+resource identity schema and derive a Pulumi-owned string ID:
+
+1. If there is an identity attribute named `id`, stringify that value.
+2. If there is exactly one identity attribute, stringify that attribute value.
+3. If there are multiple identity attributes, sort them by attribute name,
+   stringify each value, and join the values with `,`.
+
+This default format is intentionally a Pulumi list result format, not a claim
+that Terraform import accepts the same string. Terraform does not expose the
+provider's string import-ID formatter for structured identities. The derived ID
+keeps users unblocked and gives them the listed identity values; users may still
+need to adjust the string manually when importing through existing `Read`.
+Missing identity schemas, identity decode failures, and values that cannot be
+stringified deterministically should fail with an error that names the Terraform
+resource and explains that no list ID could be derived.
 
 ### Muxed Providers
 
@@ -343,9 +349,10 @@ continuation.
 - **Dynamic bridge:** Dynamic providers consuming generated schema need stable
   `listInputs` output. Add dynamic/golden coverage before changing dynamic
   schema behavior.
-- **Imports and refresh:** `ListResponse.Result.Id` must be accepted by the
-  existing `Read` path. Identity-only Terraform results are risky until proven
-  against PF import/read support.
+- **Imports and refresh:** `ListResponse.Result.Id` is best-effort for
+  structured identities because Terraform does not expose a generic string
+  import-ID format. IDs derived from identity data may need manual adjustment
+  before use with the existing `Read` import path.
 - **Secrets and unknowns:** Query conversion must preserve Pulumi unknowns and
   should reject or unwrap secrets consistently with other request inputs.
 - **Diagnostics timing:** Terraform validation diagnostics should fail before a
@@ -384,10 +391,11 @@ Runtime tests:
 - Changed continuation `token`, `query`, or `limit` is rejected.
 - `page_size` and `limit` combinations: `limit < page_size`, exact boundary,
   multi-page limit exhaustion, and provider overproduction.
-- Resource-object result decodes through state conversion and extracts the same
-  importable ID used by `Read`.
-- Identity-only result either proves a readable/importable ID path or fails
-  closed.
+- Resource-object result with a top-level `id` uses that value without calling
+  `extractID` or `ComputeID`.
+- Identity result with one attribute stringifies that value.
+- Identity result with multiple attributes uses the documented sorted
+  comma-joined Pulumi ID format.
 - Terraform `ListResource` is called with `IncludeResource: true`.
 - Terminal error after partial results returns an error, not a successful empty
   continuation.

--- a/pkg/pf/internal/pfutils/attr.go
+++ b/pkg/pf/internal/pfutils/attr.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	lschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	prschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -62,6 +63,10 @@ func FromDataSourceAttribute(x dschema.Attribute) Attr {
 }
 
 func FromResourceAttribute(x rschema.Attribute) Attr {
+	return FromAttrLike(x)
+}
+
+func FromListAttribute(x lschema.Attribute) Attr {
 	return FromAttrLike(x)
 }
 

--- a/pkg/pf/internal/pfutils/block.go
+++ b/pkg/pf/internal/pfutils/block.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	lschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	prschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -59,6 +60,10 @@ func FromDataSourceBlock(x dschema.Block) Block {
 }
 
 func FromResourceBlock(x rschema.Block) Block {
+	return FromBlockLike(x)
+}
+
+func FromListBlock(x lschema.Block) Block {
 	return FromBlockLike(x)
 }
 

--- a/pkg/pf/internal/pfutils/listresources.go
+++ b/pkg/pf/internal/pfutils/listresources.go
@@ -1,0 +1,77 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pfutils
+
+import (
+	"context"
+	"fmt"
+
+	tflist "github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+func GatherListResources[F func(Schema) shim.SchemaMap](
+	ctx context.Context, prov provider.Provider, f F,
+) (runtypes.ListResources, error) {
+	provMetadata := queryProviderMetadata(ctx, prov)
+	ls := make(collection[func() tflist.ListResource])
+
+	lprov, ok := prov.(provider.ProviderWithListResources)
+	if !ok {
+		return &listResources{collection: ls, convert: f}, nil
+	}
+
+	for _, makeListResource := range lprov.ListResources(ctx) {
+		listResource := makeListResource()
+
+		meta := resource.MetadataResponse{}
+		listResource.Metadata(ctx, resource.MetadataRequest{
+			ProviderTypeName: provMetadata.TypeName,
+		}, &meta)
+
+		schemaResponse := &tflist.ListResourceSchemaResponse{}
+		listResource.ListResourceConfigSchema(ctx, tflist.ListResourceSchemaRequest{}, schemaResponse)
+
+		listResourceSchema := schemaResponse.Schema
+		diag := schemaResponse.Diagnostics
+		if err := checkDiagsForErrors(diag); err != nil {
+			return nil, fmt.Errorf("Resource %s GetSchema() error: %w", meta.TypeName, err)
+		}
+
+		ls[runtypes.TypeOrRenamedEntityName(meta.TypeName)] = entry[func() tflist.ListResource]{
+			t:      makeListResource,
+			schema: FromListSchema(listResourceSchema),
+			tfName: runtypes.TypeName(meta.TypeName),
+		}
+	}
+
+	return &listResources{collection: ls, convert: f}, nil
+}
+
+type listResources struct {
+	collection[func() tflist.ListResource]
+	convert func(Schema) shim.SchemaMap
+}
+
+func (r listResources) Schema(t runtypes.TypeOrRenamedEntityName) runtypes.Schema {
+	entry := r.collection[t]
+	return runtypesSchemaAdapter{entry.schema, r.convert, entry.tfName}
+}
+
+func (listResources) IsListResources() {}

--- a/pkg/pf/internal/pfutils/schema.go
+++ b/pkg/pf/internal/pfutils/schema.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	lschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	prschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
@@ -64,6 +65,12 @@ func FromResourceSchema(x rschema.Schema) Schema {
 	attrs := convertMap(FromResourceAttribute, x.Attributes)
 	blocks := convertMap(FromResourceBlock, x.Blocks)
 	return newSchemaAdapter(x, x.Type(), x.DeprecationMessage, attrs, blocks, &x)
+}
+
+func FromListSchema(x lschema.Schema) Schema {
+	attrs := convertMap(FromListAttribute, x.Attributes)
+	blocks := convertMap(FromListBlock, x.Blocks)
+	return newSchemaAdapter(x, x.Type(), x.DeprecationMessage, attrs, blocks, nil)
 }
 
 type schemaAdapter struct {

--- a/pkg/pf/internal/plugin/provider_context.go
+++ b/pkg/pf/internal/plugin/provider_context.go
@@ -21,6 +21,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -82,6 +84,12 @@ type ProviderWithContext interface {
 	GetMappingsWithContext(ctx context.Context, key string) ([]string, error)
 
 	ParameterizeWithContext(context.Context, plugin.ParameterizeRequest) (plugin.ParameterizeResponse, error)
+
+	ListWithContext(
+		ctx context.Context,
+		req *pulumirpc.ListRequest,
+		stream grpc.ServerStreamingServer[pulumirpc.ListResponse],
+	) error
 }
 
 func NewProvider(p ProviderWithContext) plugin.Provider {

--- a/pkg/pf/internal/plugin/provider_server.go
+++ b/pkg/pf/internal/plugin/provider_server.go
@@ -168,12 +168,6 @@ func (p *providerServer) Handshake(ctx context.Context,
 	return nil, status.Error(codes.Unimplemented, "Handshake is not yet implemented")
 }
 
-func (p *providerServer) List(
-	req *pulumirpc.ListRequest, stream grpc.ServerStreamingServer[pulumirpc.ListResponse],
-) error {
-	return status.Error(codes.Unimplemented, "List is not yet implemented")
-}
-
 func (p *providerServer) GetSchema(ctx context.Context,
 	req *pulumirpc.GetSchemaRequest,
 ) (*pulumirpc.GetSchemaResponse, error) {
@@ -736,4 +730,11 @@ func (p *providerServer) GetMappings(ctx context.Context,
 		return nil, err
 	}
 	return &pulumirpc.GetMappingsResponse{Providers: providers}, nil
+}
+
+func (p *providerServer) List(
+	req *pulumirpc.ListRequest,
+	stream grpc.ServerStreamingServer[pulumirpc.ListResponse],
+) error {
+	return p.provider.ListWithContext(stream.Context(), req, stream)
 }

--- a/pkg/pf/internal/runtypes/types.go
+++ b/pkg/pf/internal/runtypes/types.go
@@ -66,3 +66,9 @@ type DataSources interface {
 	collection
 	IsDataSources()
 }
+
+// Represents all provider's list resources pre-indexed by TypeOrRenamedEntityName.
+type ListResources interface {
+	collection
+	IsListResources()
+}

--- a/pkg/pf/internal/schemashim/list_resource.go
+++ b/pkg/pf/internal/schemashim/list_resource.go
@@ -1,0 +1,75 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schemashim
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/valueshim"
+)
+
+func newSchemaOnlyListResource(tf runtypes.Schema) *schemaOnlyListResource {
+	return &schemaOnlyListResource{tf, internalinter.Internal{}}
+}
+
+type schemaOnlyListResource struct {
+	tf runtypes.Schema
+	internalinter.Internal
+}
+
+var _ shim.Resource = (*schemaOnlyListResource)(nil)
+
+func (r *schemaOnlyListResource) SchemaType() valueshim.Type {
+	protoSchema, err := r.tf.ResourceProtoSchema(context.Background())
+	contract.AssertNoErrorf(err, "ResourceProtoSchema failed")
+	return valueshim.FromTType(protoSchema.ValueType())
+}
+
+func (r *schemaOnlyListResource) Schema() shim.SchemaMap {
+	return r.tf.Shim()
+}
+
+func (r *schemaOnlyListResource) SchemaVersion() int {
+	panic("list resources do not have schema versions")
+}
+
+func (r *schemaOnlyListResource) DeprecationMessage() string {
+	return r.tf.DeprecationMessage()
+}
+
+func (*schemaOnlyListResource) Importer() shim.ImportFunc {
+	panic("schemaOnlyListResource does not implement runtime operation ImporterFunc")
+}
+
+func (*schemaOnlyListResource) Timeouts() *shim.ResourceTimeout {
+	panic("schemaOnlyListResource does not implement runtime operation Timeouts")
+}
+
+func (*schemaOnlyListResource) InstanceState(id string, object,
+	meta map[string]interface{},
+) (shim.InstanceState, error) {
+	panic("schemaOnlyListResource does not implement runtime operation InstanceState")
+}
+
+func (*schemaOnlyListResource) DecodeTimeouts(
+	config shim.ResourceConfig,
+) (*shim.ResourceTimeout, error) {
+	panic("schemaOnlyListResource does not implement runtime operation DecodeTimeouts")
+}

--- a/pkg/pf/internal/schemashim/list_resource_map.go
+++ b/pkg/pf/internal/schemashim/list_resource_map.go
@@ -1,0 +1,89 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schemashim
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/internalinter"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+// Resource map needs to support Set (mutability) for RenameResourceWithAlias.
+func newSchemaOnlyListResourceMap(resources runtypes.ListResources) schemaOnlyListResourceMap {
+	m := schemaOnlyListResourceMap{Map: make(map[string]*schemaOnlyListResource)}
+	for _, name := range resources.All() {
+		key := string(name)
+		v := resources.Schema(name)
+		m.Map[key] = newSchemaOnlyListResource(v)
+	}
+	return m
+}
+
+type schemaOnlyListResourceMap struct {
+	internalinter.Internal
+	Map map[string]*schemaOnlyListResource
+}
+
+var (
+	_ runtypes.ListResources = schemaOnlyListResourceMap{}
+)
+
+func (m schemaOnlyListResourceMap) Len() int {
+	return len(m.Map)
+}
+
+func (m schemaOnlyListResourceMap) Get(key string) shim.Resource {
+	return m.Map[key]
+}
+
+func (m schemaOnlyListResourceMap) GetOk(key string) (shim.Resource, bool) {
+	v, ok := m.Map[key]
+	return v, ok
+}
+
+func (m schemaOnlyListResourceMap) Range(each func(key string, value shim.Resource) bool) {
+	for k, v := range m.Map {
+		if !each(k, v) {
+			return
+		}
+	}
+}
+
+func (m schemaOnlyListResourceMap) Set(key string, value shim.Resource) {
+	v, ok := value.(*schemaOnlyListResource)
+	contract.Assertf(ok, "Set must be a %T, found a %T", v, value)
+	m.Map[key] = v
+}
+
+func (m schemaOnlyListResourceMap) All() []runtypes.TypeOrRenamedEntityName {
+	arr := make([]runtypes.TypeOrRenamedEntityName, 0, len(m.Map))
+	for k := range m.Map {
+		arr = append(arr, runtypes.TypeOrRenamedEntityName(k))
+	}
+	return arr
+}
+
+func (m schemaOnlyListResourceMap) Has(key runtypes.TypeOrRenamedEntityName) bool {
+	_, ok := m.Map[string(key)]
+	return ok
+}
+
+func (m schemaOnlyListResourceMap) Schema(key runtypes.TypeOrRenamedEntityName) runtypes.Schema {
+	return m.Map[string(key)].tf
+}
+
+func (m schemaOnlyListResourceMap) IsListResources() {}

--- a/pkg/pf/internal/schemashim/list_resource_map.go
+++ b/pkg/pf/internal/schemashim/list_resource_map.go
@@ -38,9 +38,7 @@ type schemaOnlyListResourceMap struct {
 	Map map[string]*schemaOnlyListResource
 }
 
-var (
-	_ runtypes.ListResources = schemaOnlyListResourceMap{}
-)
+var _ runtypes.ListResources = schemaOnlyListResourceMap{}
 
 func (m schemaOnlyListResourceMap) Len() int {
 	return len(m.Map)

--- a/pkg/pf/internal/schemashim/list_resource_map_test.go
+++ b/pkg/pf/internal/schemashim/list_resource_map_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schemashim
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShimSchemaOnlyProviderWithoutListResources(t *testing.T) {
+	t.Parallel()
+
+	shimmed := ShimSchemaOnlyProvider(context.Background(), providerWithoutListResources{}).(*SchemaOnlyProvider)
+
+	assert.Equal(t, 0, shimmed.ListResourcesMap().Len())
+}
+
+type providerWithoutListResources struct{}
+
+func (providerWithoutListResources) Metadata(
+	context.Context, provider.MetadataRequest, *provider.MetadataResponse,
+) {
+}
+
+func (providerWithoutListResources) Schema(
+	context.Context, provider.SchemaRequest, *provider.SchemaResponse,
+) {
+}
+
+func (providerWithoutListResources) Configure(
+	context.Context, provider.ConfigureRequest, *provider.ConfigureResponse,
+) {
+}
+
+func (providerWithoutListResources) DataSources(context.Context) []func() datasource.DataSource {
+	return nil
+}
+
+func (providerWithoutListResources) Resources(context.Context) []func() resource.Resource {
+	return nil
+}

--- a/pkg/pf/internal/schemashim/provider.go
+++ b/pkg/pf/internal/schemashim/provider.go
@@ -34,10 +34,11 @@ import (
 var _ = pf.ShimProvider(&SchemaOnlyProvider{})
 
 type SchemaOnlyProvider struct {
-	ctx           context.Context
-	tf            pfprovider.Provider
-	resourceMap   schemaOnlyResourceMap
-	dataSourceMap schemaOnlyDataSourceMap
+	ctx             context.Context
+	tf              pfprovider.Provider
+	resourceMap     schemaOnlyResourceMap
+	dataSourceMap   schemaOnlyDataSourceMap
+	listResourceMap schemaOnlyListResourceMap
 	internalinter.Internal
 }
 
@@ -92,6 +93,10 @@ func (p *SchemaOnlyProvider) ResourcesMap() shim.ResourceMap {
 
 func (p *SchemaOnlyProvider) DataSourcesMap() shim.ResourceMap {
 	return p.dataSourceMap
+}
+
+func (p *SchemaOnlyProvider) ListResourcesMap() shim.ResourceMap {
+	return p.listResourceMap
 }
 
 func (p *SchemaOnlyProvider) InternalValidate() error {

--- a/pkg/pf/internal/schemashim/schemashim.go
+++ b/pkg/pf/internal/schemashim/schemashim.go
@@ -32,12 +32,18 @@ func ShimSchemaOnlyProvider(ctx context.Context, provider pfprovider.Provider) s
 	if err != nil {
 		panic(err)
 	}
+	listResources, err := pfutils.GatherListResources(ctx, provider, NewSchemaMap)
+	if err != nil {
+		panic(err)
+	}
 	resourceMap := newSchemaOnlyResourceMap(resources)
 	dataSourceMap := newSchemaOnlyDataSourceMap(dataSources)
+	listResourceMap := newSchemaOnlyListResourceMap(listResources)
 	return &SchemaOnlyProvider{
-		ctx:           ctx,
-		tf:            provider,
-		resourceMap:   resourceMap,
-		dataSourceMap: dataSourceMap,
+		ctx:             ctx,
+		tf:              provider,
+		resourceMap:     resourceMap,
+		dataSourceMap:   dataSourceMap,
+		listResourceMap: listResourceMap,
 	}
 }

--- a/pkg/pf/tfbridge/provider.go
+++ b/pkg/pf/tfbridge/provider.go
@@ -95,6 +95,7 @@ type provider struct {
 
 	schemaOnlyProvider shim.Provider
 	providerOpts       []providerOption
+	listSessions       *listSessionStore
 }
 
 var _ pl.ProviderWithContext = &provider{}
@@ -195,6 +196,7 @@ func newProviderWithContext(ctx context.Context, info tfbridge.ProviderInfo,
 		schemaOnlyProvider: info.P,
 		parameterize:       meta.XParamaterize,
 		providerOpts:       opts,
+		listSessions:       newListSessionStore(listSessionTTL),
 	}
 
 	return configencoding.New(p), nil
@@ -229,6 +231,9 @@ func NewProviderServer(
 
 // Closer closes any underlying OS resources associated with this provider (like processes, RPC channels, etc).
 func (p *provider) Close() error {
+	if p.listSessions != nil {
+		p.listSessions.close()
+	}
 	return nil
 }
 
@@ -264,6 +269,9 @@ func (p *provider) ParameterizeWithContext(
 				return err
 			}
 			pp.Unwrap().logSink = p.logSink // Preserve the log sink from p
+			if p.listSessions != nil {
+				p.listSessions.close()
+			}
 
 			*p = *pp.Unwrap()
 
@@ -293,6 +301,10 @@ func (p *provider) GetPluginInfoWithContext(_ context.Context) (plugin.PluginInf
 // wait after SignalCancellation is called before (e.g.) hard-closing any gRPC connection.
 func (p *provider) SignalCancellationWithContext(_ context.Context) error {
 	// Some improvements are possible here to gracefully shut down.
+
+	if p.listSessions != nil {
+		p.listSessions.close()
+	}
 	return nil
 }
 

--- a/pkg/pf/tfbridge/provider_list.go
+++ b/pkg/pf/tfbridge/provider_list.go
@@ -23,7 +23,9 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -70,6 +72,7 @@ func (p *provider) ListWithContext(
 	if pageSize <= 0 {
 		pageSize = defaultListPageSize
 	}
+	pageSize = min(pageSize, int64(maxBufferedListResults))
 
 	var (
 		session *listSession
@@ -118,6 +121,7 @@ func (p *provider) ListWithContext(
 		if err := stream.Send(&pulumirpc.ListResponse{
 			Response: &pulumirpc.ListResponse_Result_{Result: item},
 		}); err != nil {
+			p.listSessions.remove(token)
 			return err
 		}
 	}
@@ -132,7 +136,11 @@ func (p *provider) ListWithContext(
 		return sendContinuation(stream, "")
 	}
 
-	return sendContinuation(stream, token)
+	if err := sendContinuation(stream, token); err != nil {
+		p.listSessions.remove(token)
+		return err
+	}
+	return nil
 }
 
 func (p *provider) startListSession(
@@ -266,11 +274,6 @@ func (p *provider) convertListResult(
 		if err != nil {
 			return nil, fmt.Errorf("terraform list result could not be decoded: %w", err)
 		}
-		stateMap, err = transformFromState(ctx, rh, stateMap)
-		if err != nil {
-			return nil, fmt.Errorf("terraform list result could not be transformed: %w", err)
-		}
-
 		if id, ok, err := propertyMapID(stateMap); ok || err != nil {
 			if err != nil {
 				return nil, fmt.Errorf("terraform list result id could not be stringified: %w", err)
@@ -511,19 +514,26 @@ func identityDataToID(
 		return "", fmt.Errorf("terraform resource %q identity data is empty", tfResourceName)
 	}
 
-	if len(values) > 1 {
-		return "", fmt.Errorf("terraform resource %q has compound identity data; list ID derivation is not supported", tfResourceName)
-	}
-
 	if idValue, ok := values["id"]; ok {
 		return stringifyTerraformValue(idValue)
 	}
 
+	names := make([]string, 0, len(values))
 	for name := range values {
-		return stringifyTerraformValue(values[name])
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	parts := make([]string, len(names))
+	for i, name := range names {
+		part, err := stringifyTerraformValue(values[name])
+		if err != nil {
+			return "", err
+		}
+		parts[i] = part
 	}
 
-	return "", fmt.Errorf("terraform resource %q identity data is empty", tfResourceName)
+	return strings.Join(parts, ","), nil
 }
 
 func stringifyTerraformValue(value tftypes.Value) (string, error) {

--- a/pkg/pf/tfbridge/provider_list.go
+++ b/pkg/pf/tfbridge/provider_list.go
@@ -75,12 +75,14 @@ func (p *provider) ListWithContext(
 	pageSize = min(pageSize, int64(maxBufferedListResults))
 
 	var (
-		session *listSession
-		token   string
-		err     error
+		session    *listSession
+		token      string
+		err        error
+		newSession bool
 	)
 
 	if req.GetContinuationToken() == "" {
+		newSession = true
 		session, token, err = p.startListSession(ctx, req)
 		if err != nil {
 			return err
@@ -112,8 +114,12 @@ func (p *provider) ListWithContext(
 	start, end, page, err := session.preparePage(ctx, pageSize)
 	if err != nil {
 		if errorsIsContext(err) {
+			if newSession {
+				p.listSessions.remove(token)
+			}
 			return status.Error(codes.Canceled, err.Error())
 		}
+		p.listSessions.remove(token)
 		return err
 	}
 
@@ -187,11 +193,6 @@ func (p *provider) startListSession(
 		return nil, "", err
 	}
 
-	identitySchema, err := p.resourceIdentitySchema(ctx, rh.terraformResourceName)
-	if err != nil {
-		return nil, "", err
-	}
-
 	token, err := newContinuationToken()
 	if err != nil {
 		return nil, "", err
@@ -206,7 +207,10 @@ func (p *provider) startListSession(
 		tfLimit = req.GetLimit()
 	}
 
-	go p.populateListSession(listCtx, session, tfListServer, rh, objectType, identitySchema, config, tfLimit)
+	go p.populateListSession(listCtx, session, tfListServer, rh, objectType, config, tfLimit,
+		func(ctx context.Context) (*tfprotov6.ResourceIdentitySchema, error) {
+			return p.resourceIdentitySchema(ctx, rh.terraformResourceName)
+		})
 
 	return session, token, nil
 }
@@ -217,9 +221,9 @@ func (p *provider) populateListSession(
 	tfListServer tfprotov6.ListResourceServer,
 	rh resourceHandle,
 	objectType tftypes.Object,
-	identitySchema *tfprotov6.ResourceIdentitySchema,
 	config *tfprotov6.DynamicValue,
 	tfLimit int64,
+	loadIdentitySchema func(context.Context) (*tfprotov6.ResourceIdentitySchema, error),
 ) {
 	listStream, err := tfListServer.ListResource(ctx, &tfprotov6.ListResourceRequest{
 		TypeName:        rh.terraformResourceName,
@@ -232,12 +236,25 @@ func (p *provider) populateListSession(
 		return
 	}
 
+	var (
+		identitySchema       *tfprotov6.ResourceIdentitySchema
+		identitySchemaLoaded bool
+		identitySchemaErr    error
+	)
+	getIdentitySchema := func(ctx context.Context) (*tfprotov6.ResourceIdentitySchema, error) {
+		if !identitySchemaLoaded {
+			identitySchema, identitySchemaErr = loadIdentitySchema(ctx)
+			identitySchemaLoaded = true
+		}
+		return identitySchema, identitySchemaErr
+	}
+
 	for result := range listStream.Results {
 		if err := p.processDiagnostics(ctx, result.Diagnostics); err != nil {
 			session.finish(err)
 			return
 		}
-		item, err := p.convertListResult(ctx, rh, objectType, identitySchema, result)
+		item, err := p.convertListResult(ctx, rh, objectType, getIdentitySchema, result)
 		if err != nil {
 			session.finish(err)
 			return
@@ -260,7 +277,7 @@ func (p *provider) convertListResult(
 	ctx context.Context,
 	rh resourceHandle,
 	objectType tftypes.Object,
-	identitySchema *tfprotov6.ResourceIdentitySchema,
+	getIdentitySchema func(context.Context) (*tfprotov6.ResourceIdentitySchema, error),
 	result tfprotov6.ListResourceResult,
 ) (*pulumirpc.ListResponse_Result, error) {
 	item := &pulumirpc.ListResponse_Result{Name: result.DisplayName}
@@ -274,18 +291,21 @@ func (p *provider) convertListResult(
 		if err != nil {
 			return nil, fmt.Errorf("terraform list result could not be decoded: %w", err)
 		}
-		if id, ok, err := propertyMapID(stateMap); ok || err != nil {
-			if err != nil {
-				return nil, fmt.Errorf("terraform list result id could not be stringified: %w", err)
-			}
+		if id, ok, err := propertyMapID(stateMap); ok && err == nil {
 			item.Id = id
 			return item, nil
+		} else if err != nil && result.Identity == nil {
+			return nil, fmt.Errorf("terraform list result id could not be stringified: %w", err)
 		}
 	}
 
 	if result.Identity == nil {
 		return nil, status.Errorf(codes.Internal,
 			"terraform list result for %q has no top-level id and no identity data", rh.terraformResourceName)
+	}
+	identitySchema, err := getIdentitySchema(ctx)
+	if err != nil {
+		return nil, err
 	}
 	id, err := identityDataToID(rh.terraformResourceName, identitySchema, result.Identity)
 	if err != nil {
@@ -645,9 +665,7 @@ func newComputedListSession() *listSession {
 
 func (s *listSession) lock() {
 	s.mu.Lock()
-	if !s.done {
-		s.lastAccess = time.Now()
-	}
+	s.lastAccess = time.Now()
 }
 
 func (s *listSession) unlock() {
@@ -664,6 +682,12 @@ func (s *listSession) append(ctx context.Context, item *pulumirpc.ListResponse_R
 			return false, ctx.Err()
 		}
 		s.cond.Wait()
+	}
+	if s.done {
+		return false, nil
+	}
+	if ctx.Err() != nil {
+		return false, ctx.Err()
 	}
 	if s.maxResults > 0 && s.produced >= s.maxResults {
 		return false, nil

--- a/pkg/pf/tfbridge/provider_list.go
+++ b/pkg/pf/tfbridge/provider_list.go
@@ -1,0 +1,941 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/convert"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/runtypes"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+const (
+	defaultListPageSize       int64 = 100
+	listSessionTTL                  = 5 * time.Minute
+	listSessionReaperInterval       = 30 * time.Second
+	// Use this only when Pulumi requested an unbounded list (limit=0).
+	terraformListFetchLimit = math.MaxInt64
+	maxBufferedListResults  = 4 * int(defaultListPageSize)
+)
+
+func (p *provider) ListWithContext(
+	ctx context.Context,
+	req *pulumirpc.ListRequest,
+	stream grpc.ServerStreamingServer[pulumirpc.ListResponse],
+) error {
+	ctx = p.initLogging(ctx, p.logSink, "")
+
+	if req.GetLimit() < 0 {
+		return status.Error(codes.InvalidArgument, "limit must be >= 0")
+	}
+	if req.GetPageSize() < 0 {
+		return status.Error(codes.InvalidArgument, "page_size must be >= 0")
+	}
+
+	pageSize := req.GetPageSize()
+	if pageSize <= 0 {
+		pageSize = defaultListPageSize
+	}
+
+	var (
+		session *listSession
+		token   string
+		err     error
+	)
+
+	if req.GetContinuationToken() == "" {
+		session, token, err = p.startListSession(ctx, req)
+		if err != nil {
+			return err
+		}
+		if session.computed {
+			return stream.Send(&pulumirpc.ListResponse{
+				Response: &pulumirpc.ListResponse_Computed_{
+					Computed: &pulumirpc.ListResponse_Computed{},
+				},
+			})
+		}
+	} else {
+		token = req.GetContinuationToken()
+		var ok bool
+		session, ok = p.listSessions.get(token)
+		if !ok {
+			return status.Error(codes.InvalidArgument, "invalid or expired continuation_token")
+		}
+		if err := session.validateContinuation(req); err != nil {
+			return err
+		}
+	}
+
+	if err := session.acquire(ctx); err != nil {
+		return err
+	}
+	defer session.release()
+
+	start, end, page, err := session.preparePage(ctx, pageSize)
+	if err != nil {
+		if errorsIsContext(err) {
+			return status.Error(codes.Canceled, err.Error())
+		}
+		return err
+	}
+
+	for _, item := range page {
+		if err := stream.Send(&pulumirpc.ListResponse{
+			Response: &pulumirpc.ListResponse_Result_{Result: item},
+		}); err != nil {
+			return err
+		}
+	}
+
+	hasMore, terminalErr := session.commit(start, end)
+	if terminalErr != nil {
+		p.listSessions.remove(token)
+		return terminalErr
+	}
+	if !hasMore {
+		p.listSessions.remove(token)
+		return sendContinuation(stream, "")
+	}
+
+	return sendContinuation(stream, token)
+}
+
+func (p *provider) startListSession(
+	ctx context.Context, req *pulumirpc.ListRequest,
+) (*listSession, string, error) {
+	if req.GetToken() == "" {
+		return nil, "", status.Error(codes.InvalidArgument, "token is required")
+	}
+
+	tfListServer, ok := p.tfServer.(tfprotov6.ListResourceServer)
+	if !ok {
+		return nil, "", status.Error(codes.Unimplemented, "terraform provider does not implement list resources")
+	}
+
+	tfNameOrRenamed, err := p.terraformResourceNameOrRenamedEntity(tokens.Type(req.GetToken()))
+	if err != nil {
+		return nil, "", status.Error(codes.InvalidArgument, err.Error())
+	}
+	rh, objectType, err := p.listResourceHandle(ctx, tfNameOrRenamed, tokens.Type(req.GetToken()))
+	if err != nil {
+		return nil, "", status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	configSchema, err := p.listConfigSchema(ctx, rh.terraformResourceName)
+	if err != nil {
+		return nil, "", err
+	}
+	query, config, err := p.listQueryToDynamicValue(req.GetQuery(), configSchema, rh.terraformResourceName)
+	if err != nil {
+		return nil, "", status.Errorf(codes.InvalidArgument, "invalid list query: %v", err)
+	}
+	if query.computed {
+		return newComputedListSession(), "", nil
+	}
+
+	validateResp, err := tfListServer.ValidateListResourceConfig(ctx, &tfprotov6.ValidateListResourceConfigRequest{
+		TypeName: rh.terraformResourceName,
+		Config:   config,
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("error calling ValidateListResourceConfig: %w", err)
+	}
+	if err := p.processDiagnostics(ctx, validateResp.Diagnostics); err != nil {
+		return nil, "", err
+	}
+
+	identitySchema, err := p.resourceIdentitySchema(ctx, rh.terraformResourceName)
+	if err != nil {
+		return nil, "", err
+	}
+
+	token, err := newContinuationToken()
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Session lifetime should span multiple RPC calls, so do not tie this context to the current call context.
+	listCtx, cancel := context.WithCancel(context.Background())
+	session := newListSession(cancel, req.GetLimit(), req.GetToken(), query.fingerprint)
+	p.listSessions.put(token, session)
+	var tfLimit int64 = terraformListFetchLimit
+	if req.GetLimit() > 0 {
+		tfLimit = req.GetLimit()
+	}
+
+	go p.populateListSession(listCtx, session, tfListServer, rh, objectType, identitySchema, config, tfLimit)
+
+	return session, token, nil
+}
+
+func (p *provider) populateListSession(
+	ctx context.Context,
+	session *listSession,
+	tfListServer tfprotov6.ListResourceServer,
+	rh resourceHandle,
+	objectType tftypes.Object,
+	identitySchema *tfprotov6.ResourceIdentitySchema,
+	config *tfprotov6.DynamicValue,
+	tfLimit int64,
+) {
+	listStream, err := tfListServer.ListResource(ctx, &tfprotov6.ListResourceRequest{
+		TypeName:        rh.terraformResourceName,
+		Config:          config,
+		IncludeResource: true,
+		Limit:           tfLimit,
+	})
+	if err != nil {
+		session.finish(err)
+		return
+	}
+
+	for result := range listStream.Results {
+		if err := p.processDiagnostics(ctx, result.Diagnostics); err != nil {
+			session.finish(err)
+			return
+		}
+		item, err := p.convertListResult(ctx, rh, objectType, identitySchema, result)
+		if err != nil {
+			session.finish(err)
+			return
+		}
+		ok, err := session.append(ctx, item)
+		if err != nil {
+			session.finish(err)
+			return
+		}
+		if !ok {
+			session.finish(nil)
+			return
+		}
+	}
+
+	session.finish(nil)
+}
+
+func (p *provider) convertListResult(
+	ctx context.Context,
+	rh resourceHandle,
+	objectType tftypes.Object,
+	identitySchema *tfprotov6.ResourceIdentitySchema,
+	result tfprotov6.ListResourceResult,
+) (*pulumirpc.ListResponse_Result, error) {
+	item := &pulumirpc.ListResponse_Result{Name: result.DisplayName}
+
+	if result.Resource != nil {
+		stateValue, err := result.Resource.Unmarshal(objectType)
+		if err != nil {
+			return nil, fmt.Errorf("terraform list result could not be unmarshaled: %w", err)
+		}
+		stateMap, err := convert.DecodePropertyMap(ctx, rh.decoder, stateValue)
+		if err != nil {
+			return nil, fmt.Errorf("terraform list result could not be decoded: %w", err)
+		}
+		stateMap, err = transformFromState(ctx, rh, stateMap)
+		if err != nil {
+			return nil, fmt.Errorf("terraform list result could not be transformed: %w", err)
+		}
+
+		if id, ok, err := propertyMapID(stateMap); ok || err != nil {
+			if err != nil {
+				return nil, fmt.Errorf("terraform list result id could not be stringified: %w", err)
+			}
+			item.Id = id
+			return item, nil
+		}
+	}
+
+	if result.Identity == nil {
+		return nil, status.Errorf(codes.Internal,
+			"terraform list result for %q has no top-level id and no identity data", rh.terraformResourceName)
+	}
+	id, err := identityDataToID(rh.terraformResourceName, identitySchema, result.Identity)
+	if err != nil {
+		return nil, fmt.Errorf("terraform list result identity could not be converted to id: %w", err)
+	}
+	item.Id = id
+	return item, nil
+}
+
+func (p *provider) listResourceHandle(
+	ctx context.Context,
+	tfNameOrRenamedEntity string,
+	token tokens.Type,
+) (resourceHandle, tftypes.Object, error) {
+	rt := runtypes.TypeOrRenamedEntityName(tfNameOrRenamedEntity)
+	if !p.resources.Has(rt) {
+		return resourceHandle{}, tftypes.Object{},
+			fmt.Errorf("[pf/tfbridge] unknown resource type: %q", tfNameOrRenamedEntity)
+	}
+
+	schema := p.resources.Schema(rt)
+	objectType, ok := schema.Type(ctx).(tftypes.Object)
+	if !ok {
+		return resourceHandle{}, tftypes.Object{},
+			fmt.Errorf("[pf/tfbridge] resource %q schema is not an object", tfNameOrRenamedEntity)
+	}
+
+	decoder, err := p.encoding.NewResourceDecoder(tfNameOrRenamedEntity, objectType)
+	if err != nil {
+		return resourceHandle{}, tftypes.Object{}, fmt.Errorf("failed to prepare resource decoder: %w", err)
+	}
+
+	rh := resourceHandle{
+		token:                 token,
+		terraformResourceName: string(schema.TFName()),
+		schema:                schema,
+		decoder:               decoder,
+	}
+	if info, ok := p.info.Resources[tfNameOrRenamedEntity]; ok {
+		rh.pulumiResourceInfo = info
+	}
+
+	return rh, objectType, nil
+}
+
+func (p *provider) listConfigSchema(ctx context.Context, tfResourceName string) (*tfprotov6.Schema, error) {
+	schemaResp, err := p.tfServer.GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
+	if err != nil {
+		return nil, err
+	}
+	if err := p.processDiagnostics(ctx, schemaResp.Diagnostics); err != nil {
+		return nil, err
+	}
+
+	if schemaResp.ListResourceSchemas != nil {
+		if schema, ok := schemaResp.ListResourceSchemas[tfResourceName]; ok {
+			return schema, nil
+		}
+	}
+
+	return nil, status.Errorf(codes.Unimplemented,
+		"terraform provider does not expose a list schema for %q", tfResourceName)
+}
+
+type listQuery struct {
+	fingerprint string
+	computed    bool
+}
+
+func (p *provider) listQueryToDynamicValue(
+	query *structpb.Struct, schema *tfprotov6.Schema, tfResourceName string,
+) (listQuery, *tfprotov6.DynamicValue, error) {
+	queryMap, err := unmarshalListQuery(query)
+	if err != nil {
+		return listQuery{}, nil, err
+	}
+	fingerprint, err := listQueryFingerprint(queryMap)
+	if err != nil {
+		return listQuery{}, nil, err
+	}
+	if queryMap.ContainsUnknowns() {
+		return listQuery{fingerprint: fingerprint, computed: true}, nil, nil
+	}
+
+	valueType := schema.ValueType()
+	objectType, ok := valueType.(tftypes.Object)
+	if !ok {
+		return listQuery{}, nil, fmt.Errorf("list config schema for %q is not an object", tfResourceName)
+	}
+
+	listResourcesProvider, ok := p.schemaOnlyProvider.(interface{ ListResourcesMap() shim.ResourceMap })
+	if !ok {
+		return listQuery{}, nil, status.Errorf(codes.Unimplemented,
+			"terraform provider does not expose list schemas")
+	}
+	listResource, ok := listResourcesProvider.ListResourcesMap().GetOk(tfResourceName)
+	if !ok {
+		return listQuery{}, nil, status.Errorf(codes.Unimplemented,
+			"terraform provider does not expose a list schema for %q", tfResourceName)
+	}
+	encoder, err := convert.NewObjectEncoder(convert.ObjectSchema{
+		SchemaMap: listResource.Schema(),
+		Object:    &objectType,
+	})
+	if err != nil {
+		return listQuery{}, nil, err
+	}
+	dv, err := convert.EncodePropertyMapToDynamic(encoder, objectType, queryMap)
+	if err != nil {
+		return listQuery{}, nil, err
+	}
+	return listQuery{fingerprint: fingerprint}, dv, nil
+}
+
+func unmarshalListQuery(query *structpb.Struct) (resource.PropertyMap, error) {
+	if query != nil {
+		return plugin.UnmarshalProperties(query, plugin.MarshalOptions{
+			Label:        "list query",
+			KeepUnknowns: true,
+			SkipNulls:    true,
+			RejectAssets: true,
+		})
+	}
+	return resource.PropertyMap{}, nil
+}
+
+func listQueryFingerprint(query resource.PropertyMap) (string, error) {
+	value, err := json.Marshal(canonicalPropertyMap(query))
+	if err != nil {
+		return "", err
+	}
+	return string(value), nil
+}
+
+func canonicalPropertyMap(pm resource.PropertyMap) map[string]any {
+	result := map[string]any{}
+	for _, key := range pm.StableKeys() {
+		result[string(key)] = canonicalPropertyValue(pm[key])
+	}
+	return result
+}
+
+func canonicalPropertyValue(v resource.PropertyValue) any {
+	switch {
+	case v.IsComputed() || (v.IsOutput() && !v.OutputValue().Known):
+		return map[string]any{"unknown": true}
+	case v.IsOutput():
+		return canonicalPropertyValue(v.OutputValue().Element)
+	case v.IsSecret():
+		return canonicalPropertyValue(v.SecretValue().Element)
+	case v.IsArray():
+		values := make([]any, len(v.ArrayValue()))
+		for i, elem := range v.ArrayValue() {
+			values[i] = canonicalPropertyValue(elem)
+		}
+		return values
+	case v.IsObject():
+		return canonicalPropertyMap(v.ObjectValue())
+	default:
+		return v.Mappable()
+	}
+}
+
+func (p *provider) resourceIdentitySchema(
+	ctx context.Context, tfResourceName string,
+) (*tfprotov6.ResourceIdentitySchema, error) {
+	resp, err := p.tfServer.GetResourceIdentitySchemas(ctx, &tfprotov6.GetResourceIdentitySchemasRequest{})
+	if err != nil {
+		return nil, err
+	}
+	if err := p.processDiagnostics(ctx, resp.Diagnostics); err != nil {
+		return nil, err
+	}
+	if resp.IdentitySchemas == nil {
+		return nil, nil
+	}
+	return resp.IdentitySchemas[tfResourceName], nil
+}
+
+func propertyMapID(stateMap resource.PropertyMap) (string, bool, error) {
+	idValue, ok := stateMap[resource.PropertyKey("id")]
+	if !ok || idValue.IsNull() {
+		return "", false, nil
+	}
+	id, err := stringifyPropertyValue(idValue)
+	return id, true, err
+}
+
+func stringifyPropertyValue(v resource.PropertyValue) (string, error) {
+	switch {
+	case v.IsComputed() || (v.IsOutput() && !v.OutputValue().Known):
+		return "", fmt.Errorf("value is unknown")
+	case v.IsOutput():
+		return stringifyPropertyValue(v.OutputValue().Element)
+	case v.IsSecret():
+		return stringifyPropertyValue(v.SecretValue().Element)
+	case v.IsString():
+		return v.StringValue(), nil
+	case v.IsBool():
+		return strconv.FormatBool(v.BoolValue()), nil
+	case v.IsNumber():
+		return strconv.FormatFloat(v.NumberValue(), 'f', -1, 64), nil
+	default:
+		return "", fmt.Errorf("unsupported id value type %s", v.TypeString())
+	}
+}
+
+func identityDataToID(
+	tfResourceName string, schema *tfprotov6.ResourceIdentitySchema, data *tfprotov6.ResourceIdentityData,
+) (string, error) {
+	if data == nil || data.IdentityData == nil {
+		return "", fmt.Errorf("identity data is empty")
+	}
+	if schema == nil {
+		return "", fmt.Errorf("terraform resource %q does not expose an identity schema", tfResourceName)
+	}
+	value, err := data.IdentityData.Unmarshal(schema.ValueType())
+	if err != nil {
+		return "", err
+	}
+	values := map[string]tftypes.Value{}
+	if err := value.As(&values); err != nil {
+		return "", err
+	}
+	if len(values) == 0 {
+		return "", fmt.Errorf("terraform resource %q identity data is empty", tfResourceName)
+	}
+
+	if len(values) > 1 {
+		return "", fmt.Errorf("terraform resource %q has compound identity data; list ID derivation is not supported", tfResourceName)
+	}
+
+	if idValue, ok := values["id"]; ok {
+		return stringifyTerraformValue(idValue)
+	}
+
+	for name := range values {
+		return stringifyTerraformValue(values[name])
+	}
+
+	return "", fmt.Errorf("terraform resource %q identity data is empty", tfResourceName)
+}
+
+func stringifyTerraformValue(value tftypes.Value) (string, error) {
+	if !value.IsFullyKnown() {
+		return "", fmt.Errorf("value is unknown")
+	}
+	if value.IsNull() {
+		return "", fmt.Errorf("value is null")
+	}
+	switch {
+	case value.Type().Is(tftypes.String):
+		var s string
+		if err := value.As(&s); err != nil {
+			return "", err
+		}
+		return s, nil
+	case value.Type().Is(tftypes.Bool):
+		var b bool
+		if err := value.As(&b); err != nil {
+			return "", err
+		}
+		return strconv.FormatBool(b), nil
+	case value.Type().Is(tftypes.Number):
+		var n big.Float
+		if err := value.As(&n); err != nil {
+			return "", err
+		}
+		return n.Text('f', -1), nil
+	default:
+		elements, err := stringifyTerraformList(value)
+		if err != nil {
+			return "", fmt.Errorf("unsupported identity value type %s", value.Type())
+		}
+		bytes, err := json.Marshal(elements)
+		if err != nil {
+			return "", err
+		}
+		return string(bytes), nil
+	}
+}
+
+func stringifyTerraformList(value tftypes.Value) ([]string, error) {
+	var values []tftypes.Value
+	if err := value.As(&values); err != nil {
+		return nil, err
+	}
+	result := make([]string, len(values))
+	for i, elem := range values {
+		s, err := stringifyTerraformValue(elem)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = s
+	}
+	return result, nil
+}
+
+func sendContinuation(stream grpc.ServerStreamingServer[pulumirpc.ListResponse], token string) error {
+	return stream.Send(&pulumirpc.ListResponse{
+		Response: &pulumirpc.ListResponse_Continuation_{
+			Continuation: &pulumirpc.ListResponse_Continuation{ContinuationToken: token},
+		},
+	})
+}
+
+func newContinuationToken() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf[:]), nil
+}
+
+type listSession struct {
+	cancel context.CancelFunc
+
+	mu         sync.Mutex
+	cond       *sync.Cond
+	lastAccess time.Time
+	inUse      bool
+	// maxResults is the overall ListRequest.limit bound across all pages.
+	// A value of 0 means unbounded.
+	maxResults       int64
+	requestToken     string
+	queryFingerprint string
+	produced         int64
+	consumed         int64
+	items            []*pulumirpc.ListResponse_Result
+	done             bool
+	err              error
+	computed         bool
+}
+
+func newListSession(cancel context.CancelFunc, maxResults int64, requestToken, queryFingerprint string) *listSession {
+	s := &listSession{
+		cancel:           cancel,
+		lastAccess:       time.Now(),
+		maxResults:       maxResults,
+		requestToken:     requestToken,
+		queryFingerprint: queryFingerprint,
+	}
+	s.cond = sync.NewCond(&s.mu)
+	return s
+}
+
+func newComputedListSession() *listSession {
+	return &listSession{computed: true}
+}
+
+func (s *listSession) lock() {
+	s.mu.Lock()
+	if !s.done {
+		s.lastAccess = time.Now()
+	}
+}
+
+func (s *listSession) unlock() {
+	s.mu.Unlock()
+}
+
+func (s *listSession) append(ctx context.Context, item *pulumirpc.ListResponse_Result) (bool, error) {
+	s.lock()
+	defer s.unlock()
+	stop := contextWakeup(ctx, s.cond)
+	defer stop()
+	for len(s.items) >= maxBufferedListResults && !s.done {
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		s.cond.Wait()
+	}
+	if s.maxResults > 0 && s.produced >= s.maxResults {
+		return false, nil
+	}
+	s.items = append(s.items, item)
+	s.produced++
+	s.cond.Broadcast()
+	return true, nil
+}
+
+func (s *listSession) finish(err error) {
+	s.lock()
+	defer s.unlock()
+	if s.done {
+		return
+	}
+	s.done = true
+	s.err = err
+	s.cond.Broadcast()
+}
+
+func (s *listSession) close() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	s.finish(context.Canceled)
+}
+
+func (s *listSession) acquire(ctx context.Context) error {
+	if s.computed {
+		return nil
+	}
+	s.lock()
+	defer s.unlock()
+	stop := contextWakeup(ctx, s.cond)
+	defer stop()
+
+	for s.inUse {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		s.cond.Wait()
+	}
+	s.inUse = true
+	return nil
+}
+
+func (s *listSession) release() {
+	if s.computed {
+		return
+	}
+	s.lock()
+	defer s.unlock()
+	s.inUse = false
+	s.cond.Broadcast()
+}
+
+func (s *listSession) validateContinuation(req *pulumirpc.ListRequest) error {
+	if s.requestToken != "" && req.GetToken() != s.requestToken {
+		return status.Error(codes.InvalidArgument, "continuation_token was used with a different token")
+	}
+	if req.GetLimit() != s.maxResults {
+		return status.Error(codes.InvalidArgument, "continuation_token was used with a different limit")
+	}
+	queryMap, err := unmarshalListQuery(req.GetQuery())
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid list query: %v", err)
+	}
+	fingerprint, err := listQueryFingerprint(queryMap)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid list query: %v", err)
+	}
+	if s.queryFingerprint != "" && fingerprint != s.queryFingerprint {
+		return status.Error(codes.InvalidArgument, "continuation_token was used with a different query")
+	}
+	return nil
+}
+
+func (s *listSession) preparePage(
+	ctx context.Context, limit int64,
+) (int64, int64, []*pulumirpc.ListResponse_Result, error) {
+	if s.computed {
+		return 0, 0, []*pulumirpc.ListResponse_Result{nil}, nil
+	}
+	s.lock()
+	defer s.unlock()
+
+	start := int64(0)
+	stop := contextWakeup(ctx, s.cond)
+	defer stop()
+
+	for {
+		if ctx.Err() != nil {
+			return 0, 0, nil, ctx.Err()
+		}
+		available := int64(len(s.items))
+		if available >= limit || s.done {
+			break
+		}
+		s.cond.Wait()
+	}
+
+	if len(s.items) == 0 && s.done && s.err != nil {
+		return 0, 0, nil, s.err
+	}
+
+	end := start + limit
+	visibleLen := int64(len(s.items))
+	if end > visibleLen {
+		end = visibleLen
+	}
+	page := append([]*pulumirpc.ListResponse_Result(nil), s.items[int(start):int(end)]...)
+	return start, end, page, nil
+}
+
+func (s *listSession) commit(start, end int64) (hasMore bool, terminalErr error) {
+	if s.computed {
+		return false, nil
+	}
+	s.lock()
+	defer s.unlock()
+
+	if end < start {
+		end = start
+	}
+	if end > int64(len(s.items)) {
+		end = int64(len(s.items))
+	}
+	if end > 0 {
+		copy(s.items, s.items[end:])
+		for i := int64(len(s.items)) - end; i < int64(len(s.items)); i++ {
+			s.items[i] = nil
+		}
+		s.items = s.items[:int64(len(s.items))-end]
+		s.consumed += end
+		s.cond.Broadcast()
+	}
+
+	hasMore = len(s.items) > 0 || (!s.done && (s.maxResults == 0 || s.consumed < s.maxResults))
+	if !hasMore && len(s.items) == 0 && s.err != nil {
+		terminalErr = s.err
+	}
+	return hasMore, terminalErr
+}
+
+func (s *listSession) isExpired(now time.Time, ttl time.Duration) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return now.Sub(s.lastAccess) > ttl
+}
+
+func contextWakeup(ctx context.Context, cond *sync.Cond) func() {
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			cond.L.Lock()
+			cond.Broadcast()
+			cond.L.Unlock()
+		case <-done:
+		}
+	}()
+	return func() {
+		close(done)
+	}
+}
+
+type listSessionStore struct {
+	ttl      time.Duration
+	mu       sync.Mutex
+	sessions map[string]*listSession
+	started  bool
+	closed   bool
+	stopCh   chan struct{}
+}
+
+func newListSessionStore(ttl time.Duration) *listSessionStore {
+	return &listSessionStore{
+		ttl:      ttl,
+		sessions: map[string]*listSession{},
+		stopCh:   make(chan struct{}),
+	}
+}
+
+func (s *listSessionStore) ensureReaper() {
+	if s.started || s.closed {
+		return
+	}
+	s.started = true
+	go s.reapLoop()
+}
+
+func (s *listSessionStore) put(token string, session *listSession) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		session.close()
+		return
+	}
+	defer s.mu.Unlock()
+	s.ensureReaper()
+	s.sessions[token] = session
+}
+
+func (s *listSessionStore) get(token string) (*listSession, bool) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, false
+	}
+	session, ok := s.sessions[token]
+	s.mu.Unlock()
+	if !ok {
+		return nil, false
+	}
+	session.lock()
+	session.unlock()
+	return session, true
+}
+
+func (s *listSessionStore) remove(token string) {
+	s.mu.Lock()
+	session, ok := s.sessions[token]
+	if ok {
+		delete(s.sessions, token)
+	}
+	s.mu.Unlock()
+	if ok {
+		session.close()
+	}
+}
+
+func (s *listSessionStore) reapLoop() {
+	ticker := time.NewTicker(listSessionReaperInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case <-ticker.C:
+		}
+
+		s.reapExpired(time.Now())
+	}
+}
+
+func (s *listSessionStore) reapExpired(now time.Time) {
+	var expiredTokens []string
+
+	s.mu.Lock()
+	for token, session := range s.sessions {
+		if session.isExpired(now, s.ttl) {
+			expiredTokens = append(expiredTokens, token)
+		}
+	}
+	s.mu.Unlock()
+
+	for _, token := range expiredTokens {
+		s.remove(token)
+	}
+}
+
+func (s *listSessionStore) close() {
+	var sessions map[string]*listSession
+
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
+	close(s.stopCh)
+	sessions = s.sessions
+	s.sessions = map[string]*listSession{}
+	s.mu.Unlock()
+
+	for _, session := range sessions {
+		session.close()
+	}
+}
+
+func errorsIsContext(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}

--- a/pkg/pf/tfbridge/provider_list.go
+++ b/pkg/pf/tfbridge/provider_list.go
@@ -836,7 +836,7 @@ func (s *listSession) commit(start, end int64) (hasMore bool, terminalErr error)
 func (s *listSession) isExpired(now time.Time, ttl time.Duration) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return now.Sub(s.lastAccess) > ttl
+	return !s.inUse && now.Sub(s.lastAccess) > ttl
 }
 
 func contextWakeup(ctx context.Context, cond *sync.Cond) func() {

--- a/pkg/pf/tfbridge/provider_list_test.go
+++ b/pkg/pf/tfbridge/provider_list_test.go
@@ -43,6 +43,37 @@ func TestListSessionStoreReapExpiredRemovesAndCancels(t *testing.T) {
 	assert.EqualValues(t, 1, canceled.Load())
 }
 
+func TestListSessionStoreReapExpiredSkipsInUseSession(t *testing.T) {
+	t.Parallel()
+
+	store := newListSessionStore(time.Minute)
+	t.Cleanup(store.close)
+
+	var canceled atomic.Int32
+	session := newListSession(func() { canceled.Add(1) }, 0, "", "")
+	require.NoError(t, session.acquire(context.Background()))
+	session.mu.Lock()
+	session.lastAccess = time.Now().Add(-2 * time.Minute)
+	session.mu.Unlock()
+	store.put("active", session)
+
+	store.reapExpired(time.Now())
+
+	_, ok := store.get("active")
+	assert.True(t, ok)
+	assert.EqualValues(t, 0, canceled.Load())
+
+	session.release()
+	session.mu.Lock()
+	session.lastAccess = time.Now().Add(-2 * time.Minute)
+	session.mu.Unlock()
+	store.reapExpired(time.Now())
+
+	_, ok = store.get("active")
+	assert.False(t, ok)
+	assert.EqualValues(t, 1, canceled.Load())
+}
+
 func TestListSessionStoreCloseCancelsAllAndRejectsNewSessions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/pf/tfbridge/provider_list_test.go
+++ b/pkg/pf/tfbridge/provider_list_test.go
@@ -1,0 +1,433 @@
+package tfbridge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestListSessionStoreReapExpiredRemovesAndCancels(t *testing.T) {
+	t.Parallel()
+
+	store := newListSessionStore(time.Minute)
+	t.Cleanup(store.close)
+
+	var canceled atomic.Int32
+	session := newListSession(func() { canceled.Add(1) }, 0, "", "")
+	session.mu.Lock()
+	session.lastAccess = time.Now().Add(-2 * time.Minute)
+	session.mu.Unlock()
+	store.put("expired", session)
+
+	store.reapExpired(time.Now())
+
+	_, ok := store.get("expired")
+	assert.False(t, ok)
+	assert.EqualValues(t, 1, canceled.Load())
+}
+
+func TestListSessionStoreCloseCancelsAllAndRejectsNewSessions(t *testing.T) {
+	t.Parallel()
+
+	store := newListSessionStore(time.Minute)
+	var canceled atomic.Int32
+
+	store.put("a", newListSession(func() { canceled.Add(1) }, 0, "", ""))
+	store.put("b", newListSession(func() { canceled.Add(1) }, 0, "", ""))
+	store.close()
+
+	assert.EqualValues(t, 2, canceled.Load())
+
+	store.put("c", newListSession(func() { canceled.Add(1) }, 0, "", ""))
+	assert.EqualValues(t, 3, canceled.Load())
+
+	_, okA := store.get("a")
+	_, okB := store.get("b")
+	_, okC := store.get("c")
+	assert.False(t, okA)
+	assert.False(t, okB)
+	assert.False(t, okC)
+}
+
+func TestListWithContextContinuationPaging(t *testing.T) {
+	t.Parallel()
+
+	p := &provider{listSessions: newListSessionStore(time.Minute)}
+	t.Cleanup(p.listSessions.close)
+
+	session := newListSession(func() {}, 0, "", "")
+	for i := 0; i < 3; i++ {
+		ok, err := session.append(context.Background(), &pulumirpc.ListResponse_Result{Id: fmt.Sprintf("id-%d", i+1)})
+		require.NoError(t, err)
+		require.True(t, ok)
+	}
+	session.finish(nil)
+
+	token := "tok"
+	p.listSessions.put(token, session)
+
+	req := &pulumirpc.ListRequest{ContinuationToken: token, PageSize: 2}
+
+	stream1 := newRecordingListStream(context.Background())
+	require.NoError(t, p.ListWithContext(context.Background(), req, stream1))
+	results1, cont1 := splitResponses(stream1.sent)
+	require.Len(t, results1, 2)
+	assert.Equal(t, token, cont1)
+
+	stream2 := newRecordingListStream(context.Background())
+	require.NoError(t, p.ListWithContext(context.Background(), req, stream2))
+	results2, cont2 := splitResponses(stream2.sent)
+	require.Len(t, results2, 1)
+	assert.Empty(t, cont2)
+
+	_, ok := p.listSessions.get(token)
+	assert.False(t, ok)
+}
+
+func TestListWithContextDefaultPageSize(t *testing.T) {
+	t.Parallel()
+
+	p := &provider{listSessions: newListSessionStore(time.Minute)}
+	t.Cleanup(p.listSessions.close)
+
+	session := newListSession(func() {}, 0, "", "")
+	for i := int64(0); i < defaultListPageSize+50; i++ {
+		ok, err := session.append(context.Background(), &pulumirpc.ListResponse_Result{Id: fmt.Sprintf("id-%d", i+1)})
+		require.NoError(t, err)
+		require.True(t, ok)
+	}
+	session.finish(nil)
+
+	token := "tok-default-size"
+	p.listSessions.put(token, session)
+
+	req := &pulumirpc.ListRequest{ContinuationToken: token, PageSize: 0}
+	stream := newRecordingListStream(context.Background())
+	require.NoError(t, p.ListWithContext(context.Background(), req, stream))
+	results, cont := splitResponses(stream.sent)
+
+	assert.Len(t, results, int(defaultListPageSize))
+	assert.Equal(t, token, cont)
+}
+
+func TestListWithContextRejectsNegativeBounds(t *testing.T) {
+	t.Parallel()
+
+	p := &provider{listSessions: newListSessionStore(time.Minute)}
+	t.Cleanup(p.listSessions.close)
+
+	stream := newRecordingListStream(context.Background())
+	err := p.ListWithContext(context.Background(), &pulumirpc.ListRequest{Limit: -1}, stream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "limit must be >= 0")
+
+	stream = newRecordingListStream(context.Background())
+	err = p.ListWithContext(context.Background(), &pulumirpc.ListRequest{PageSize: -1}, stream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "page_size must be >= 0")
+}
+
+func TestListWithContextContinuationRejectsChangedRequest(t *testing.T) {
+	t.Parallel()
+
+	p := &provider{listSessions: newListSessionStore(time.Minute)}
+	t.Cleanup(p.listSessions.close)
+
+	query, err := listQueryFingerprint(resource.PropertyMap{
+		"name": resource.NewStringProperty("original"),
+	})
+	require.NoError(t, err)
+
+	session := newListSession(func() {}, 0, "pkg:index:Res", query)
+	ok, err := session.append(context.Background(), &pulumirpc.ListResponse_Result{Id: "id-1"})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	token := "tok-bound"
+	p.listSessions.put(token, session)
+
+	stream := newRecordingListStream(context.Background())
+	err = p.ListWithContext(context.Background(), &pulumirpc.ListRequest{
+		ContinuationToken: token,
+		Token:             "pkg:index:Other",
+		Query:             mustStruct(t, map[string]any{"name": "original"}),
+	}, stream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "different token")
+
+	stream = newRecordingListStream(context.Background())
+	err = p.ListWithContext(context.Background(), &pulumirpc.ListRequest{
+		ContinuationToken: token,
+		Token:             "pkg:index:Res",
+		Limit:             1,
+		Query:             mustStruct(t, map[string]any{"name": "original"}),
+	}, stream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "different limit")
+
+	stream = newRecordingListStream(context.Background())
+	err = p.ListWithContext(context.Background(), &pulumirpc.ListRequest{
+		ContinuationToken: token,
+		Token:             "pkg:index:Res",
+		Query:             mustStruct(t, map[string]any{"name": "changed"}),
+	}, stream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "different query")
+}
+
+func TestListWithContextReturnsTerminalErrorAfterPartialResults(t *testing.T) {
+	t.Parallel()
+
+	p := &provider{listSessions: newListSessionStore(time.Minute)}
+	t.Cleanup(p.listSessions.close)
+
+	session := newListSession(func() {}, 0, "", "")
+	ok, err := session.append(context.Background(), &pulumirpc.ListResponse_Result{Id: "id-1"})
+	require.NoError(t, err)
+	require.True(t, ok)
+	session.finish(errors.New("terminal list failure"))
+
+	token := "tok-terminal-error"
+	p.listSessions.put(token, session)
+
+	stream := newRecordingListStream(context.Background())
+	err = p.ListWithContext(context.Background(), &pulumirpc.ListRequest{ContinuationToken: token, PageSize: 10}, stream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "terminal list failure")
+
+	results, cont := splitResponses(stream.sent)
+	require.Len(t, results, 1)
+	assert.Empty(t, cont)
+}
+
+func TestPopulateListSessionIntegration(t *testing.T) {
+	t.Parallel()
+
+	p := &provider{listSessions: newListSessionStore(time.Minute)}
+	t.Cleanup(p.listSessions.close)
+
+	session := newListSession(func() {}, 0, "", "")
+	token := "tok-integration"
+	p.listSessions.put(token, session)
+
+	caller := &fakeListResourceCaller{
+		results: []tfprotov6.ListResourceResult{
+			{DisplayName: "one", Identity: mustIdentityData(t, "one")},
+			{DisplayName: "two", Identity: mustIdentityData(t, "two")},
+			{DisplayName: "three", Identity: mustIdentityData(t, "three")},
+		},
+	}
+
+	p.populateListSession(context.Background(), session, caller,
+		resourceHandle{terraformResourceName: "test_resource"}, tftypes.Object{}, &tfprotov6.ResourceIdentitySchema{
+			IdentityAttributes: []*tfprotov6.ResourceIdentitySchemaAttribute{
+				{Name: "name", Type: tftypes.String, RequiredForImport: true},
+			},
+		}, nil, terraformListFetchLimit)
+
+	req := &pulumirpc.ListRequest{ContinuationToken: token, PageSize: 2}
+	stream := newRecordingListStream(context.Background())
+	require.NoError(t, p.ListWithContext(context.Background(), req, stream))
+
+	results, cont := splitResponses(stream.sent)
+	require.Len(t, results, 2)
+	assert.Equal(t, "one", results[0].Name)
+	assert.Equal(t, "two", results[1].Name)
+	assert.Equal(t, "one", results[0].Id)
+	assert.Equal(t, token, cont)
+}
+
+func TestIdentityDataToID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		attrs  []*tfprotov6.ResourceIdentitySchemaAttribute
+		values map[string]tftypes.Value
+		want   string
+		err    string
+	}{
+		{
+			name: "id attribute wins",
+			attrs: []*tfprotov6.ResourceIdentitySchemaAttribute{
+				{Name: "id", Type: tftypes.String, RequiredForImport: true},
+			},
+			values: map[string]tftypes.Value{
+				"id": tftypes.NewValue(tftypes.String, "id-value"),
+			},
+			want: "id-value",
+		},
+		{
+			name: "single attribute",
+			attrs: []*tfprotov6.ResourceIdentitySchemaAttribute{
+				{Name: "arn", Type: tftypes.String, RequiredForImport: true},
+			},
+			values: map[string]tftypes.Value{
+				"arn": tftypes.NewValue(tftypes.String, "arn-value"),
+			},
+			want: "arn-value",
+		},
+		{
+			name: "compound attributes fail closed",
+			attrs: []*tfprotov6.ResourceIdentitySchemaAttribute{
+				{Name: "zeta", Type: tftypes.String, RequiredForImport: true},
+				{Name: "alpha", Type: tftypes.String, RequiredForImport: true},
+			},
+			values: map[string]tftypes.Value{
+				"zeta":  tftypes.NewValue(tftypes.String, "z"),
+				"alpha": tftypes.NewValue(tftypes.String, "a"),
+			},
+			err: "compound identity data",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			schema := &tfprotov6.ResourceIdentitySchema{IdentityAttributes: tt.attrs}
+			got, err := identityDataToID("test_resource", schema, mustIdentityDataWithSchema(t, schema, tt.values))
+			if tt.err != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPropertyMapIDUsesConcreteTopLevelID(t *testing.T) {
+	t.Parallel()
+
+	id, ok, err := propertyMapID(resource.PropertyMap{
+		"id": resource.NewStringProperty("resource-id"),
+	})
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "resource-id", id)
+}
+
+func TestUnmarshalListQueryPreservesUnknowns(t *testing.T) {
+	t.Parallel()
+
+	query, err := plugin.MarshalProperties(resource.PropertyMap{
+		"name": resource.MakeComputed(resource.NewStringProperty("")),
+	}, plugin.MarshalOptions{KeepUnknowns: true})
+	require.NoError(t, err)
+
+	props, err := unmarshalListQuery(query)
+	require.NoError(t, err)
+	assert.True(t, props.ContainsUnknowns())
+}
+
+type fakeListResourceCaller struct {
+	results []tfprotov6.ListResourceResult
+	err     error
+}
+
+func (f *fakeListResourceCaller) ValidateListResourceConfig(
+	_ context.Context, _ *tfprotov6.ValidateListResourceConfigRequest,
+) (*tfprotov6.ValidateListResourceConfigResponse, error) {
+	return &tfprotov6.ValidateListResourceConfigResponse{}, nil
+}
+
+func (f *fakeListResourceCaller) ListResource(
+	_ context.Context, _ *tfprotov6.ListResourceRequest,
+) (*tfprotov6.ListResourceServerStream, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &tfprotov6.ListResourceServerStream{
+		Results: func(yield func(tfprotov6.ListResourceResult) bool) {
+			for _, r := range f.results {
+				if !yield(r) {
+					return
+				}
+			}
+		},
+	}, nil
+}
+
+type recordingListStream struct {
+	ctx  context.Context
+	sent []*pulumirpc.ListResponse
+}
+
+func newRecordingListStream(ctx context.Context) *recordingListStream {
+	return &recordingListStream{ctx: ctx}
+}
+
+func (s *recordingListStream) Send(resp *pulumirpc.ListResponse) error {
+	s.sent = append(s.sent, resp)
+	return nil
+}
+
+func (s *recordingListStream) SetHeader(metadata.MD) error { return nil }
+
+func (s *recordingListStream) SendHeader(metadata.MD) error { return nil }
+
+func (s *recordingListStream) SetTrailer(metadata.MD) {}
+
+func (s *recordingListStream) Context() context.Context { return s.ctx }
+
+func (s *recordingListStream) SendMsg(any) error { return nil }
+
+func (s *recordingListStream) RecvMsg(any) error { return nil }
+
+func splitResponses(resps []*pulumirpc.ListResponse) ([]*pulumirpc.ListResponse_Result, string) {
+	var results []*pulumirpc.ListResponse_Result
+	var continuation string
+	for _, r := range resps {
+		if rr := r.GetResult(); rr != nil {
+			results = append(results, rr)
+		}
+		if cc := r.GetContinuation(); cc != nil {
+			continuation = cc.GetContinuationToken()
+		}
+	}
+	return results, continuation
+}
+
+func mustStruct(t *testing.T, values map[string]any) *structpb.Struct {
+	t.Helper()
+	s, err := structpb.NewStruct(values)
+	require.NoError(t, err)
+	return s
+}
+
+func mustIdentityData(t *testing.T, value string) *tfprotov6.ResourceIdentityData {
+	t.Helper()
+	schema := &tfprotov6.ResourceIdentitySchema{
+		IdentityAttributes: []*tfprotov6.ResourceIdentitySchemaAttribute{
+			{Name: "name", Type: tftypes.String, RequiredForImport: true},
+		},
+	}
+	return mustIdentityDataWithSchema(t, schema, map[string]tftypes.Value{
+		"name": tftypes.NewValue(tftypes.String, value),
+	})
+}
+
+func mustIdentityDataWithSchema(
+	t *testing.T, schema *tfprotov6.ResourceIdentitySchema, values map[string]tftypes.Value,
+) *tfprotov6.ResourceIdentityData {
+	t.Helper()
+	identityValue := tftypes.NewValue(schema.ValueType(), values)
+	dv, err := tfprotov6.NewDynamicValue(schema.ValueType(), identityValue)
+	require.NoError(t, err)
+	return &tfprotov6.ResourceIdentityData{IdentityData: &dv}
+}

--- a/pkg/pf/tfbridge/provider_list_test.go
+++ b/pkg/pf/tfbridge/provider_list_test.go
@@ -123,6 +123,31 @@ func TestListWithContextDefaultPageSize(t *testing.T) {
 	assert.Equal(t, token, cont)
 }
 
+func TestListWithContextCapsOversizedPageSize(t *testing.T) {
+	t.Parallel()
+
+	p := &provider{listSessions: newListSessionStore(time.Minute)}
+	t.Cleanup(p.listSessions.close)
+
+	session := newListSession(func() {}, 0, "", "")
+	for i := 0; i < maxBufferedListResults; i++ {
+		ok, err := session.append(context.Background(), &pulumirpc.ListResponse_Result{Id: fmt.Sprintf("id-%d", i+1)})
+		require.NoError(t, err)
+		require.True(t, ok)
+	}
+
+	token := "tok-oversized-page"
+	p.listSessions.put(token, session)
+
+	req := &pulumirpc.ListRequest{ContinuationToken: token, PageSize: int64(maxBufferedListResults + 1)}
+	stream := newRecordingListStream(context.Background())
+	require.NoError(t, p.ListWithContext(context.Background(), req, stream))
+
+	results, cont := splitResponses(stream.sent)
+	assert.Len(t, results, maxBufferedListResults)
+	assert.Equal(t, token, cont)
+}
+
 func TestListWithContextRejectsNegativeBounds(t *testing.T) {
 	t.Parallel()
 
@@ -213,6 +238,56 @@ func TestListWithContextReturnsTerminalErrorAfterPartialResults(t *testing.T) {
 	assert.Empty(t, cont)
 }
 
+func TestListWithContextResultSendFailureRemovesSession(t *testing.T) {
+	t.Parallel()
+
+	p := &provider{listSessions: newListSessionStore(time.Minute)}
+	t.Cleanup(p.listSessions.close)
+
+	var canceled atomic.Int32
+	session := newListSession(func() { canceled.Add(1) }, 0, "", "")
+	ok, err := session.append(context.Background(), &pulumirpc.ListResponse_Result{Id: "id-1"})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	token := "tok-result-send-failure"
+	p.listSessions.put(token, session)
+
+	sendErr := errors.New("send failed")
+	stream := newFailingListStream(context.Background(), 1, sendErr)
+	err = p.ListWithContext(context.Background(), &pulumirpc.ListRequest{ContinuationToken: token, PageSize: 1}, stream)
+	require.ErrorIs(t, err, sendErr)
+
+	_, ok = p.listSessions.get(token)
+	assert.False(t, ok)
+	assert.EqualValues(t, 1, canceled.Load())
+}
+
+func TestListWithContextContinuationSendFailureRemovesSession(t *testing.T) {
+	t.Parallel()
+
+	p := &provider{listSessions: newListSessionStore(time.Minute)}
+	t.Cleanup(p.listSessions.close)
+
+	var canceled atomic.Int32
+	session := newListSession(func() { canceled.Add(1) }, 0, "", "")
+	ok, err := session.append(context.Background(), &pulumirpc.ListResponse_Result{Id: "id-1"})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	token := "tok-continuation-send-failure"
+	p.listSessions.put(token, session)
+
+	sendErr := errors.New("send failed")
+	stream := newFailingListStream(context.Background(), 2, sendErr)
+	err = p.ListWithContext(context.Background(), &pulumirpc.ListRequest{ContinuationToken: token, PageSize: 1}, stream)
+	require.ErrorIs(t, err, sendErr)
+
+	_, ok = p.listSessions.get(token)
+	assert.False(t, ok)
+	assert.EqualValues(t, 1, canceled.Load())
+}
+
 func TestPopulateListSessionIntegration(t *testing.T) {
 	t.Parallel()
 
@@ -248,6 +323,8 @@ func TestPopulateListSessionIntegration(t *testing.T) {
 	assert.Equal(t, "two", results[1].Name)
 	assert.Equal(t, "one", results[0].Id)
 	assert.Equal(t, token, cont)
+	require.NotNil(t, caller.listRequest)
+	assert.True(t, caller.listRequest.IncludeResource)
 }
 
 func TestIdentityDataToID(t *testing.T) {
@@ -281,7 +358,7 @@ func TestIdentityDataToID(t *testing.T) {
 			want: "arn-value",
 		},
 		{
-			name: "compound attributes fail closed",
+			name: "compound attributes sort and join by name",
 			attrs: []*tfprotov6.ResourceIdentitySchemaAttribute{
 				{Name: "zeta", Type: tftypes.String, RequiredForImport: true},
 				{Name: "alpha", Type: tftypes.String, RequiredForImport: true},
@@ -290,7 +367,19 @@ func TestIdentityDataToID(t *testing.T) {
 				"zeta":  tftypes.NewValue(tftypes.String, "z"),
 				"alpha": tftypes.NewValue(tftypes.String, "a"),
 			},
-			err: "compound identity data",
+			want: "a,z",
+		},
+		{
+			name: "id attribute wins in compound identity",
+			attrs: []*tfprotov6.ResourceIdentitySchemaAttribute{
+				{Name: "zeta", Type: tftypes.String, RequiredForImport: true},
+				{Name: "id", Type: tftypes.String, RequiredForImport: true},
+			},
+			values: map[string]tftypes.Value{
+				"zeta": tftypes.NewValue(tftypes.String, "z"),
+				"id":   tftypes.NewValue(tftypes.String, "id-value"),
+			},
+			want: "id-value",
 		},
 	}
 
@@ -336,8 +425,9 @@ func TestUnmarshalListQueryPreservesUnknowns(t *testing.T) {
 }
 
 type fakeListResourceCaller struct {
-	results []tfprotov6.ListResourceResult
-	err     error
+	results     []tfprotov6.ListResourceResult
+	err         error
+	listRequest *tfprotov6.ListResourceRequest
 }
 
 func (f *fakeListResourceCaller) ValidateListResourceConfig(
@@ -347,8 +437,9 @@ func (f *fakeListResourceCaller) ValidateListResourceConfig(
 }
 
 func (f *fakeListResourceCaller) ListResource(
-	_ context.Context, _ *tfprotov6.ListResourceRequest,
+	_ context.Context, req *tfprotov6.ListResourceRequest,
 ) (*tfprotov6.ListResourceServerStream, error) {
+	f.listRequest = req
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -373,6 +464,28 @@ func newRecordingListStream(ctx context.Context) *recordingListStream {
 }
 
 func (s *recordingListStream) Send(resp *pulumirpc.ListResponse) error {
+	s.sent = append(s.sent, resp)
+	return nil
+}
+
+type failingListStream struct {
+	recordingListStream
+	failOn int
+	err    error
+}
+
+func newFailingListStream(ctx context.Context, failOn int, err error) *failingListStream {
+	return &failingListStream{
+		recordingListStream: recordingListStream{ctx: ctx},
+		failOn:              failOn,
+		err:                 err,
+	}
+}
+
+func (s *failingListStream) Send(resp *pulumirpc.ListResponse) error {
+	if len(s.sent)+1 == s.failOn {
+		return s.err
+	}
 	s.sent = append(s.sent, resp)
 	return nil
 }

--- a/pkg/pf/tfbridge/provider_list_test.go
+++ b/pkg/pf/tfbridge/provider_list_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/convert"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 )
 
 func TestListSessionStoreReapExpiredRemovesAndCancels(t *testing.T) {
@@ -238,6 +242,29 @@ func TestListWithContextReturnsTerminalErrorAfterPartialResults(t *testing.T) {
 	assert.Empty(t, cont)
 }
 
+func TestListWithContextTerminalPreparePageErrorRemovesSession(t *testing.T) {
+	t.Parallel()
+
+	p := &provider{listSessions: newListSessionStore(time.Minute)}
+	t.Cleanup(p.listSessions.close)
+
+	var canceled atomic.Int32
+	session := newListSession(func() { canceled.Add(1) }, 0, "", "")
+	session.finish(errors.New("terminal list failure"))
+
+	token := "tok-terminal-error-empty"
+	p.listSessions.put(token, session)
+
+	stream := newRecordingListStream(context.Background())
+	err := p.ListWithContext(context.Background(), &pulumirpc.ListRequest{ContinuationToken: token, PageSize: 10}, stream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "terminal list failure")
+
+	_, ok := p.listSessions.get(token)
+	assert.False(t, ok)
+	assert.EqualValues(t, 1, canceled.Load())
+}
+
 func TestListWithContextResultSendFailureRemovesSession(t *testing.T) {
 	t.Parallel()
 
@@ -291,6 +318,22 @@ func TestListWithContextContinuationSendFailureRemovesSession(t *testing.T) {
 func TestPopulateListSessionIntegration(t *testing.T) {
 	t.Parallel()
 
+	identitySchema := &tfprotov6.ResourceIdentitySchema{
+		IdentityAttributes: []*tfprotov6.ResourceIdentitySchemaAttribute{
+			{Name: "name", Type: tftypes.String, RequiredForImport: true},
+		},
+	}
+	caller := &fakeListResourceCaller{
+		results: []tfprotov6.ListResourceResult{
+			{DisplayName: "one", Identity: mustIdentityData(t, "one")},
+			{DisplayName: "two", Identity: mustIdentityData(t, "two")},
+			{DisplayName: "three", Identity: mustIdentityData(t, "three")},
+		},
+		identitySchemas: map[string]*tfprotov6.ResourceIdentitySchema{
+			"test_resource": identitySchema,
+		},
+	}
+
 	p := &provider{listSessions: newListSessionStore(time.Minute)}
 	t.Cleanup(p.listSessions.close)
 
@@ -298,20 +341,11 @@ func TestPopulateListSessionIntegration(t *testing.T) {
 	token := "tok-integration"
 	p.listSessions.put(token, session)
 
-	caller := &fakeListResourceCaller{
-		results: []tfprotov6.ListResourceResult{
-			{DisplayName: "one", Identity: mustIdentityData(t, "one")},
-			{DisplayName: "two", Identity: mustIdentityData(t, "two")},
-			{DisplayName: "three", Identity: mustIdentityData(t, "three")},
-		},
-	}
-
 	p.populateListSession(context.Background(), session, caller,
-		resourceHandle{terraformResourceName: "test_resource"}, tftypes.Object{}, &tfprotov6.ResourceIdentitySchema{
-			IdentityAttributes: []*tfprotov6.ResourceIdentitySchemaAttribute{
-				{Name: "name", Type: tftypes.String, RequiredForImport: true},
-			},
-		}, nil, terraformListFetchLimit)
+		resourceHandle{terraformResourceName: "test_resource"}, tftypes.Object{}, nil, terraformListFetchLimit,
+		func(context.Context) (*tfprotov6.ResourceIdentitySchema, error) {
+			return identitySchema, nil
+		})
 
 	req := &pulumirpc.ListRequest{ContinuationToken: token, PageSize: 2}
 	stream := newRecordingListStream(context.Background())
@@ -325,6 +359,103 @@ func TestPopulateListSessionIntegration(t *testing.T) {
 	assert.Equal(t, token, cont)
 	require.NotNil(t, caller.listRequest)
 	assert.True(t, caller.listRequest.IncludeResource)
+}
+
+func TestConvertListResultSkipsIdentitySchemaWhenResourceIDPresent(t *testing.T) {
+	t.Parallel()
+
+	objectType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{"id": tftypes.String}}
+	decoder, err := convert.NewObjectDecoder(convert.ObjectSchema{
+		SchemaMap: schema.SchemaMap{
+			"id": (&schema.Schema{Type: shim.TypeString}).Shim(),
+		},
+		Object: &objectType,
+	})
+	require.NoError(t, err)
+	resourceValue := tftypes.NewValue(objectType, map[string]tftypes.Value{
+		"id": tftypes.NewValue(tftypes.String, "resource-id"),
+	})
+	resourceDV, err := tfprotov6.NewDynamicValue(objectType, resourceValue)
+	require.NoError(t, err)
+
+	var identitySchemaCalls atomic.Int32
+	item, err := (&provider{}).convertListResult(
+		context.Background(),
+		resourceHandle{terraformResourceName: "test_resource", decoder: decoder},
+		objectType,
+		func(context.Context) (*tfprotov6.ResourceIdentitySchema, error) {
+			identitySchemaCalls.Add(1)
+			return nil, errors.New("identity schema should not be loaded")
+		},
+		tfprotov6.ListResourceResult{Resource: &resourceDV},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "resource-id", item.Id)
+	assert.EqualValues(t, 0, identitySchemaCalls.Load())
+}
+
+func TestConvertListResultFallsBackToIdentityWhenResourceIDUnusable(t *testing.T) {
+	t.Parallel()
+
+	objectType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"id": tftypes.Map{ElementType: tftypes.String},
+	}}
+	decoder, err := convert.NewObjectDecoder(convert.ObjectSchema{
+		SchemaMap: schema.SchemaMap{
+			"id": (&schema.Schema{
+				Type: shim.TypeMap,
+				Elem: (&schema.Schema{Type: shim.TypeString}).Shim(),
+			}).Shim(),
+		},
+		Object: &objectType,
+	})
+	require.NoError(t, err)
+	resourceValue := tftypes.NewValue(objectType, map[string]tftypes.Value{
+		"id": tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, map[string]tftypes.Value{
+			"part": tftypes.NewValue(tftypes.String, "not-a-pulumi-id"),
+		}),
+	})
+	resourceDV, err := tfprotov6.NewDynamicValue(objectType, resourceValue)
+	require.NoError(t, err)
+
+	identitySchema := &tfprotov6.ResourceIdentitySchema{
+		IdentityAttributes: []*tfprotov6.ResourceIdentitySchemaAttribute{
+			{Name: "name", Type: tftypes.String, RequiredForImport: true},
+		},
+	}
+	var identitySchemaCalls atomic.Int32
+	item, err := (&provider{}).convertListResult(
+		context.Background(),
+		resourceHandle{terraformResourceName: "test_resource", decoder: decoder},
+		objectType,
+		func(context.Context) (*tfprotov6.ResourceIdentitySchema, error) {
+			identitySchemaCalls.Add(1)
+			return identitySchema, nil
+		},
+		tfprotov6.ListResourceResult{
+			Resource: &resourceDV,
+			Identity: mustIdentityDataWithSchema(t, identitySchema, map[string]tftypes.Value{
+				"name": tftypes.NewValue(tftypes.String, "identity-id"),
+			}),
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "identity-id", item.Id)
+	assert.EqualValues(t, 1, identitySchemaCalls.Load())
+}
+
+func TestListSessionAppendStopsWhenSessionClosed(t *testing.T) {
+	t.Parallel()
+
+	var canceled atomic.Int32
+	session := newListSession(func() { canceled.Add(1) }, 0, "", "")
+	session.close()
+
+	ok, err := session.append(context.Background(), &pulumirpc.ListResponse_Result{Id: "late-id"})
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, session.items)
+	assert.EqualValues(t, 1, canceled.Load())
 }
 
 func TestIdentityDataToID(t *testing.T) {
@@ -425,9 +556,10 @@ func TestUnmarshalListQueryPreservesUnknowns(t *testing.T) {
 }
 
 type fakeListResourceCaller struct {
-	results     []tfprotov6.ListResourceResult
-	err         error
-	listRequest *tfprotov6.ListResourceRequest
+	results         []tfprotov6.ListResourceResult
+	identitySchemas map[string]*tfprotov6.ResourceIdentitySchema
+	err             error
+	listRequest     *tfprotov6.ListResourceRequest
 }
 
 func (f *fakeListResourceCaller) ValidateListResourceConfig(
@@ -452,6 +584,12 @@ func (f *fakeListResourceCaller) ListResource(
 			}
 		},
 	}, nil
+}
+
+func (f *fakeListResourceCaller) GetResourceIdentitySchemas(
+	_ context.Context, _ *tfprotov6.GetResourceIdentitySchemasRequest,
+) (*tfprotov6.GetResourceIdentitySchemasResponse, error) {
+	return &tfprotov6.GetResourceIdentitySchemasResponse{IdentitySchemas: f.identitySchemas}, nil
 }
 
 type recordingListStream struct {

--- a/pkg/pf/tfgen/tfgen_test.go
+++ b/pkg/pf/tfgen/tfgen_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	tflist "github.com/hashicorp/terraform-plugin-framework/list"
+	lschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	prschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -80,6 +82,7 @@ func TestMaxItemsOne(t *testing.T) {
 type schemaTestProvider struct {
 	schema    prschema.Schema
 	resources map[string]rschema.Schema
+	lists     map[string]lschema.Schema
 }
 
 func (*schemaTestProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -104,6 +107,172 @@ func (p *schemaTestProvider) Resources(context.Context) []func() resource.Resour
 		r = append(r, makeTestResource(k, v))
 	}
 	return r
+}
+
+func (p *schemaTestProvider) ListResources(context.Context) []func() tflist.ListResource {
+	r := make([]func() tflist.ListResource, 0, len(p.lists))
+	for k, v := range p.lists {
+		r = append(r, makeTestListResource(k, v))
+	}
+	return r
+}
+
+func makeTestListResource(name string, schema lschema.Schema) func() tflist.ListResource {
+	return func() tflist.ListResource { return schemaTestListResource{name, schema} }
+}
+
+type schemaTestListResource struct {
+	name   string
+	schema lschema.Schema
+}
+
+func (r schemaTestListResource) Metadata(
+	_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse,
+) {
+	resp.TypeName = req.ProviderTypeName + r.name
+}
+
+func (r schemaTestListResource) ListResourceConfigSchema(
+	_ context.Context, _ tflist.ListResourceSchemaRequest, resp *tflist.ListResourceSchemaResponse,
+) {
+	resp.Schema = r.schema
+}
+
+func (r schemaTestListResource) List(
+	_ context.Context, _ tflist.ListRequest, _ *tflist.ListResultsStream,
+) {
+	panic(r.name)
+}
+
+func TestListInputs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	p := &schemaTestProvider{
+		resources: map[string]rschema.Schema{
+			"thing": {
+				Attributes: map[string]rschema.Attribute{
+					"name": rschema.StringAttribute{
+						Required: true,
+					},
+				},
+			},
+		},
+		lists: map[string]lschema.Schema{
+			"thing": {
+				Attributes: map[string]lschema.Attribute{
+					"parent_id": lschema.StringAttribute{
+						Required:    true,
+						Description: "The parent identifier to list things under.",
+					},
+					"prefix": lschema.StringAttribute{
+						Optional:    true,
+						Description: "An optional name prefix filter.",
+					},
+				},
+			},
+		},
+	}
+
+	res, err := GenerateSchema(ctx, GenerateSchemaOptions{
+		ProviderInfo: tfbridge.ProviderInfo{
+			Name: "testprovider",
+			P:    pftfbridge.ShimProvider(p),
+			Resources: map[string]*tfbridge.ResourceInfo{
+				"test_thing": {
+					Tok: "testprovider:index:Thing",
+				},
+			},
+		},
+		XInMemoryDocs: true,
+	})
+	require.NoError(t, err)
+
+	var schema puschema.PackageSpec
+	require.NoError(t, json.Unmarshal(res.ProviderMetadata.PackageSchema, &schema))
+
+	resource := schema.Resources["testprovider:index:Thing"]
+	require.NotNil(t, resource.ListInputs)
+	require.Equal(t, "object", resource.ListInputs.Type)
+	require.Equal(t, []string{"parentId"}, resource.ListInputs.Required)
+	require.Contains(t, resource.ListInputs.Properties, "parentId")
+	require.Contains(t, resource.ListInputs.Properties, "prefix")
+}
+
+func TestListInputsEmptySchema(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	p := &schemaTestProvider{
+		resources: map[string]rschema.Schema{
+			"thing": {
+				Attributes: map[string]rschema.Attribute{
+					"name": rschema.StringAttribute{Required: true},
+				},
+			},
+		},
+		lists: map[string]lschema.Schema{
+			"thing": {},
+		},
+	}
+
+	res, err := GenerateSchema(ctx, GenerateSchemaOptions{
+		ProviderInfo: tfbridge.ProviderInfo{
+			Name: "testprovider",
+			P:    pftfbridge.ShimProvider(p),
+			Resources: map[string]*tfbridge.ResourceInfo{
+				"test_thing": {
+					Tok: "testprovider:index:Thing",
+				},
+			},
+		},
+		XInMemoryDocs: true,
+	})
+	require.NoError(t, err)
+
+	var schema puschema.PackageSpec
+	require.NoError(t, json.Unmarshal(res.ProviderMetadata.PackageSchema, &schema))
+
+	resource := schema.Resources["testprovider:index:Thing"]
+	require.NotNil(t, resource.ListInputs)
+	require.Equal(t, "object", resource.ListInputs.Type)
+	require.Empty(t, resource.ListInputs.Properties)
+	require.Empty(t, resource.ListInputs.Required)
+}
+
+func TestListInputsOmittedWithoutListResource(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	p := &schemaTestProvider{
+		resources: map[string]rschema.Schema{
+			"thing": {
+				Attributes: map[string]rschema.Attribute{
+					"name": rschema.StringAttribute{Required: true},
+				},
+			},
+		},
+	}
+
+	res, err := GenerateSchema(ctx, GenerateSchemaOptions{
+		ProviderInfo: tfbridge.ProviderInfo{
+			Name: "testprovider",
+			P:    pftfbridge.ShimProvider(p),
+			Resources: map[string]*tfbridge.ResourceInfo{
+				"test_thing": {
+					Tok: "testprovider:index:Thing",
+				},
+			},
+		},
+		XInMemoryDocs: true,
+	})
+	require.NoError(t, err)
+
+	var schema puschema.PackageSpec
+	require.NoError(t, json.Unmarshal(res.ProviderMetadata.PackageSchema, &schema))
+
+	resource := schema.Resources["testprovider:index:Thing"]
+	require.Nil(t, resource.ListInputs)
 }
 
 func makeTestResource(name string, schema rschema.Schema) func() resource.Resource {

--- a/pkg/providerserver/panic_recovering_provider.go
+++ b/pkg/providerserver/panic_recovering_provider.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/logging"
@@ -481,6 +482,34 @@ func (s *PanicRecoveringProviderServer) GetMappings(
 		}()
 	}
 	return s.innerServer.GetMappings(withPanicHandlerInstalled(ctx), req)
+}
+
+func (s *PanicRecoveringProviderServer) List(
+	req *pulumirpc.ListRequest,
+	stream grpc.ServerStreamingServer[pulumirpc.ListResponse],
+) error {
+	ctx := stream.Context()
+	if !isPanicHandlerInstalled(ctx) {
+		defer func() {
+			if err := recover(); err != nil {
+				s.logPanic(ctx, "List", err, debug.Stack(), nil)
+				panic(err) // rethrow
+			}
+		}()
+	}
+	return s.innerServer.List(req, &panicHandlerListStream{
+		ServerStreamingServer: stream,
+		ctx:                   withPanicHandlerInstalled(ctx),
+	})
+}
+
+type panicHandlerListStream struct {
+	grpc.ServerStreamingServer[pulumirpc.ListResponse]
+	ctx context.Context
+}
+
+func (s *panicHandlerListStream) Context() context.Context {
+	return s.ctx
 }
 
 // Guess Pulumi URN from ConstructRequest.

--- a/pkg/providerserver/panic_recovering_provider_test.go
+++ b/pkg/providerserver/panic_recovering_provider_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"gotest.tools/v3/assert"
 )
@@ -300,6 +301,15 @@ func TestPanicRecoveryByMethod(t *testing.T) {
 			//nolint:lll
 			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=GetMappings): GetMappings panic"),
 		},
+		{
+			testName: "List",
+			send: func(rps pulumirpc.ResourceProviderServer) {
+				err := rps.List(&pulumirpc.ListRequest{}, &testListServerStream{ctx: ctx})
+				contract.IgnoreError(err)
+			},
+			expectURN:     autogold.Expect(urn.URN("")),
+			expectMessage: autogold.Expect("Bridged provider panic (provider=myprov v=1.2.3 method=List): List panic"),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -547,3 +557,33 @@ func (s *testRPS) GetMappings(
 ) (*pulumirpc.GetMappingsResponse, error) {
 	panic("GetMappings panic")
 }
+
+func (s *testRPS) List(
+	req *pulumirpc.ListRequest,
+	stream pulumirpc.ResourceProvider_ListServer,
+) error {
+	panic("List panic")
+}
+
+type testListServerStream struct {
+	ctx context.Context
+}
+
+func (s *testListServerStream) SetHeader(metadata.MD) error { return nil }
+
+func (s *testListServerStream) SendHeader(metadata.MD) error { return nil }
+
+func (s *testListServerStream) SetTrailer(metadata.MD) {}
+
+func (s *testListServerStream) Context() context.Context {
+	if s.ctx != nil {
+		return s.ctx
+	}
+	return context.Background()
+}
+
+func (s *testListServerStream) Send(*pulumirpc.ListResponse) error { return nil }
+
+func (s *testListServerStream) SendMsg(any) error { return nil }
+
+func (s *testListServerStream) RecvMsg(any) error { return nil }

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -41,6 +41,7 @@ import (
 	pulumilog "github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -2036,6 +2037,15 @@ func (p *Provider) GetMapping(
 
 	// An empty response is valid for GetMapping, it means we don't have a mapping for the given key
 	return &pulumirpc.GetMappingResponse{}, nil
+}
+
+func (p *Provider) List(
+	req *pulumirpc.ListRequest,
+	stream grpc.ServerStreamingServer[pulumirpc.ListResponse],
+) error {
+	_ = req
+	_ = stream
+	return status.Error(codes.Unimplemented, "List is not implemented for sdkv2 tfbridge providers")
 }
 
 func initializationError(id string, props *pbstruct.Struct, reasons []string) error {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -805,6 +805,7 @@ type resourceType struct {
 	inprops    []*variable
 	outprops   []*variable
 	reqprops   map[string]bool
+	listprops  []*variable
 	argst      *propertyType // input properties.
 	statet     *propertyType // output properties (all optional).
 	schema     shim.Resource
@@ -1038,6 +1039,23 @@ func (g *Generator) debug(f string, args ...interface{}) {
 
 func (g *Generator) provider() shim.Provider {
 	return g.info.P
+}
+
+type listResourceProvider interface {
+	ListResourcesMap() shim.ResourceMap
+}
+
+func (g *Generator) listResourceSchema(rawname string) (shim.Resource, bool) {
+	provider, ok := g.provider().(listResourceProvider)
+	if !ok {
+		return nil, false
+	}
+
+	resources := provider.ListResourcesMap()
+	if resources == nil {
+		return nil, false
+	}
+	return resources.GetOk(rawname)
 }
 
 type GenerateOptions struct {
@@ -1545,6 +1563,37 @@ func (g *Generator) gatherResource(rawname string,
 		if stateVar != nil {
 			stateVar.opt = true
 			stateVars = append(stateVars, stateVar)
+		}
+	}
+
+	if !isProvider {
+		if listSchema, ok := g.listResourceSchema(rawname); ok {
+			res.listprops = []*variable{}
+			for _, key := range stableSchemas(listSchema.Schema()) {
+				propschema := listSchema.Schema().Get(key)
+				if propschema.Removed() != "" {
+					continue
+				}
+
+				propinfo := info.Fields[key]
+				if !input(propschema, propinfo) {
+					continue
+				}
+
+				rawdoc := reformatText(infoContext{
+					language: g.language,
+					pkg:      g.pkg,
+					info:     g.info,
+				}, propschema.Description(), nil)
+				listprop, err := g.propertyVariable(resourcePath.ListInputs(),
+					key, listSchema.Schema(), info.Fields, rawdoc, rawdoc, false /*out*/, entityDocs)
+				if err != nil {
+					return nil, err
+				}
+				if listprop != nil {
+					res.listprops = append(res.listprops, listprop)
+				}
+			}
 		}
 	}
 

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -98,6 +98,7 @@ func (nt *schemaNestedTypes) gatherFromMember(member moduleMember) {
 		p := member.resourcePath
 		nt.gatherFromProperties(p.Inputs(), member, member.name, member.inprops, true)
 		nt.gatherFromProperties(p.Outputs(), member, member.name, member.outprops, false)
+		nt.gatherFromProperties(p.ListInputs(), member, member.name, member.listprops, true)
 		if !member.IsProvider() {
 			nt.gatherFromProperties(p.State(), member, member.name, member.statet.properties, true)
 		}
@@ -860,6 +861,21 @@ func (g *schemaGenerator) genResourceType(mod tokens.Module, res *resourceType) 
 			typePaths: paths.SingletonTypePathSet(stateTypePath),
 		}, true)
 		spec.StateInputs = &stateInputs
+	}
+
+	// If the resources supports listing we'll have set listprops to non-nil, and we need to correspondingly populate
+	// the ListInputs section of the schema. Note that there might not actually be _any_ properties.
+	if res.listprops != nil {
+		spec.ListInputs = &pschema.ObjectTypeSpec{
+			Type:       "object",
+			Properties: map[string]pschema.PropertySpec{},
+		}
+		for _, prop := range res.listprops {
+			spec.ListInputs.Properties[prop.name] = g.genProperty(prop)
+			if !prop.optional() {
+				spec.ListInputs.Required = append(spec.ListInputs.Required, prop.name)
+			}
+		}
 	}
 
 	for _, a := range res.info.Aliases {

--- a/pkg/tfgen/internal/paths/paths.go
+++ b/pkg/tfgen/internal/paths/paths.go
@@ -95,6 +95,13 @@ func (p *ResourcePath) State() *ResourceMemberPath {
 	}
 }
 
+func (p *ResourcePath) ListInputs() *ResourceMemberPath {
+	return &ResourceMemberPath{
+		ResourcePath:       p,
+		ResourceMemberKind: ResourceListInputs,
+	}
+}
+
 func (p *ResourcePath) String() string {
 	if p.isProvider {
 		return fmt.Sprintf("resource[provider=%q]", p.token.String())
@@ -110,6 +117,7 @@ const (
 	ResourceInputs ResourceMemberKind = iota
 	ResourceOutputs
 	ResourceState
+	ResourceListInputs
 )
 
 func (s ResourceMemberKind) String() string {
@@ -120,6 +128,8 @@ func (s ResourceMemberKind) String() string {
 		return "outputs"
 	case ResourceState:
 		return "state"
+	case ResourceListInputs:
+		return "listInputs"
 	}
 	return "unknown"
 }

--- a/pkg/x/muxer/muxer.go
+++ b/pkg/x/muxer/muxer.go
@@ -418,6 +418,17 @@ func (m *muxer) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*empt
 	})
 }
 
+func (m *muxer) List(
+	req *pulumirpc.ListRequest,
+	stream pulumirpc.ResourceProvider_ListServer,
+) error {
+	server := m.getResource(req.GetToken())
+	if server == nil {
+		return status.Errorf(codes.NotFound, "Resource type '%s' not found.", req.GetToken())
+	}
+	return server.List(req, stream)
+}
+
 func (m *muxer) Construct(ctx context.Context, req *pulumirpc.ConstructRequest) (*pulumirpc.ConstructResponse, error) {
 	server := m.getResource(req.GetType())
 	if server == nil {

--- a/pkg/x/muxer/tests/muxer_test.go
+++ b/pkg/x/muxer/tests/muxer_test.go
@@ -68,6 +68,40 @@ func TestSimpleDispatch(t *testing.T) {
 	)
 }
 
+func TestListDispatch(t *testing.T) {
+	t.Parallel()
+	var m muxer.DispatchTable
+	m.Resources = map[string]int{
+		"test:mod:A": 0,
+		"test:mod:B": 1,
+	}
+
+	muxedServer := buildMux(t, m, nil,
+		&server{t: t},
+		&server{t: t, calls: []call{
+			{
+				incoming: `{
+					"token": "test:mod:B",
+					"pageSize": "10"
+				}`,
+				response: `{
+					"result": {
+						"id": "listed-resource"
+					}
+				}`,
+			},
+		}},
+	)
+	stream := &listStream{ctx: context.Background()}
+	err := muxedServer.List(&pulumirpc.ListRequest{
+		Token:    "test:mod:B",
+		PageSize: 10,
+	}, stream)
+	require.NoError(t, err)
+	require.Len(t, stream.responses, 1)
+	assert.Equal(t, "listed-resource", stream.responses[0].GetResult().GetId())
+}
+
 func TestCheckConfigErrorNotDuplicated(t *testing.T) {
 	t.Parallel()
 	var m muxer.DispatchTable
@@ -480,6 +514,17 @@ func (m *server) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*emp
 	return handleMethod[*pulumirpc.DeleteRequest, *emptypb.Empty](m, req)
 }
 
+func (m *server) List(
+	req *pulumirpc.ListRequest,
+	stream pulumirpc.ResourceProvider_ListServer,
+) error {
+	response, err := handleMethod[*pulumirpc.ListRequest, *pulumirpc.ListResponse](m, req)
+	if err != nil {
+		return err
+	}
+	return stream.Send(response)
+}
+
 func (m *server) Construct(ctx context.Context, req *pulumirpc.ConstructRequest) (*pulumirpc.ConstructResponse, error) {
 	return handleMethod[*pulumirpc.ConstructRequest, *pulumirpc.ConstructResponse](m, req)
 }
@@ -500,4 +545,20 @@ func (m *server) GetMapping(
 	ctx context.Context, req *pulumirpc.GetMappingRequest,
 ) (*pulumirpc.GetMappingResponse, error) {
 	return handleMethod[*pulumirpc.GetMappingRequest, *pulumirpc.GetMappingResponse](m, req)
+}
+
+type listStream struct {
+	pulumirpc.ResourceProvider_ListServer
+
+	ctx       context.Context
+	responses []*pulumirpc.ListResponse
+}
+
+func (s *listStream) Send(response *pulumirpc.ListResponse) error {
+	s.responses = append(s.responses, response)
+	return nil
+}
+
+func (s *listStream) Context() context.Context {
+	return s.ctx
 }


### PR DESCRIPTION
## Summary

This PR defines and implements the first coherent bridge slice for Terraform protocol list resources exposed through Pulumi `List`.

The checked-in specs document the end-state contract, the staged rollout plan, and the identity/import tradeoffs:

- `docs/specs/terraform-list-runtime-semantics.md` defines the target bridge semantics.
- `docs/specs/terraform-list-runtime-rollout.md` tracks the Phase 1 implementation boundary and remaining phases.
- `docs/specs/terraform-list-identity-review.md` explains why Terraform list identity data, Pulumi state IDs, and Terraform import strings are related but not equivalent.

The implementation in this PR lands Phase 1 for Plugin Framework-owned list resources, including the normal muxed-provider path used by providers such as `pulumi-aws`.

## High-Level Decisions

- Use Terraform list resource config schemas as the source of truth for Pulumi `listInputs`; do not infer listability from managed resource schemas.
- Fail closed for unsupported resources instead of exposing partial or guessed list behavior.
- Preserve Pulumi unknowns in list queries. A query containing unknowns returns a computed list result without calling Terraform validation or list.
- Validate concrete list config with Terraform before exposing any continuation session.
- Request Terraform resource objects with `IncludeResource: true`.
- Use a concrete top-level resource object `id` when Terraform returns one.
- Otherwise derive deterministic Pulumi-owned list result IDs from Terraform identity data: prefer `id`, then a single identity value, then sorted comma-joined compound identity values.
- Treat identity-derived IDs as useful list result IDs, not proof that Terraform string import accepts the same value.
- Bound provider-side buffering for unbounded Pulumi limits and clean up list sessions on terminal errors, send failures, close, and TTL expiry.
- Route muxed `List` calls through the existing resource dispatch table for resources already owned by the PF subprovider.

## What Changed

- Added PF list resource schema discovery and `listInputs` generation.
- Added PF runtime `ListWithContext` support with query conversion, validation, pagination, continuation-token validation, result conversion, cancellation, and session cleanup.
- Added panic recovery for the streaming `List` RPC.
- Added mux forwarding for PF-owned list resources.
- Added focused coverage for schema generation, runtime list behavior, session lifecycle, panic recovery, and mux dispatch.
- Built on the earlier list work in #3440 and aligned it with the specs added here.

## Deferred

This PR intentionally does not complete the full end-state spec.

Deferred follow-up work includes:

- List-specific mux schema and dispatch metadata for resources whose CRUD owner and list owner differ.
- SDKv2-owned resources whose Terraform list implementation is exposed through a Plugin Framework sidecar.
- Identity-aware `Read` / import using Terraform structured identity instead of string import IDs.
- Any claim that identity-derived list result IDs are guaranteed Terraform import strings.

Unsupported cases should continue to fail closed until those phases land.

## Testing

- `mise exec -- go test -count=1 ./pkg/pf/internal/schemashim ./pkg/pf/tfgen ./pkg/pf/tfbridge -run 'Test.*List|Test.*ListResource|TestIdentityDataToID|TestPropertyMapIDUsesConcreteTopLevelID'`
- `mise exec -- go test -count=1 ./pkg/providerserver -run TestPanicRecoveryByMethod`
- `mise exec -- go test -count=1 ./pkg/x/muxer/... -run 'TestListDispatch|TestSimpleDispatch'`
- `git diff --check`

Also manually tested with a local checkout of pulumi-aws.

fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/3444

Co-authored-by: Fraser Waters <fraser@pulumi.com>