### PR TITLE
Route List RPCs by list owner

### DIFF
--- a/docs/specs/terraform-list-runtime-rollout.md
+++ b/docs/specs/terraform-list-runtime-rollout.md
@@ -138,6 +138,8 @@ git diff --check origin/main..HEAD
 Goal: represent list-resource ownership separately from managed-resource CRUD
 ownership.
 
+Status: implemented on branch `list-runtime-sdkv2`.
+
 Required work:
 
 - Extend PF mux schema discovery to carry list-resource maps from each
@@ -160,6 +162,11 @@ Minimum tests:
 Goal: route Pulumi `List` to the subprovider that owns Terraform list support
 when that owner differs from the managed-resource CRUD owner.
 
+Status: implemented on branch `list-runtime-sdkv2` with repo-local mux tests.
+The downstream `pulumi-aws` SDKv2 live proof is staged in
+`provider/list_live_test.go` in the `chall-list-rpc-live-test` worktree and
+requires manual AWS credentials.
+
 Required work:
 
 - Route by list dispatch table, not by managed-resource dispatch.
@@ -173,6 +180,8 @@ Minimum tests:
 - Muxed SDK-backed list resource dispatches to the PF/framework list owner.
 - CRUD dispatch and list dispatch may target different subproviders for the
   same Pulumi resource token.
+- Downstream manual proof: `pulumi-aws` can call `List` for an SDKv2-backed
+  resource exposed through an upstream framework list wrapper.
 
 ## Deferred: Identity-Aware Import Or Read
 
@@ -189,8 +198,6 @@ These are known gaps between the current implementation commits and the
 end-state spec:
 
 - Non-list PF providers can panic during schema-only shim construction.
-- The muxer has no list-owner dispatch table for resources whose CRUD owner and
-  Terraform list owner differ.
 - Identity-only results currently synthesize `identity:` IDs.
 - Continuation tokens are looked up by opaque token only.
 - Query conversion uses `structpb.Struct.AsMap()` and loses Pulumi unknowns.

--- a/pkg/pf/internal/muxer/muxer.go
+++ b/pkg/pf/internal/muxer/muxer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/schemashim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	shimschema "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/x/muxer"
 )
 
@@ -89,6 +90,20 @@ type ProviderShim struct {
 	MuxedProviders []shim.Provider
 }
 
