### PR TITLE
fix: skip auto-named defaults that trigger upstream ConflictsWith

### DIFF
--- a/dynamic/conflicting_test.go
+++ b/dynamic/conflicting_test.go
@@ -50,3 +50,35 @@ func TestConflictsWithNamePrefixOnly(t *testing.T) {
 		require.NotNil(t, resp)
 	})
 }
+
+// When the user explicitly supplies both `name` and `name_prefix`, the bridge
+// must surface the upstream ConflictsWith error rather than silently dropping
+// one of the user-provided values.
+func TestConflictsWithBothUserSpecified(t *testing.T) {
+	t.Parallel()
+	helper.Integration(t)
+	skipWindows(t)
+
+	server := parameterizedTestServer(t, conflictsProviderPath)
+
+	const typ = "conflictsprovider:index/logGroup:LogGroup"
+	urn := string(resource.NewURN("test", "test", "", typ, "lg"))
+
+	news := marshal(resource.PropertyMap{
+		"name":       resource.NewProperty("explicit-name"),
+		"namePrefix": resource.NewProperty("example-"),
+	})
+
+	resp, err := server.Check(t.Context(), &pulumirpc.CheckRequest{Urn: urn, News: news})
+	require.NoError(t, err)
+	require.Len(t, resp.Failures, 2,
+		"Check must surface both ConflictsWith failures when the user provides both values")
+
+	reasons := []string{resp.Failures[0].Reason, resp.Failures[1].Reason}
+	assert.Contains(t, reasons,
+		`Conflicting configuration arguments. "name": conflicts with name_prefix.`+
+			` Examine values at 'lg.name'.`)
+	assert.Contains(t, reasons,
+		`Conflicting configuration arguments. "name_prefix": conflicts with name.`+
+			` Examine values at 'lg.namePrefix'.`)
+}

--- a/dynamic/conflicting_test.go
+++ b/dynamic/conflicting_test.go
@@ -1,0 +1,52 @@
+// Reproduces the failure observed when running aws_cloudwatch_log_group
+// through the dynamic (terraform-provider) bridge: a resource that has
+// `name` and `name_prefix` with ConflictsWith fails Create when only
+// `namePrefix` is supplied. Tofu accepts this configuration (it sees only
+// name_prefix); the bridge should as well.
+package main
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	helper "github.com/pulumi/pulumi-terraform-bridge/v3/dynamic/internal/testing"
+)
+
+var conflictsProviderPath = helper.BuildOnce(&globalTempDir,
+	"test/conflictsprovider", "terraform-provider-conflictsprovider")
+
+func TestConflictsWithNamePrefixOnly(t *testing.T) {
+	t.Parallel()
+	helper.Integration(t)
+	skipWindows(t)
+
+	server := parameterizedTestServer(t, conflictsProviderPath)
+
+	const typ = "conflictsprovider:index/logGroup:LogGroup"
+	urn := string(resource.NewURN("test", "test", "", typ, "lg"))
+
+	// User specifies only namePrefix; name is intentionally omitted (the
+	// equivalent of HCL `name_prefix = "x"` with `name` unset).
+	news := marshal(resource.PropertyMap{
+		"namePrefix": resource.NewProperty("example-"),
+	})
+
+	t.Run("check", func(t *testing.T) {
+		resp, err := server.Check(t.Context(), &pulumirpc.CheckRequest{Urn: urn, News: news})
+		require.NoError(t, err)
+		assert.Empty(t, resp.Failures, "Check should not fail validation")
+	})
+
+	t.Run("create", func(t *testing.T) {
+		resp, err := server.Create(t.Context(), &pulumirpc.CreateRequest{
+			Urn: urn, Properties: news,
+		})
+		require.NoErrorf(t, err,
+			"Create with only namePrefix should succeed (tofu accepts it); got: %v", err)
+		require.NotNil(t, resp)
+	})
+}

