### PR TITLE
Add `--exclude` flag to dynamic provider parameterization

### DIFF
--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -104,24 +104,34 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 		prov.Repository = "https://github.com/" + ghOrg + "/terraform-provider-" + name
 	}
 
-	// Apply resource filtering if specified
-	if len(value.Includes) > 0 {
-		// Create a set of resources to include
-		includeSet := make(map[string]bool)
+	if len(value.Includes) > 0 || len(value.Excludes) > 0 {
+		includeSet := make(map[string]bool, len(value.Includes))
 		for _, resource := range value.Includes {
 			includeSet[resource] = true
 		}
+		excludeSet := make(map[string]bool, len(value.Excludes))
+		for _, resource := range value.Excludes {
+			excludeSet[resource] = true
+		}
 
-		// Add all resources NOT in the include set to IgnoreMappings
+		// A token is ignored if it is explicitly excluded, or if an include
+		// filter is present and the token is not in it.
+		shouldIgnore := func(key string) bool {
+			if excludeSet[key] {
+				return true
+			}
+			return len(includeSet) > 0 && !includeSet[key]
+		}
+
 		var ignoreMappings []string
 		for key := range provider.ResourcesMap().Range {
-			if !includeSet[key] {
+			if shouldIgnore(key) {
 				ignoreMappings = append(ignoreMappings, key)
 			}
 		}
 		// Also check data sources
 		for key := range provider.DataSourcesMap().Range {
-			if !includeSet[key] {
+			if shouldIgnore(key) {
 				ignoreMappings = append(ignoreMappings, key)
 			}
 		}

--- a/dynamic/info_test.go
+++ b/dynamic/info_test.go
@@ -312,6 +312,98 @@ func TestIncludeFilter(t *testing.T) {
 	})
 }
 
+func TestExcludeFilter(t *testing.T) {
+	t.Parallel()
+
+	provider := schemaOnlyProvider{
+		name:    "test",
+		version: "1.0.0",
+		schema: &tfprotov6.GetProviderSchemaResponse{
+			ResourceSchemas: map[string]*tfprotov6.Schema{
+				"test_resource_a": {Block: &tfprotov6.SchemaBlock{}},
+				"test_resource_b": {Block: &tfprotov6.SchemaBlock{}},
+				"test_resource_c": {Block: &tfprotov6.SchemaBlock{}},
+			},
+			DataSourceSchemas: map[string]*tfprotov6.Schema{
+				"test_data_a": {Block: &tfprotov6.SchemaBlock{}},
+				"test_data_b": {Block: &tfprotov6.SchemaBlock{}},
+			},
+		},
+	}
+
+	tokens := func(prov info.Provider) []string {
+		out := make([]string, 0, len(prov.Resources)+len(prov.DataSources))
+		for tfName := range prov.Resources {
+			out = append(out, tfName)
+		}
+		for tfName := range prov.DataSources {
+			out = append(out, tfName)
+		}
+		return out
+	}
+
+	t.Run("exclude a single resource", func(t *testing.T) {
+		info, err := providerInfo(context.Background(), provider, parameterize.Value{
+			Excludes: []string{"test_resource_b"},
+		})
+		require.NoError(t, err)
+
+		assert.ElementsMatch(t, []string{"test_resource_b"}, info.IgnoreMappings)
+		assert.ElementsMatch(t,
+			[]string{"test_resource_a", "test_resource_c", "test_data_a", "test_data_b"},
+			tokens(info))
+	})
+
+	t.Run("exclude a datasource", func(t *testing.T) {
+		info, err := providerInfo(context.Background(), provider, parameterize.Value{
+			Excludes: []string{"test_data_a"},
+		})
+		require.NoError(t, err)
+
+		assert.ElementsMatch(t, []string{"test_data_a"}, info.IgnoreMappings)
+		assert.ElementsMatch(t,
+			[]string{"test_resource_a", "test_resource_b", "test_resource_c", "test_data_b"},
+			tokens(info))
+	})
+
+	t.Run("include and exclude disjoint", func(t *testing.T) {
+		info, err := providerInfo(context.Background(), provider, parameterize.Value{
+			Includes: []string{"test_resource_a", "test_resource_b"},
+			Excludes: []string{"test_data_a"},
+		})
+		require.NoError(t, err)
+
+		assert.ElementsMatch(t,
+			[]string{"test_resource_c", "test_data_a", "test_data_b"},
+			info.IgnoreMappings)
+		assert.ElementsMatch(t, []string{"test_resource_a", "test_resource_b"}, tokens(info))
+	})
+
+	t.Run("exclude non-existent token is a no-op", func(t *testing.T) {
+		info, err := providerInfo(context.Background(), provider, parameterize.Value{
+			Excludes: []string{"non_existent_resource"},
+		})
+		require.NoError(t, err)
+
+		assert.Empty(t, info.IgnoreMappings)
+		assert.ElementsMatch(t,
+			[]string{"test_resource_a", "test_resource_b", "test_resource_c", "test_data_a", "test_data_b"},
+			tokens(info))
+	})
+
+	t.Run("nil excludes excludes nothing", func(t *testing.T) {
+		info, err := providerInfo(context.Background(), provider, parameterize.Value{
+			Excludes: nil,
+		})
+		require.NoError(t, err)
+
+		assert.Empty(t, info.IgnoreMappings)
+		assert.ElementsMatch(t,
+			[]string{"test_resource_a", "test_resource_b", "test_resource_c", "test_data_a", "test_data_b"},
+			tokens(info))
+	})
+}
+
 func TestProviderNameOverride(t *testing.T) {
 	t.Parallel()
 

--- a/dynamic/main.go
+++ b/dynamic/main.go
@@ -173,6 +173,7 @@ func initialSetup() (info.Provider, pfbridge.ProviderMetadata, func() error) {
 
 			value := parameterize.Value{
 				Includes:     args.Includes,
+				Excludes:     args.Excludes,
 				ProviderName: args.ProviderName,
 			}
 			if args.Local != nil {

--- a/dynamic/parameterize/args.go
+++ b/dynamic/parameterize/args.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
@@ -37,6 +38,9 @@ type Args struct {
 	// Includes is the list of resource and datasource TF tokens to include in the
 	// provider.  If empty, all resources and datasources are included.
 	Includes []string
+	// Excludes is the list of resource and datasource TF tokens to exclude from the
+	// provider.  If empty, nothing is excluded.
+	Excludes []string
 	// ProviderName is the custom name for the generated provider.
 	// If empty, the default Terraform provider name is used.
 	ProviderName string
@@ -73,6 +77,7 @@ func ParseArgs(ctx context.Context, cliArgs []string) (Args, error) {
 	var upstreamRepoPath string
 	var indexDocOutDir string
 	var includes []string
+	var excludes []string
 	var providerName string
 
 	// If --help is included in `a`, then `RunE` will never be executed.
@@ -85,7 +90,8 @@ func ParseArgs(ctx context.Context, cliArgs []string) (Args, error) {
 		RunE: func(cmd *cobra.Command, a []string) error {
 			cmdWasRun = true
 			var err error
-			args, err = parseArgs(cmd.Context(), a, fullDocs, upstreamRepoPath, indexDocOutDir, includes, providerName)
+			args, err = parseArgs(
+				cmd.Context(), a, fullDocs, upstreamRepoPath, indexDocOutDir, includes, excludes, providerName)
 			return err
 		},
 		Args: func(cmd *cobra.Command, args []string) error {
@@ -108,6 +114,11 @@ func ParseArgs(ctx context.Context, cliArgs []string) (Args, error) {
 			`(e.g. aws_instance,aws_vpc).
 
 If no include filter is specified, all resources and datasources are mapped.`)
+	cmd.Flags().StringSliceVar(&excludes, "exclude", nil,
+		`Comma-separated list of resource and datasource Terraform tokens to exclude from the provider `+
+			`(e.g. aws_instance,aws_vpc).
+
+If no exclude filter is specified, nothing is excluded.`)
 	cmd.Flags().StringVar(&providerName, "provider-name", "",
 		"Custom name for the generated provider to avoid name collisions")
 
@@ -156,9 +167,14 @@ func parseArgs(
 	args []string,
 	fullDocs bool,
 	upstreamRepoPath, indexDocOutDir string,
-	includes []string,
+	includes, excludes []string,
 	providerName string,
 ) (Args, error) {
+	if conflicts := intersection(includes, excludes); len(conflicts) > 0 {
+		return Args{}, fmt.Errorf(
+			"tokens cannot be both included and excluded: %s", strings.Join(conflicts, ", "))
+	}
+
 	// If we see a local prefix (starts with '.' or '/'), parse args for a local provider
 	if strings.HasPrefix(args[0], ".") || strings.HasPrefix(args[0], "/") {
 		if len(args) > 1 {
@@ -178,6 +194,7 @@ func parseArgs(
 				IndexDocOutDir:   indexDocOutDir,
 			},
 			Includes:     includes,
+			Excludes:     excludes,
 			ProviderName: providerName,
 		}, nil
 	}
@@ -200,5 +217,22 @@ func parseArgs(
 		Version:        version,
 		Docs:           fullDocs,
 		IndexDocOutDir: indexDocOutDir,
-	}, Includes: includes, ProviderName: providerName}, nil
+	}, Includes: includes, Excludes: excludes, ProviderName: providerName}, nil
+}
+
+func intersection(a, b []string) []string {
+	bSet := make(map[string]bool, len(b))
+	for _, x := range b {
+		bSet[x] = true
+	}
+	var common []string
+	seen := make(map[string]bool)
+	for _, x := range a {
+		if bSet[x] && !seen[x] {
+			seen[x] = true
+			common = append(common, x)
+		}
+	}
+	sort.Strings(common)
+	return common
 }

--- a/dynamic/parameterize/args_test.go
+++ b/dynamic/parameterize/args_test.go
@@ -175,6 +175,61 @@ func TestParseArgs(t *testing.T) {
 			},
 		},
 		{
+			name: "local with excludes",
+			args: []string{"./my-provider", "--exclude=resource1,resource2"},
+			expect: Args{
+				Local:    &LocalArgs{Path: "./my-provider"},
+				Excludes: []string{"resource1", "resource2"},
+			},
+		},
+		{
+			name: "remote with excludes",
+			args: []string{"registry/provider", "1.2.3", "--exclude=res_a,res_b,res_c"},
+			expect: Args{
+				Remote: &RemoteArgs{
+					Name:    "registry/provider",
+					Version: "1.2.3",
+				},
+				Excludes: []string{"res_a", "res_b", "res_c"},
+			},
+		},
+		{
+			name: "single exclude",
+			args: []string{"registry/provider", "--exclude=single_resource"},
+			expect: Args{
+				Remote: &RemoteArgs{
+					Name: "registry/provider",
+				},
+				Excludes: []string{"single_resource"},
+			},
+		},
+		{
+			name: "multiple exclude invocations",
+			args: []string{"registry/provider", "--exclude", "res_a", "--exclude", "res_b"},
+			expect: Args{
+				Remote: &RemoteArgs{
+					Name: "registry/provider",
+				},
+				Excludes: []string{"res_a", "res_b"},
+			},
+		},
+		{
+			name: "include and exclude disjoint",
+			args: []string{"registry/provider", "--include=res_a,res_b", "--exclude=res_c"},
+			expect: Args{
+				Remote: &RemoteArgs{
+					Name: "registry/provider",
+				},
+				Includes: []string{"res_a", "res_b"},
+				Excludes: []string{"res_c"},
+			},
+		},
+		{
+			name:   "include and exclude conflict",
+			args:   []string{"registry/provider", "--include=res_a,res_b", "--exclude=res_b,res_c"},
+			errMsg: autogold.Expect("tokens cannot be both included and excluded: res_b"),
+		},
+		{
 			name: "local with provider name",
 			args: []string{"./my-provider", "--provider-name=custom-provider"},
 			expect: Args{

--- a/dynamic/parameterize/value.go
+++ b/dynamic/parameterize/value.go
@@ -31,6 +31,9 @@ type Value struct {
 	// Includes is the list of resource and datasource names to include in the
 	// provider.  If empty, all resources are included.
 	Includes []string `json:"includes,omitempty"`
+	// Excludes is the list of resource and datasource names to exclude from the
+	// provider.  If empty, nothing is excluded.
+	Excludes []string `json:"excludes,omitempty"`
 	// ProviderName is the custom name for the generated provider.
 	// If empty, the default Terraform provider name is used.
 	ProviderName string `json:"providerName,omitempty"`
@@ -103,10 +106,10 @@ func (p *Value) IntoArgs() Args {
 	if p.Local != nil {
 		return Args{Local: &LocalArgs{
 			Path: p.Local.Path,
-		}, Includes: p.Includes, ProviderName: p.ProviderName}
+		}, Includes: p.Includes, Excludes: p.Excludes, ProviderName: p.ProviderName}
 	}
 	return Args{Remote: &RemoteArgs{
 		Name:    p.Remote.URL,
 		Version: p.Remote.Version,
-	}, Includes: p.Includes, ProviderName: p.ProviderName}
+	}, Includes: p.Includes, Excludes: p.Excludes, ProviderName: p.ProviderName}
 }

--- a/dynamic/parameterize/value_test.go
+++ b/dynamic/parameterize/value_test.go
@@ -61,6 +61,30 @@ func TestMarshalValue(t *testing.T) {
 		}.Marshal()))
 	})
 