+type listResourceMapProvider interface {
+	ListResourcesMap() shim.ResourceMap
+}
+
+// ListResourcesMap is not part of shim.Provider: plain SDKv2 providers do not
+// expose Terraform protocol list resources, while PF schema-only providers may.
+// Treat providers without this optional method as having no list resources.
+func listResourcesMap(provider shim.Provider) shim.ResourceMap {
+	if provider, ok := provider.(listResourceMapProvider); ok {
+		return provider.ListResourcesMap()
+	}
+	return shimschema.ResourceMap{}
+}
+
 // Check if a Resource is served via in the Plugin Framework.
 func (m *ProviderShim) ResourceIsPF(token string) bool {
 	// In an augmented shim.Provider, underlying providers are PF providers iff they
@@ -125,8 +140,10 @@ func (m *ProviderShim) extend(provider shim.Provider) ([]string, []string) {
 	conflictingResources := res.ConflictingKeys()
 	data := newUnionMap(m.dataSources, provider.DataSourcesMap())
 	conflictingDataSources := data.ConflictingKeys()
+	listResources := newUnionMap(m.listResources, listResourcesMap(provider))
 	m.resources = res
 	m.dataSources = data
+	m.listResources = listResources
 	m.MuxedProviders = append(m.MuxedProviders, provider)
 	return conflictingResources, conflictingDataSources
 }
@@ -134,9 +151,10 @@ func (m *ProviderShim) extend(provider shim.Provider) ([]string, []string) {
 func newProviderShim(provider shim.Provider) ProviderShim {
 	return ProviderShim{
 		simpleSchemaProvider: simpleSchemaProvider{
-			schema:      provider.Schema(),
-			resources:   provider.ResourcesMap(),
-			dataSources: provider.DataSourcesMap(),
+			schema:        provider.Schema(),
+			resources:     provider.ResourcesMap(),
+			dataSources:   provider.DataSourcesMap(),
+			listResources: listResourcesMap(provider),
 		},
 		MuxedProviders: []shim.Provider{provider},
 	}
@@ -151,29 +169,34 @@ func (m *ProviderShim) ResolveDispatch(info *tfbridge.ProviderInfo) (muxer.Dispa
 	var dispatch muxer.DispatchTable
 	dispatch.Resources = map[string]int{}
 	dispatch.Functions = map[string]int{}
+	dispatch.ListResources = map[string]int{}
 
 	unbackedResources := resolveDispatchMap(m, dispatch.Resources, info.Resources,
 		func(p shim.Provider) shim.ResourceMap { return p.ResourcesMap() })
 	unbackedDatasources := resolveDispatchMap(m, dispatch.Functions, info.DataSources,
 		func(p shim.Provider) shim.ResourceMap { return p.DataSourcesMap() })
+	// List ownership is intentionally separate from CRUD ownership. Muxed providers
+	// can expose a Terraform list resource from a PF sidecar for an SDKv2 CRUD resource.
+	unbackedListResources := resolveDispatchMap(m, dispatch.ListResources, info.Resources, listResourcesMap)
 	joinErr := func(label string, tks []string) error {
 		return fmt.Errorf("%s without backing provider:\n- %s",
 			label, strings.Join(tks, "\n- "))
 	}
 
-	switch {
-	case len(unbackedResources) == 0 && len(unbackedDatasources) == 0:
-		return dispatch, nil
-	case len(unbackedResources) == 0:
-		return dispatch, joinErr("DataSources", unbackedDatasources)
-	case len(unbackedDatasources) == 0:
-		return dispatch, joinErr("Resources", unbackedResources)
-	default:
-		return dispatch, multierror.Append(
-			joinErr("Resources", unbackedResources),
-			joinErr("DataSources", unbackedDatasources),
-		)
+	var errs multierror.Error
+	if len(unbackedResources) > 0 {
+		errs.Errors = append(errs.Errors, joinErr("Resources", unbackedResources))
 	}
+	if len(unbackedDatasources) > 0 {
+		errs.Errors = append(errs.Errors, joinErr("DataSources", unbackedDatasources))
+	}
+	if len(unbackedListResources) > 0 {
+		errs.Errors = append(errs.Errors, joinErr("ListResources", unbackedListResources))
+	}
+	if len(errs.Errors) > 0 {
+		return dispatch, &errs
+	}
+	return dispatch, nil
 }
 
 // Resolve either resources or datasoruces into their originating providers.
@@ -234,9 +257,10 @@ func resolveDispatchMap[T interface{ GetTok() tokens.Token }](
 
 type simpleSchemaProvider struct {
 	schemashim.SchemaOnlyProvider
-	schema      shim.SchemaMap
-	resources   shim.ResourceMap
-	dataSources shim.ResourceMap
+	schema        shim.SchemaMap
+	resources     shim.ResourceMap
+	dataSources   shim.ResourceMap
+	listResources shim.ResourceMap
 }
 
 func (p *simpleSchemaProvider) Schema() shim.SchemaMap {
@@ -249,6 +273,10 @@ func (p *simpleSchemaProvider) ResourcesMap() shim.ResourceMap {
 
 func (p *simpleSchemaProvider) DataSourcesMap() shim.ResourceMap {
 	return p.dataSources
+}
+
+func (p *simpleSchemaProvider) ListResourcesMap() shim.ResourceMap {
+	return p.listResources
 }
 
 var _ shim.Provider = (*simpleSchemaProvider)(nil)

--- a/pkg/pf/tfbridge/main.go
+++ b/pkg/pf/tfbridge/main.go
@@ -31,6 +31,8 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf"
 	pfmuxer "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/muxer"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	shimschema "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/x/muxer"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 )
@@ -172,7 +174,10 @@ func MakeMuxedServer(
 				m.Servers = append(m.Servers, muxer.Endpoint{
 					Server: func(host *rprovider.HostClient) (pulumirpc.ResourceProviderServer, error) {
 						infoCopy := info
-						infoCopy.P = prov
+						infoCopy.P = muxedPFSchemaProvider{
+							ShimProvider:   prov.(pf.ShimProvider),
+							schemaProvider: shim,
+						}
 
 						// https://github.com/pulumi/pulumi-terraform-bridge/issues/2697:
 						// Avoid accidentally casting (*rprovider.HostClient)(nil) to
@@ -195,4 +200,27 @@ func MakeMuxedServer(
 		}
 		return m.Server(host, pkg, version)
 	}
+}
+
+type listResourceSchemaProvider interface {
+	ListResourcesMap() shim.ResourceMap
+}
+
+type muxedPFSchemaProvider struct {
+	pf.ShimProvider
+	schemaProvider shim.Provider
+}
+
+func (p muxedPFSchemaProvider) ResourcesMap() shim.ResourceMap {
+	// A PF list sidecar can list resources whose CRUD schema is owned by another
+	// provider in the mux. Keep runtime RPCs on the PF sidecar, but expose the
+	// merged schema map so list result decoding can use the CRUD resource schema.
+	return p.schemaProvider.ResourcesMap()
+}
+
+func (p muxedPFSchemaProvider) ListResourcesMap() shim.ResourceMap {
+	if provider, ok := p.schemaProvider.(listResourceSchemaProvider); ok {
+		return provider.ListResourcesMap()
+	}
+	return shimschema.ResourceMap{}
 }

--- a/pkg/pf/tfbridge/provider_list.go
+++ b/pkg/pf/tfbridge/provider_list.go
@@ -321,12 +321,11 @@ func (p *provider) listResourceHandle(
 	token tokens.Type,
 ) (resourceHandle, tftypes.Object, error) {
 	rt := runtypes.TypeOrRenamedEntityName(tfNameOrRenamedEntity)
-	if !p.resources.Has(rt) {
+	schema, ok := p.listResultResourceSchema(rt)
+	if !ok {
 		return resourceHandle{}, tftypes.Object{},
 			fmt.Errorf("[pf/tfbridge] unknown resource type: %q", tfNameOrRenamedEntity)
 	}
-
-	schema := p.resources.Schema(rt)
 	objectType, ok := schema.Type(ctx).(tftypes.Object)
 	if !ok {
 		return resourceHandle{}, tftypes.Object{},
@@ -349,6 +348,62 @@ func (p *provider) listResourceHandle(
 	}
 
 	return rh, objectType, nil
+}
+
+func (p *provider) listResultResourceSchema(
+	rt runtypes.TypeOrRenamedEntityName,
+) (runtypes.Schema, bool) {
+	if p.resources != nil && p.resources.Has(rt) {
+		return p.resources.Schema(rt), true
+	}
+
+	// Muxed list providers may serve only the Terraform ListResource RPC while
+	// the corresponding CRUD resource schema comes from another provider.
+	resource, ok := p.schemaOnlyProvider.ResourcesMap().GetOk(string(rt))
+	if !ok {
+		return nil, false
+	}
+	return shimResourceSchema{
+		name:     runtypes.TypeName(rt),
+		resource: resource,
+	}, true
+}
+
+type shimResourceSchema struct {
+	name     runtypes.TypeName
+	resource shim.Resource
+}
+
+var _ runtypes.Schema = shimResourceSchema{}
+
+func (s shimResourceSchema) ApplyTerraform5AttributePathStep(
+	step tftypes.AttributePathStep,
+) (interface{}, error) {
+	return s.Type(context.Background()).(tftypes.Object).ApplyTerraform5AttributePathStep(step)
+}
+
+func (s shimResourceSchema) Type(context.Context) tftypes.Type {
+	return convert.InferObjectType(s.resource.Schema(), nil)
+}
+
+func (s shimResourceSchema) ResourceSchemaVersion() int64 {
+	return int64(s.resource.SchemaVersion())
+}
+
+func (s shimResourceSchema) Shim() shim.SchemaMap {
+	return s.resource.Schema()
+}
+
+func (s shimResourceSchema) DeprecationMessage() string {
+	return s.resource.DeprecationMessage()
+}
+
+func (s shimResourceSchema) ResourceProtoSchema(context.Context) (*tfprotov6.Schema, error) {
+	return nil, nil
+}
+
+func (s shimResourceSchema) TFName() runtypes.TypeName {
+	return s.name
 }
 
 func (p *provider) listConfigSchema(ctx context.Context, tfResourceName string) (*tfprotov6.Schema, error) {

--- a/pkg/pf/tfbridge/provider_list_test.go
+++ b/pkg/pf/tfbridge/provider_list_test.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/convert"
+	bridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 )
@@ -390,6 +391,56 @@ func TestPopulateListSessionIntegration(t *testing.T) {
 	assert.Equal(t, token, cont)
 	require.NotNil(t, caller.listRequest)
 	assert.True(t, caller.listRequest.IncludeResource)
+}
+
+func TestListResourceHandleUsesSchemaOnlyResourceSchema(t *testing.T) {
+	t.Parallel()
+
+	resourceSchema := schema.SchemaMap{
+		"id":   (&schema.Schema{Type: shim.TypeString, Computed: true}).Shim(),
+		"name": (&schema.Schema{Type: shim.TypeString, Computed: true}).Shim(),
+	}
+	schemaProvider := (&schema.Provider{
+		ResourcesMap: schema.ResourceMap{
+			"test_resource": (&schema.Resource{Schema: resourceSchema}).Shim(),
+		},
+	}).Shim()
+	info := bridge.ProviderInfo{
+		Resources: map[string]*bridge.ResourceInfo{
+			"test_resource": {Tok: "test:index:Resource"},
+		},
+	}
+	p := &provider{
+		info:               info,
+		schemaOnlyProvider: schemaProvider,
+		encoding:           convert.NewEncoding(schemaProvider, &info),
+	}
+
+	rh, objectType, err := p.listResourceHandle(context.Background(), "test_resource", "test:index:Resource")
+	require.NoError(t, err)
+	assert.Equal(t, "test_resource", rh.terraformResourceName)
+	assert.Contains(t, objectType.AttributeTypes, "id")
+	assert.Contains(t, objectType.AttributeTypes, "name")
+
+	resourceValue := tftypes.NewValue(objectType, map[string]tftypes.Value{
+		"id":   tftypes.NewValue(tftypes.String, "resource-id"),
+		"name": tftypes.NewValue(tftypes.String, "resource-name"),
+	})
+	resourceDV, err := tfprotov6.NewDynamicValue(objectType, resourceValue)
+	require.NoError(t, err)
+
+	item, err := p.convertListResult(
+		context.Background(),
+		rh,
+		objectType,
+		func(context.Context) (*tfprotov6.ResourceIdentitySchema, error) {
+			return nil, errors.New("identity schema should not be loaded")
+		},
+		tfprotov6.ListResourceResult{DisplayName: "display-name", Resource: &resourceDV},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "resource-id", item.Id)
+	assert.Equal(t, "display-name", item.Name)
 }
 
 func TestConvertListResultSkipsIdentitySchemaWhenResourceIDPresent(t *testing.T) {

--- a/pkg/pf/tfgen/tfgen_test.go
+++ b/pkg/pf/tfgen/tfgen_test.go
@@ -32,12 +32,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hexops/autogold/v2"
 	puschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema" //nolint:importas
 	"github.com/stretchr/testify/require"
 
+	pfmuxer "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/muxer"
 	pftfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	sdkv2shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 )
 
 // Regressing an issue with AWS provider not recognizing that assume_role config setting is singular via
@@ -197,6 +200,61 @@ func TestListInputs(t *testing.T) {
 	require.Equal(t, []string{"parentId"}, resource.ListInputs.Required)
 	require.Contains(t, resource.ListInputs.Properties, "parentId")
 	require.Contains(t, resource.ListInputs.Properties, "prefix")
+}
+
+func TestListInputsForSDKv2ResourceFromPFListResource(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	sdkProvider := &sdkschema.Provider{
+		Schema: map[string]*sdkschema.Schema{},
+		ResourcesMap: map[string]*sdkschema.Resource{
+			"test_thing": {
+				Schema: map[string]*sdkschema.Schema{
+					"id": {
+						Type:     sdkschema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+	pfListProvider := &schemaTestProvider{
+		lists: map[string]lschema.Schema{
+			"thing": {
+				Attributes: map[string]lschema.Attribute{
+					"parent_id": lschema.StringAttribute{Required: true},
+				},
+			},
+		},
+	}
+	providerInfo := tfbridge.ProviderInfo{
+		Name: "testprovider",
+		P: pftfbridge.MuxShimWithPF(ctx,
+			sdkv2shim.NewProvider(sdkProvider),
+			pfListProvider),
+		Resources: map[string]*tfbridge.ResourceInfo{
+			"test_thing": {
+				Tok: "testprovider:index:Thing",
+			},
+		},
+	}
+
+	res, err := GenerateSchema(ctx, GenerateSchemaOptions{
+		ProviderInfo:  providerInfo,
+		XInMemoryDocs: true,
+	})
+	require.NoError(t, err)
+
+	var schema puschema.PackageSpec
+	require.NoError(t, json.Unmarshal(res.ProviderMetadata.PackageSchema, &schema))
+	require.NotNil(t, schema.Resources["testprovider:index:Thing"].ListInputs)
+	require.Contains(t, schema.Resources["testprovider:index:Thing"].ListInputs.Properties, "parentId")
+
+	dispatch, err := providerInfo.P.(*pfmuxer.ProviderShim).ResolveDispatch(&providerInfo)
+	require.NoError(t, err)
+	require.Equal(t, 0, dispatch.Resources["testprovider:index:Thing"])
+	require.Equal(t, 1, dispatch.ListResources["testprovider:index:Thing"])
 }
 
 func TestListInputsEmptySchema(t *testing.T) {

--- a/pkg/x/muxer/mapping.go
+++ b/pkg/x/muxer/mapping.go
@@ -67,18 +67,23 @@ type dispatchTable struct {
 	// Resources and functions can only map to a single provider
 	Resources map[string]int `json:"resources"`
 	Functions map[string]int `json:"functions"`
+	// ListResources can differ from Resources for muxed providers where CRUD is
+	// SDKv2-backed but Terraform ListResource is exposed by a PF sidecar.
+	ListResources map[string]int `json:"listResources,omitempty"`
 }
 
 func newDispatchTable() dispatchTable {
 	return dispatchTable{
-		Resources: make(map[string]int),
-		Functions: make(map[string]int),
+		Resources:     make(map[string]int),
+		Functions:     make(map[string]int),
+		ListResources: make(map[string]int),
 	}
 }
 
 func (dispatchTable dispatchTable) isEmpty() bool {
 	return dispatchTable.Resources == nil &&
-		dispatchTable.Functions == nil
+		dispatchTable.Functions == nil &&
+		dispatchTable.ListResources == nil
 }
 
 // Layer `srcSchema` under `dstSchema`, keeping track of where resources and functions
@@ -194,6 +199,9 @@ type dispatchTableCtx struct {
 
 func (m *dispatchTableCtx) setResource(token string, resource schema.ResourceSpec) {
 	m.dispatchTable.Resources[token] = m.srcIndex
+	if resource.ListInputs != nil {
+		m.dispatchTable.ListResources[token] = m.srcIndex
+	}
 
 	m.dstSchema.Resources[token] = resource
 	m.addProperties(resource.InputProperties)

--- a/pkg/x/muxer/mapping_test.go
+++ b/pkg/x/muxer/mapping_test.go
@@ -163,6 +163,35 @@ func TestMergeSchemasAndComputeDispatchTable(t *testing.T) {
 			"pkg:mod:ResA": 0,
 			"pkg:mod:ResB": 1,
 		},
-		Functions: map[string]int{},
+		Functions:     map[string]int{},
+		ListResources: map[string]int{},
 	}, computedDT.dispatchTable)
+}
+
+func TestMergeSchemasAndComputeDispatchTableRecordsListOwner(t *testing.T) {
+	t.Parallel()
+
+	schemas := []schema.PackageSpec{
+		{
+			Name: "pkg",
+			Resources: map[string]schema.ResourceSpec{
+				"pkg:mod:ResA": {},
+			},
+		},
+		{
+			Name: "pkg",
+			Resources: map[string]schema.ResourceSpec{
+				"pkg:mod:ResB": {
+					ListInputs: &schema.ObjectTypeSpec{Type: "object"},
+				},
+			},
+		},
+	}
+
+	computedDT, _, err := MergeSchemasAndComputeDispatchTable(schemas)
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]int{
+		"pkg:mod:ResB": 1,
+	}, computedDT.dispatchTable.ListResources)
 }

--- a/pkg/x/muxer/muxer.go
+++ b/pkg/x/muxer/muxer.go
@@ -117,6 +117,18 @@ func (m *muxer) getResource(token string) server {
 	return m.servers[i]
 }
 
+func (m *muxer) getListResource(token string) server {
+	if m.dispatchTable.ListResources == nil {
+		return m.getResource(token)
+	}
+
+	i, ok := m.dispatchTable.ListResources[token]
+	if !ok {
+		return nil
+	}
+	return m.servers[i]
+}
+
 func (m *muxer) GetSchema(ctx context.Context, req *pulumirpc.GetSchemaRequest) (*pulumirpc.GetSchemaResponse, error) {
 	if req.Version != SchemaVersion {
 		return nil, fmt.Errorf("Expected schema version %d, got %d",
@@ -422,9 +434,9 @@ func (m *muxer) List(
 	req *pulumirpc.ListRequest,
 	stream pulumirpc.ResourceProvider_ListServer,
 ) error {
-	server := m.getResource(req.GetToken())
+	server := m.getListResource(req.GetToken())
 	if server == nil {
-		return status.Errorf(codes.NotFound, "Resource type '%s' not found.", req.GetToken())
+		return status.Errorf(codes.Unimplemented, "Resource type '%s' is not listable.", req.GetToken())
 	}
 	return server.List(req, stream)
 }

--- a/pkg/x/muxer/tests/muxer_test.go
+++ b/pkg/x/muxer/tests/muxer_test.go
@@ -102,6 +102,60 @@ func TestListDispatch(t *testing.T) {
 	assert.Equal(t, "listed-resource", stream.responses[0].GetResult().GetId())
 }
 
+func TestListDispatchUsesListOwner(t *testing.T) {
+	t.Parallel()
+	var m muxer.DispatchTable
+	m.Resources = map[string]int{
+		"test:mod:A": 0,
+	}
+	m.ListResources = map[string]int{
+		"test:mod:A": 1,
+	}
+
+	muxedServer := buildMux(t, m, nil,
+		&server{t: t},
+		&server{t: t, calls: []call{
+			{
+				incoming: `{
+					"token": "test:mod:A",
+					"pageSize": "10"
+				}`,
+				response: `{
+					"result": {
+						"id": "listed-resource"
+					}
+				}`,
+			},
+		}},
+	)
+	stream := &listStream{ctx: context.Background()}
+	err := muxedServer.List(&pulumirpc.ListRequest{
+		Token:    "test:mod:A",
+		PageSize: 10,
+	}, stream)
+	require.NoError(t, err)
+	require.Len(t, stream.responses, 1)
+	assert.Equal(t, "listed-resource", stream.responses[0].GetResult().GetId())
+}
+
+func TestListDispatchRejectsUnlistableResource(t *testing.T) {
+	t.Parallel()
+	var m muxer.DispatchTable
+	m.Resources = map[string]int{
+		"test:mod:A": 0,
+	}
+	m.ListResources = map[string]int{}
+
+	muxedServer := buildMux(t, m, nil, &server{t: t})
+	stream := &listStream{ctx: context.Background()}
+	err := muxedServer.List(&pulumirpc.ListRequest{
+		Token:    "test:mod:A",
+		PageSize: 10,
+	}, stream)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not listable")
+}
+
 func TestCheckConfigErrorNotDuplicated(t *testing.T) {
 	t.Parallel()
 	var m muxer.DispatchTable


### PR DESCRIPTION
## Summary
- Add list-resource ownership to mux dispatch metadata, separate from CRUD/resource ownership.
- Expose PF-sidecar list schemas through the augmented shim so SDKv2 CRUD resources can still get `listInputs` when Terraform list support lives in PF.
- Dispatch Pulumi `List` by list owner and keep unlistable SDKv2-only resources failing closed.

## Testing
- `mise exec -- go test -count=1 ./pkg/x/muxer/... -run 'TestListDispatch|TestMergeSchemasAndComputeDispatchTable'`
- `mise exec -- go test -count=1 ./pkg/pf/tfgen -run TestListInputsForSDKv2ResourceFromPFListResource`
- `mise exec -- go test -count=1 ./pkg/pf/tests -run 'TestMuxedGetMapping|TestPFGetMapping|TestRenameResourceWithAliasInAugmentedProvider|TestRenameMuxedDataSourceWithAliasInAugmentedProvider|TestMuxed'`
- `mise exec -- go test -count=1 ./pkg/tfgen -run 'TestMiniMuxed'`
- `mise exec -- go test -count=1 ./pkg/pf/internal/muxer ./pkg/pf/tfbridge ./pkg/pf/internal/schemashim -run 'Test.*List|Test.*Dispatch|TestShimSchemaOnlyProviderWithoutListResources'`
- `mise exec -- go test -count=1 ./pkg/pf/internal/muxer`
- `git diff --check`

## Manual Downstream Proof
- Staged a `pulumi-aws` live test for `aws_secretsmanager_secret_version`, an SDKv2-backed resource exposed through an upstream framework list wrapper.
- Not run locally here because it requires AWS credentials.