--- a/dynamic/provider_test.go
+++ b/dynamic/provider_test.go
@@ -54,7 +54,7 @@ func TestStacktraceDisplayed(t *testing.T) {
 	skipWindows(t)
 
 	ctx := context.Background()
-	grpc := parameterizedTestServer(ctx, t, pfProviderPath)
+	grpc := parameterizedTestServer(t, pfProviderPath)
 
 	_, err := grpc.Create(ctx, &pulumirpc.CreateRequest{
 		Urn: string(resource.NewURN(
@@ -385,10 +385,10 @@ func grpcTestServer(ctx context.Context, t *testing.T) pulumirpc.ResourceProvide
 }
 
 func parameterizedTestServer(
-	ctx context.Context, t *testing.T,
+	t *testing.T,
 	pathHelper func(t *testing.T) string,
 ) pulumirpc.ResourceProviderServer {
-	grpc := grpcTestServer(ctx, t)
+	grpc := grpcTestServer(t.Context(), t)
 	t.Run("parameterize", assertGRPCCall(grpc.Parameterize, &pulumirpc.ParameterizeRequest{
 		Parameters: &pulumirpc.ParameterizeRequest_Args{
 			Args: &pulumirpc.ParameterizeRequest_ParametersArgs{
@@ -757,9 +757,7 @@ func TestSDKv1Provider(t *testing.T) {
 	helper.Integration(t)
 	skipWindows(t)
 
-	ctx := context.Background()
-
-	server := parameterizedTestServer(ctx, t, sdkv1ProviderPath)
+	server := parameterizedTestServer(t, sdkv1ProviderPath)
 
 	const typ = "sdkv1:index/res:Res"
 	urn := string(resource.NewURN(

--- a/dynamic/test/conflictsprovider/main.go
+++ b/dynamic/test/conflictsprovider/main.go
@@ -1,0 +1,53 @@
+// Package main is a tiny SDKv2 TF provider used by dynamic-bridge tests to
+// reproduce the aws_cloudwatch_log_group `name` / `name_prefix`
+// ConflictsWith pattern.
+package main
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+)
+
+func provider() *schema.Provider {
+	return &schema.Provider{
+		ResourcesMap: map[string]*schema.Resource{
+			// log_group mirrors aws_cloudwatch_log_group's name / name_prefix
+			// shape — both optional+computed and mutually exclusive via
+			// ConflictsWith.
+			"conflictsprovider_log_group": {
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:          schema.TypeString,
+						Optional:      true,
+						Computed:      true,
+						ForceNew:      true,
+						ConflictsWith: []string{"name_prefix"},
+					},
+					"name_prefix": {
+						Type:          schema.TypeString,
+						Optional:      true,
+						Computed:      true,
+						ForceNew:      true,
+						ConflictsWith: []string{"name"},
+					},
+				},
+				CreateContext: func(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+					d.SetId("log-group-id")
+					return nil
+				},
+				ReadContext:   func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				UpdateContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+				DeleteContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics { return nil },
+			},
+		},
+	}
+}
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: provider,
+	})
+}

--- a/dynamic/testdata/TestConflictsWithBothUserSpecified/parameterize.golden
+++ b/dynamic/testdata/TestConflictsWithBothUserSpecified/parameterize.golden
@@ -1,0 +1,4 @@
+{
+  "name": "conflictsprovider",
+  "version": "0.0.0"
+}

--- a/dynamic/testdata/TestConflictsWithNamePrefixOnly/parameterize.golden
+++ b/dynamic/testdata/TestConflictsWithNamePrefixOnly/parameterize.golden
@@ -1,0 +1,4 @@
+{
+  "name": "conflictsprovider",
+  "version": "0.0.0"
+}

--- a/pkg/pf/tfbridge/provider_check.go
+++ b/pkg/pf/tfbridge/provider_check.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/defaults"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
 // Check validates the given resource inputs from the user program and computes checked inputs that fill out default
@@ -79,10 +80,17 @@ func (p *provider) CheckWithContext(
 		ProviderConfig: p.lastKnownProviderConfig,
 	})
 
-	checkFailures, err := p.validateResourceConfig(ctx, urn, rh, news)
-
 	schemaMap := rh.schemaOnlyShimResource.Schema()
 	schemaInfos := rh.pulumiResourceInfo.GetFields()
+
+	// Identify keys auto-defaulted by ApplyDefaultInfoValues (via AutoName) so we can
+	// roll them back if they trigger upstream ConflictsWith validation. The bridge
+	// cannot read ConflictsWith from the protocol-level schema, so the only way to
+	// learn about a conflict is to call ValidateResourceConfig.
+	autoDefaulted := autoDefaultedKeys(inputs, news, schemaMap, schemaInfos)
+
+	news, checkFailures, err := p.validateResourceConfig(ctx, urn, rh, news, autoDefaulted)
+
 	news = tfbridge.MarkSchemaSecrets(ctx, schemaMap, schemaInfos, resource.NewObjectProperty(news)).ObjectValue()
 
 	if err != nil {
@@ -97,12 +105,13 @@ func (p *provider) validateResourceConfig(
 	urn resource.URN,
 	rh resourceHandle,
 	inputs resource.PropertyMap,
-) ([]plugin.CheckFailure, error) {
+	autoDefaulted map[resource.PropertyKey]bool,
+) (resource.PropertyMap, []plugin.CheckFailure, error) {
 	tfType := rh.schema.Type(ctx).(tftypes.Object)
 
 	encodedInputs, err := convert.EncodePropertyMapToDynamic(rh.encoder, tfType, inputs)
 	if err != nil {
-		return nil, fmt.Errorf("cannot encode resource inputs to call ValidateResourceConfig: %w", err)
+		return inputs, nil, fmt.Errorf("cannot encode resource inputs to call ValidateResourceConfig: %w", err)
 	}
 
 	req := tfprotov6.ValidateResourceConfigRequest{
@@ -115,11 +124,22 @@ func (p *provider) validateResourceConfig(
 
 	resp, err := p.tfServer.ValidateResourceConfig(ctx, &req)
 	if err != nil {
-		return nil, fmt.Errorf("error calling ValidateResourceConfig: %w", err)
+		return inputs, nil, fmt.Errorf("error calling ValidateResourceConfig: %w", err)
 	}
 
 	schemaMap := rh.schemaOnlyShimResource.Schema()
 	schemaInfos := rh.pulumiResourceInfo.GetFields()
+
+	// If any ConflictsWith failure targets a property we auto-defaulted (e.g. an
+	// AutoName injected `name`), drop it from the inputs and re-validate once.
+	// The bridge cannot see ConflictsWith metadata in the protocol-level schema,
+	// so this is the only way to honour it for dynamic providers.
+	if len(autoDefaulted) > 0 {
+		stripped := stripConflictingAutoDefaults(inputs, autoDefaulted, resp.Diagnostics, schemaMap, schemaInfos)
+		if stripped != nil {
+			return p.validateResourceConfig(ctx, urn, rh, stripped, nil)
+		}
+	}
 
 	checkFailures := []plugin.CheckFailure{}
 	remainingDiagnostics := []*tfprotov6.Diagnostic{}
@@ -133,8 +153,76 @@ func (p *provider) validateResourceConfig(
 
 	sc := &schemaContext{schemaMap: schemaMap, schemaInfos: schemaInfos}
 	if err := p.processDiagnosticsWithContext(ctx, remainingDiagnostics, sc); err != nil {
-		return nil, err
+		return inputs, nil, err
 	}
 
-	return checkFailures, nil
+	return inputs, checkFailures, nil
+}
+
+// autoDefaultedKeys returns the property keys that ApplyDefaultInfoValues added to
+// news via an AutoName default (the user did not provide them in inputs).
+func autoDefaultedKeys(
+	inputs, news resource.PropertyMap,
+	schemaMap shim.SchemaMap,
+	schemaInfos map[string]*tfbridge.SchemaInfo,
+) map[resource.PropertyKey]bool {
+	out := map[resource.PropertyKey]bool{}
+	for tfKey, info := range schemaInfos {
+		if info == nil || info.Default == nil || !info.Default.AutoNamed {
+			continue
+		}
+		pk := resource.PropertyKey(tfbridge.TerraformToPulumiNameV2(tfKey, schemaMap, schemaInfos))
+		if _, inUser := inputs[pk]; inUser {
+			continue
+		}
+		if _, inNews := news[pk]; inNews {
+			out[pk] = true
+		}
+	}
+	return out
+}
+
+// stripConflictingAutoDefaults inspects ValidateResourceConfig diagnostics for
+// "Conflicting configuration arguments" errors. If the conflict points at an
+// auto-defaulted attribute, the attribute is removed from the returned inputs.
+// Returns nil if no auto-defaulted keys were dropped.
+func stripConflictingAutoDefaults(
+	inputs resource.PropertyMap,
+	autoDefaulted map[resource.PropertyKey]bool,
+	diags []*tfprotov6.Diagnostic,
+	schemaMap shim.SchemaMap,
+	schemaInfos map[string]*tfbridge.SchemaInfo,
+) resource.PropertyMap {
+	stripped := inputs.Copy()
+	dropped := false
+	for _, diag := range diags {
+		if diag == nil || diag.Severity > tfprotov6.DiagnosticSeverityError {
+			continue
+		}
+		if diag.Summary != "Conflicting configuration arguments" {
+			continue
+		}
+		if diag.Attribute == nil {
+			continue
+		}
+		steps := diag.Attribute.Steps()
+		if len(steps) != 1 {
+			continue
+		}
+		name, ok := steps[0].(tftypes.AttributeName)
+		if !ok {
+			continue
+		}
+		pulumiName := tfbridge.TerraformToPulumiNameV2(string(name), schemaMap, schemaInfos)
+		pk := resource.PropertyKey(pulumiName)
+		if !autoDefaulted[pk] {
+			continue
+		}
+		delete(stripped, pk)
+		dropped = true
+	}
+	if !dropped {
+		return nil
+	}
+	return stripped
 }


### PR DESCRIPTION
## Summary

The dynamic bridge runs `SetAutonaming` against every wrapped provider, which attaches an `AutoName` default to any property literally called `name`. During `Check`, `defaults.ApplyDefaultInfoValues` fires that default whenever the user omits `name`, populating it with a generated value before forwarding to the upstream provider's `ValidateResourceConfig`.

For providers like `aws_cloudwatch_log_group` whose `name` and `name_prefix` are `Optional + Computed + ConflictsWith: each other`, the injected `name` collides with the user-supplied `name_prefix` and SDKv2 returns two "Conflicting configuration arguments" diagnostics. The protocol-level schema doesn't surface `ConflictsWith`, so the bridge can't anticipate the conflict.

This change detects the case after the first `ValidateResourceConfig` call: if a `ConflictsWith` diagnostic targets an attribute the bridge auto-named, strip the auto-default from the inputs and re-validate once. The cleaned inputs are also returned from `Check` so the property doesn't leak into state — the upstream SDK will compute the final `name` from `name_prefix` during plan/apply, matching tofu's behavior.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/1095

## Test plan

- [x] New `TestConflictsWithNamePrefixOnly` in `dynamic/conflicting_test.go` reproduces the failure and now passes (check + create subtests).
- [x] Existing `pkg/pf/tfbridge` unit tests still pass.
- [ ] CI green on this branch.