+	t.Run("remote with excludes", func(t *testing.T) {
+		autogold.Expect(
+			`{"remote":{"url":"registry/owner/type","version":"1.2.3"},"excludes":["res1","res2"]}`,
+		).Equal(t, string(Value{
+			Remote: &RemoteValue{
+				URL:     "registry/owner/type",
+				Version: "1.2.3",
+			},
+			Excludes: []string{"res1", "res2"},
+		}.Marshal()))
+	})
+
+	t.Run("local with includes and excludes", func(t *testing.T) {
+		autogold.Expect(
+			`{"local":{"path":"./path"},"includes":["resource_a"],"excludes":["resource_b"]}`,
+		).Equal(t, string(Value{
+			Local: &LocalValue{
+				Path: "./path",
+			},
+			Includes: []string{"resource_a"},
+			Excludes: []string{"resource_b"},
+		}.Marshal()))
+	})
+
 	// Invalid values of Value should panic to help catch bugs early.
 	shouldPanicOnMarshal := []struct {
 		name string
@@ -142,6 +166,28 @@ func TestUnmarshal(t *testing.T) {
 				Includes: []string{"resource_a"},
 			},
 		},
+		{
+			name:  "remote with excludes",
+			input: `{"remote":{"url":"registry/owner/type","version":"1.2.3"},"excludes":["res1","res2"]}`,
+			expect: Value{
+				Remote: &RemoteValue{
+					URL:     "registry/owner/type",
+					Version: "1.2.3",
+				},
+				Excludes: []string{"res1", "res2"},
+			},
+		},
+		{
+			name:  "local with includes and excludes",
+			input: `{"local":{"path":"./path"},"includes":["resource_a"],"excludes":["resource_b"]}`,
+			expect: Value{
+				Local: &LocalValue{
+					Path: "./path",
+				},
+				Includes: []string{"resource_a"},
+				Excludes: []string{"resource_b"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -218,6 +264,40 @@ func TestValueIntoArgs(t *testing.T) {
 					Path: "./a/b/c",
 				},
 				Includes: []string{"local_res"},
+			},
+		},
+		{
+			name: "remote with includes and excludes",
+			value: Value{
+				Remote: &RemoteValue{
+					URL:     "a/b/c",
+					Version: "1.2.3",
+				},
+				Includes: []string{"res1", "res2"},
+				Excludes: []string{"res3"},
+			},
+			args: Args{
+				Remote: &RemoteArgs{
+					Name:    "a/b/c",
+					Version: "1.2.3",
+				},
+				Includes: []string{"res1", "res2"},
+				Excludes: []string{"res3"},
+			},
+		},
+		{
+			name: "local with excludes",
+			value: Value{
+				Local: &LocalValue{
+					Path: "./a/b/c",
+				},
+				Excludes: []string{"local_res"},
+			},
+			args: Args{
+				Local: &LocalArgs{
+					Path: "./a/b/c",
+				},
+				Excludes: []string{"local_res"},
 			},
 		},
 	}


### PR DESCRIPTION
We already have an `--include` flag, add an `--exclude` flag to help with issues like https://github.com/pulumi/pulumi/issues/21826 where codegen can fail because of naming collisions between resource names and helper classes/types.

Fixes https://github.com/pulumi/pulumi/issues/21826
