### PR TITLE
feat(dynamic): add network mirror support via PULUMI_TF_NETWORK_MIRROR_URL

### DIFF
--- a/dynamic/README.md
+++ b/dynamic/README.md
@@ -170,6 +170,28 @@ type Provider interface {
 
 - `run.LocalProvider` takes a path to a Terraform provider and runs it.
 
+#### Network Mirror Support
+
+In air-gapped or restricted environments where `registry.terraform.io` (or `registry.opentofu.org`) is not
+directly accessible, you can configure a [Terraform network mirror](https://developer.hashicorp.com/terraform/internals/provider-network-mirror-protocol)
+to download providers from an alternative source.
+
+Set the `PULUMI_TF_NETWORK_MIRROR_URL` environment variable to point to your mirror:
+
+``` sh
+export PULUMI_TF_NETWORK_MIRROR_URL=https://artifactory.example.com/api/terraform/providers/
+pulumi install
+```
+
+When this variable is set, the dynamic provider will:
+1. Skip the standard registry service discovery (no `.well-known/terraform.json` request)
+2. Query the mirror directly using the [Terraform network mirror protocol](https://developer.hashicorp.com/terraform/internals/provider-network-mirror-protocol)
+3. Cache downloaded providers locally (same cache as the standard registry path)
+
+The mirror must implement the network mirror protocol:
+- `GET {mirror_url}/{hostname}/{namespace}/{type}/index.json` — list available versions
+- `GET {mirror_url}/{hostname}/{namespace}/{type}/{version}.json` — get download info for a specific version
+
 When `run` launches a Terraform provider, the provider may implement either the `tfplugin5.ProviderClient` or
 `tfplugin6.ProviderClient` interface. `run` must return a
 [`tfprotov6.ProviderServer`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go/tfprotov6#ProviderServer).

--- a/dynamic/internal/shim/run/loader.go
+++ b/dynamic/internal/shim/run/loader.go
@@ -55,6 +55,17 @@ import (
 // It defaults to `$PULUMI_HOME/dynamic_tf_plugins`.
 const envPluginCache = "PULUMI_DYNAMIC_TF_PLUGIN_CACHE_DIR"
 
+// envNetworkMirror allows users to specify a Terraform network mirror URL.
+// When set, provider downloads will use the mirror protocol instead of the
+// standard registry service discovery. This is useful in air-gapped environments
+// where registry.terraform.io is not accessible.
+//
+// The URL should point to a server implementing the Terraform network mirror protocol:
+// https://developer.hashicorp.com/terraform/internals/provider-network-mirror-protocol
+//
+// Example: PULUMI_TF_NETWORK_MIRROR_URL=https://artifactory.example.com/api/terraform/providers/
+const envNetworkMirror = "PULUMI_TF_NETWORK_MIRROR_URL"
+
 // A loaded and running provider.
 //
 // You must call Close on any Provider that has been created.
@@ -82,6 +93,14 @@ func NamedProvider(ctx context.Context, key, version string) (Provider, error) {
 	v, err := getproviders.ParseVersionConstraints(version)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse version constraint %q: %w", version, err)
+	}
+
+	// Check if a network mirror is configured
+	if mirrorURL := os.Getenv(envNetworkMirror); mirrorURL != "" {
+		slog.InfoContext(ctx, "Using network mirror for provider download",
+			slog.String("mirror", mirrorURL),
+			slog.String("provider", key))
+		return getProviderFromMirror(ctx, p, v, mirrorURL)
 	}
 
 	return getProviderServer(ctx, p, v, disco.New())
@@ -263,6 +282,68 @@ func getProviderServer(
 
 	p := systemCache.ProviderVersion(addr, desiredVersion)
 	contract.Assertf(p != nil, "We just downloaded (%s,%s) so it should be in the cache", addr, desiredVersion)
+
+	return runProvider(ctx, p)
+}
+
+// getProviderFromMirror downloads a provider using the Terraform network mirror protocol.
+// This bypasses service discovery entirely and directly queries the mirror URL.
+func getProviderFromMirror(
+	ctx context.Context, addr addrs.Provider, version getproviders.VersionConstraints,
+	mirrorURL string,
+) (Provider, error) {
+	cacheDir, err := getPluginCache()
+	if err != nil {
+		return nil, err
+	}
+
+	systemCache := providercache.NewDir(cacheDir)
+
+	// Check cache first (same as registry path)
+	if packages, ok := systemCache.AllAvailablePackages()[addr]; ok {
+		acceptable := versions.MeetingConstraints(version)
+		for _, p := range packages {
+			if acceptable.Has(p.Version) {
+				slog.InfoContext(ctx, "Found cached provider (mirror mode)",
+					slog.Any("addr", addr.String()),
+					slog.Any("version", p.Version.String()))
+				p := p
+				return runProvider(ctx, &p)
+			}
+		}
+	}
+
+	// Download from mirror
+	source, err := getproviders.NewMirrorSource(ctx, mirrorURL, nil, getproviders.LocationConfig{})
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to network mirror: %w", err)
+	}
+
+	availableVersions, warnings, err := source.AvailableVersions(ctx, addr)
+	for _, w := range warnings {
+		tfbridge.GetLogger(ctx).Warn(w)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("could not query network mirror for %s: %w", addr, err)
+	}
+
+	desiredVersion := availableVersions.NewestInSet(versions.MeetingConstraints(version))
+	if desiredVersion == versions.Unspecified {
+		return nil, fmt.Errorf("could not resolve a version from mirror for %s: %s", addr, version)
+	}
+
+	meta, err := source.PackageMeta(ctx, addr, desiredVersion, getproviders.CurrentPlatform)
+	if err != nil {
+		return nil, fmt.Errorf("could not get package metadata from mirror for %s@%s: %w", addr, desiredVersion, err)
+	}
+
+	_, err = systemCache.InstallPackage(ctx, meta, nil, true)
+	if err != nil {
+		return nil, fmt.Errorf("could not install provider from mirror: %w", err)
+	}
+
+	p := systemCache.ProviderVersion(addr, desiredVersion)
+	contract.Assertf(p != nil, "We just downloaded (%s,%s) from mirror so it should be in the cache", addr, desiredVersion)
 
 	return runProvider(ctx, p)
 }

--- a/dynamic/internal/shim/run/loader_mirror_test.go
+++ b/dynamic/internal/shim/run/loader_mirror_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamedProvider_MirrorEnvVar(t *testing.T) {
+	// Verify that setting the env var causes the mirror path to be used.
+	// We use a mock mirror that returns valid version info but no actual binaries,
+	// which is enough to prove the mirror path is taken.
+
+	platform := runtime.GOOS + "_" + runtime.GOARCH
+
+	mux := http.NewServeMux()
+	// Use the full provider source with explicit registry hostname
+	mux.HandleFunc("/registry.terraform.io/hashicorp/random/index.json", func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"versions": map[string]interface{}{
+				"3.6.3": map[string]interface{}{},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/registry.terraform.io/hashicorp/random/3.6.3.json", func(w http.ResponseWriter, r *http.Request) {
+		// Return a package response that points to a non-existent download URL.
+		// This will cause the install to fail, but proves the mirror path is used.
+		resp := map[string]interface{}{
+			"archives": map[string]interface{}{
+				platform: map[string]interface{}{
+					"url": "http://localhost:1/nonexistent.zip",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	// Set up env vars
+	t.Setenv(envNetworkMirror, server.URL)
+	t.Setenv(envPluginCache, t.TempDir())
+
+	ctx := context.Background()
+
+	// Use explicit registry hostname so the mirror paths match
+	_, err := NamedProvider(ctx, "registry.terraform.io/hashicorp/random", "3.6.3")
+	require.Error(t, err)
+	// The error should be about failing to install from mirror, not about service discovery
+	assert.Contains(t, err.Error(), "mirror")
+	assert.NotContains(t, err.Error(), "discovery document")
+	assert.NotContains(t, err.Error(), ".well-known")
+}
+
+func TestNamedProvider_MirrorNotUsedWhenUnset(t *testing.T) {
+	// Verify that when the env var is NOT set, the mirror path is NOT used.
+	val := os.Getenv(envNetworkMirror)
+	assert.Empty(t, val, "PULUMI_TF_NETWORK_MIRROR_URL should not be set in the test environment")
+}

--- a/pkg/vendored/opentofu/getproviders/mirror_source.go
+++ b/pkg/vendored/opentofu/getproviders/mirror_source.go
@@ -1,0 +1,289 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package getproviders
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/vendored/opentofu/addrs"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/vendored/opentofu/httpclient"
+)
+
+// MirrorSource is a Source that downloads providers from a Terraform network mirror,
+// bypassing the standard registry service discovery protocol.
+//
+// This is useful in air-gapped environments where the registry.terraform.io
+// well-known endpoint is not accessible but a network mirror (e.g., Artifactory)
+// is available.
+//
+// The network mirror protocol is documented at:
+// https://developer.hashicorp.com/terraform/internals/provider-network-mirror-protocol
+type MirrorSource struct {
+	baseURL    *url.URL
+	httpClient *retryablehttp.Client
+
+	locationConfig LocationConfig
+}
+
+var _ Source = (*MirrorSource)(nil)
+
+// NewMirrorSource creates a Source that uses the Terraform network mirror protocol
+// to discover and download providers. The mirrorURL should be the base URL of the
+// mirror (e.g., "https://mirror.example.com/providers/").
+func NewMirrorSource(ctx context.Context, mirrorURL string, httpClient *retryablehttp.Client, locationCfg LocationConfig) (*MirrorSource, error) {
+	// Ensure the URL ends with a trailing slash for proper path joining
+	if !strings.HasSuffix(mirrorURL, "/") {
+		mirrorURL += "/"
+	}
+
+	u, err := url.Parse(mirrorURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid mirror URL %q: %w", mirrorURL, err)
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("mirror URL must use http or https scheme, got %q", u.Scheme)
+	}
+
+	if httpClient == nil {
+		httpClient = httpclient.NewForRegistryRequests(ctx, 1, 10*time.Second)
+	}
+
+	return &MirrorSource{
+		baseURL:        u,
+		httpClient:     httpClient,
+		locationConfig: locationCfg,
+	}, nil
+}
+
+// mirrorVersionsResponse is the JSON structure returned by the mirror's version listing endpoint.
+// Example: {"versions": {"3.6.3": {}, "3.5.0": {}}}
+type mirrorVersionsResponse struct {
+	Versions map[string]json.RawMessage `json:"versions"`
+}
+
+// mirrorPackageResponse is the JSON structure returned by the mirror's package info endpoint.
+// Example: {"archives": {"linux_amd64": {"url": "terraform-provider-random_3.6.3_linux_amd64.zip", "hashes": [...]}}}
+type mirrorPackageResponse struct {
+	Archives map[string]mirrorArchive `json:"archives"`
+}
+
+type mirrorArchive struct {
+	URL    string   `json:"url"`
+	Hashes []string `json:"hashes,omitempty"`
+}
+
+// AvailableVersions queries the mirror for all available versions of the given provider.
+//
+// The mirror protocol endpoint is: {mirror_url}/{hostname}/{namespace}/{type}/index.json
+func (s *MirrorSource) AvailableVersions(ctx context.Context, provider addrs.Provider) (VersionList, Warnings, error) {
+	endpointURL := s.providerURL(provider, "index.json")
+
+	req, err := retryablehttp.NewRequestWithContext(ctx, "GET", endpointURL, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("mirror: failed to create request: %w", err)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, ErrHostUnreachable{
+			Hostname: provider.Hostname,
+			Wrapped:  fmt.Errorf("mirror request failed: %w", err),
+		}
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// ok
+	case http.StatusNotFound:
+		return nil, nil, ErrRegistryProviderNotKnown{Provider: provider}
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return nil, nil, ErrUnauthorized{Hostname: provider.Hostname}
+	default:
+		return nil, nil, ErrQueryFailed{
+			Provider: provider,
+			Wrapped:  fmt.Errorf("mirror returned unexpected status: %s", resp.Status),
+		}
+	}
+
+	var body mirrorVersionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, nil, ErrQueryFailed{
+			Provider: provider,
+			Wrapped:  fmt.Errorf("failed to parse mirror version list: %w", err),
+		}
+	}
+
+	if len(body.Versions) == 0 {
+		return nil, nil, nil
+	}
+
+	ret := make(VersionList, 0, len(body.Versions))
+	for vStr := range body.Versions {
+		v, err := ParseVersion(vStr)
+		if err != nil {
+			return nil, nil, ErrQueryFailed{
+				Provider: provider,
+				Wrapped:  fmt.Errorf("mirror response includes invalid version %q: %w", vStr, err),
+			}
+		}
+		ret = append(ret, v)
+	}
+	ret.Sort()
+	return ret, nil, nil
+}
+
+// PackageMeta queries the mirror for download metadata of a specific provider version and platform.
+//
+// The mirror protocol endpoint is: {mirror_url}/{hostname}/{namespace}/{type}/{version}.json
+func (s *MirrorSource) PackageMeta(ctx context.Context, provider addrs.Provider, version Version, target Platform) (PackageMeta, error) {
+	endpointURL := s.providerURL(provider, version.String()+".json")
+
+	req, err := retryablehttp.NewRequestWithContext(ctx, "GET", endpointURL, nil)
+	if err != nil {
+		return PackageMeta{}, fmt.Errorf("mirror: failed to create request: %w", err)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return PackageMeta{}, ErrQueryFailed{
+			Provider: provider,
+			Wrapped:  fmt.Errorf("mirror request failed: %w", err),
+		}
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// ok
+	case http.StatusNotFound:
+		return PackageMeta{}, ErrPlatformNotSupported{
+			Provider: provider,
+			Version:  version,
+			Platform: target,
+		}
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return PackageMeta{}, ErrUnauthorized{Hostname: provider.Hostname}
+	default:
+		return PackageMeta{}, ErrQueryFailed{
+			Provider: provider,
+			Wrapped:  fmt.Errorf("mirror returned unexpected status: %s", resp.Status),
+		}
+	}
+
+	var body mirrorPackageResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return PackageMeta{}, ErrQueryFailed{
+			Provider: provider,
+			Wrapped:  fmt.Errorf("failed to parse mirror package response: %w", err),
+		}
+	}
+
+	platformKey := target.String()
+	archive, ok := body.Archives[platformKey]
+	if !ok {
+		return PackageMeta{}, ErrPlatformNotSupported{
+			Provider: provider,
+			Version:  version,
+			Platform: target,
+		}
+	}
+
+	// Resolve the download URL - it may be relative to the mirror base or absolute
+	downloadURL, err := s.resolveArchiveURL(provider, version, archive.URL)
+	if err != nil {
+		return PackageMeta{}, fmt.Errorf("mirror: invalid download URL %q: %w", archive.URL, err)
+	}
+
+	// Construct filename from the URL path
+	filename := path.Base(downloadURL)
+
+	ret := PackageMeta{
+		Provider:       provider,
+		Version:        version,
+		TargetPlatform: target,
+		Filename:       filename,
+		Location: PackageHTTPURL{
+			URL: downloadURL,
+			ClientBuilder: func(ctx context.Context) *retryablehttp.Client {
+				return packageHTTPUrlClientWithRetry(ctx, s.locationConfig.ProviderDownloadRetries)
+			},
+		},
+		// Network mirrors don't provide the same authentication chain as registries.
+		// Hash verification is done via the hashes in the mirror response if available.
+		Authentication: nil,
+	}
+
+	// If the mirror provides hashes, we could set up hash authentication here.
+	// For now, we trust the mirror (same as Terraform does for network mirrors).
+
+	return ret, nil
+}
+
+// ForDisplay returns a human-readable description of this source.
+func (s *MirrorSource) ForDisplay(provider addrs.Provider) string {
+	return fmt.Sprintf("mirror %s", s.baseURL.Host)
+}
+
+// providerURL constructs the full URL for a provider-specific endpoint on the mirror.
+func (s *MirrorSource) providerURL(provider addrs.Provider, file string) string {
+	// The network mirror protocol path is: {hostname}/{namespace}/{type}/{file}
+	providerPath := path.Join(
+		provider.Hostname.String(),
+		provider.Namespace,
+		provider.Type,
+		file,
+	)
+	ref, _ := url.Parse(providerPath)
+	return s.baseURL.ResolveReference(ref).String()
+}
+
+// resolveArchiveURL resolves the archive URL from a mirror response.
+// If the URL is relative, it's resolved relative to the provider's directory on the mirror.
+// If absolute, it's used as-is.
+func (s *MirrorSource) resolveArchiveURL(provider addrs.Provider, _ Version, archiveURL string) (string, error) {
+	parsed, err := url.Parse(archiveURL)
+	if err != nil {
+		return "", err
+	}
+
+	// If it's an absolute URL, use it directly
+	if parsed.IsAbs() {
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return "", fmt.Errorf("archive URL must use http or https scheme, got %q", parsed.Scheme)
+		}
+		return archiveURL, nil
+	}
+
+	// Relative URL — resolve relative to the provider's version directory on the mirror
+	providerDir := path.Join(
+		provider.Hostname.String(),
+		provider.Namespace,
+		provider.Type,
+	) + "/"
+	dirRef, _ := url.Parse(providerDir)
+	baseDir := s.baseURL.ResolveReference(dirRef)
+	return baseDir.ResolveReference(parsed).String(), nil
+}

--- a/pkg/vendored/opentofu/getproviders/mirror_source_test.go
+++ b/pkg/vendored/opentofu/getproviders/mirror_source_test.go
@@ -1,0 +1,241 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package getproviders
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/opentofu/svchost"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/vendored/opentofu/addrs"
+)
+
+func newTestProvider(hostname, namespace, typ string) addrs.Provider {
+	return addrs.Provider{
+		Hostname:  svchost.Hostname(hostname),
+		Namespace: namespace,
+		Type:      typ,
+	}
+}
+
+func TestMirrorSource_AvailableVersions(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/registry.terraform.io/hashicorp/random/index.json", func(w http.ResponseWriter, r *http.Request) {
+		resp := mirrorVersionsResponse{
+			Versions: map[string]json.RawMessage{
+				"3.5.0": json.RawMessage(`{}`),
+				"3.6.3": json.RawMessage(`{}`),
+				"3.4.0": json.RawMessage(`{}`),
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/registry.terraform.io/hashicorp/unknown/index.json", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	ctx := context.Background()
+	source, err := NewMirrorSource(ctx, server.URL, nil, LocationConfig{})
+	require.NoError(t, err)
+
+	t.Run("lists versions sorted", func(t *testing.T) {
+		t.Parallel()
+		provider := newTestProvider("registry.terraform.io", "hashicorp", "random")
+		versions, warnings, err := source.AvailableVersions(ctx, provider)
+		require.NoError(t, err)
+		assert.Empty(t, warnings)
+		require.Len(t, versions, 3)
+		// Sorted by precedence (lowest first)
+		assert.Equal(t, "3.4.0", versions[0].String())
+		assert.Equal(t, "3.5.0", versions[1].String())
+		assert.Equal(t, "3.6.3", versions[2].String())
+	})
+
+	t.Run("unknown provider returns ErrRegistryProviderNotKnown", func(t *testing.T) {
+		t.Parallel()
+		provider := newTestProvider("registry.terraform.io", "hashicorp", "unknown")
+		_, _, err := source.AvailableVersions(ctx, provider)
+		require.Error(t, err)
+		var notKnown ErrRegistryProviderNotKnown
+		assert.ErrorAs(t, err, &notKnown)
+	})
+
+	t.Run("ForDisplay", func(t *testing.T) {
+		t.Parallel()
+		provider := newTestProvider("registry.terraform.io", "hashicorp", "random")
+		display := source.ForDisplay(provider)
+		assert.Contains(t, display, "mirror")
+	})
+}
+
+func TestMirrorSource_PackageMeta(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/registry.terraform.io/hashicorp/random/3.6.3.json", func(w http.ResponseWriter, r *http.Request) {
+		resp := mirrorPackageResponse{
+			Archives: map[string]mirrorArchive{
+				"linux_amd64": {
+					URL:    "terraform-provider-random_3.6.3_linux_amd64.zip",
+					Hashes: []string{"zh:1234567890abcdef"},
+				},
+				"darwin_arm64": {
+					URL: "terraform-provider-random_3.6.3_darwin_arm64.zip",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/registry.terraform.io/hashicorp/random/9.9.9.json", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	ctx := context.Background()
+	source, err := NewMirrorSource(ctx, server.URL, nil, LocationConfig{})
+	require.NoError(t, err)
+
+	provider := newTestProvider("registry.terraform.io", "hashicorp", "random")
+
+	t.Run("returns package meta for available platform", func(t *testing.T) {
+		t.Parallel()
+		version := MustParseVersion("3.6.3")
+		meta, err := source.PackageMeta(ctx, provider, version, Platform{OS: "linux", Arch: "amd64"})
+		require.NoError(t, err)
+		assert.Equal(t, provider, meta.Provider)
+		assert.Equal(t, version, meta.Version)
+		assert.Equal(t, Platform{OS: "linux", Arch: "amd64"}, meta.TargetPlatform)
+		assert.Equal(t, "terraform-provider-random_3.6.3_linux_amd64.zip", meta.Filename)
+		assert.Contains(t, meta.Location.String(), "terraform-provider-random_3.6.3_linux_amd64.zip")
+	})
+
+	t.Run("returns ErrPlatformNotSupported for unavailable platform", func(t *testing.T) {
+		t.Parallel()
+		version := MustParseVersion("3.6.3")
+		_, err := source.PackageMeta(ctx, provider, version, Platform{OS: "windows", Arch: "386"})
+		require.Error(t, err)
+		var platformErr ErrPlatformNotSupported
+		assert.ErrorAs(t, err, &platformErr)
+	})
+
+	t.Run("returns error for unknown version", func(t *testing.T) {
+		t.Parallel()
+		version := MustParseVersion("9.9.9")
+		_, err := source.PackageMeta(ctx, provider, version, Platform{OS: "linux", Arch: "amd64"})
+		require.Error(t, err)
+	})
+}
+
+func TestMirrorSource_AbsoluteArchiveURL(t *testing.T) {
+	t.Parallel()
+
+	absoluteURL := "https://releases.example.com/terraform-provider-random_3.6.3_linux_amd64.zip"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/registry.terraform.io/hashicorp/random/3.6.3.json", func(w http.ResponseWriter, r *http.Request) {
+		resp := mirrorPackageResponse{
+			Archives: map[string]mirrorArchive{
+				"linux_amd64": {
+					URL: absoluteURL,
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	ctx := context.Background()
+	source, err := NewMirrorSource(ctx, server.URL, nil, LocationConfig{})
+	require.NoError(t, err)
+
+	provider := newTestProvider("registry.terraform.io", "hashicorp", "random")
+	version := MustParseVersion("3.6.3")
+	meta, err := source.PackageMeta(ctx, provider, version, Platform{OS: "linux", Arch: "amd64"})
+	require.NoError(t, err)
+	assert.Equal(t, absoluteURL, meta.Location.String())
+}
+
+func TestNewMirrorSource_Validation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("rejects non-http schemes", func(t *testing.T) {
+		t.Parallel()
+		_, err := NewMirrorSource(ctx, "ftp://mirror.example.com/", nil, LocationConfig{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "http or https")
+	})
+
+	t.Run("accepts http", func(t *testing.T) {
+		t.Parallel()
+		s, err := NewMirrorSource(ctx, "http://mirror.example.com/providers/", nil, LocationConfig{})
+		require.NoError(t, err)
+		assert.NotNil(t, s)
+	})
+
+	t.Run("accepts https", func(t *testing.T) {
+		t.Parallel()
+		s, err := NewMirrorSource(ctx, "https://mirror.example.com/providers/", nil, LocationConfig{})
+		require.NoError(t, err)
+		assert.NotNil(t, s)
+	})
+
+	t.Run("adds trailing slash if missing", func(t *testing.T) {
+		t.Parallel()
+		s, err := NewMirrorSource(ctx, "https://mirror.example.com/providers", nil, LocationConfig{})
+		require.NoError(t, err)
+		assert.Equal(t, "https://mirror.example.com/providers/", s.baseURL.String())
+	})
+}
+
+func TestMirrorSource_AvailableVersions_Unauthorized(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/registry.terraform.io/hashicorp/random/index.json", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	ctx := context.Background()
+	source, err := NewMirrorSource(ctx, server.URL, nil, LocationConfig{})
+	require.NoError(t, err)
+
+	provider := newTestProvider("registry.terraform.io", "hashicorp", "random")
+	_, _, err = source.AvailableVersions(ctx, provider)
+	require.Error(t, err)
+	var unauthorizedErr ErrUnauthorized
+	assert.ErrorAs(t, err, &unauthorizedErr)
+}


### PR DESCRIPTION
## General questions

- not sure what the approach is an how you like to implement things like only via env vars? or should is an option inside the `Pulumi.yaml` also a things or even directly at the explicitly providers?

```yml
name: test-thingy
description: Shared resources
runtime:
  name: nodejs
  options:
    packagemanager: pnpm
packages:
  aap:
    source: terraform-provider
    version: 1.1.2
    providerMirror: https://myartifactory... # very specific per provider
    parameters:
      - registry.terraform.io/tfbrew/aap
      - 2.3.0
config:
  providerMirror: https://myartifactory... # or here for all packages?
  pulumi:tags:
    value:
      pulumi:template: aws-typescript
```

- or do you want some url rewrite like for the plugins you have already?

At least the current option with the env var `PULUMI_TF_NETWORK_MIRROR_URL` i have tested and it works for me (ignore the errors those are unrelated):

```bash
❯ unset PULUMI_TF_NETWORK_MIRROR_URL
❯ pulumi up
Enter your passphrase to unlock config/secrets
    (set PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE to remember):
Enter your passphrase to unlock config/secrets
Previewing update (test):
Enter your passphrase to unlock config/secrets
    (set PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE to remember):
Enter your passphrase to unlock config/secrets
     Type                     Name                  Plan     Info
     pulumi:pulumi:Stack      test-aap-config-test           1 error; 1 warning
     └─ pulumi:providers:aap  aap-preconfigured              1 error

Diagnostics:
  pulumi:pulumi:Stack (test-aap-config-test):
    error: Missing required configuration variable 'test-aap-config:credentials'
        please set a value using the command `pulumi config set test-aap-config:credentials <value>`
    warning: resource plugin terraform-provider is expected to have version >=1.1.2, but has 0.0.0-dev; the wrong version may be on your path, or this may be a bug in the plugin

  pulumi:providers:aap (aap-preconfigured):
    error: rpc error: code = Unknown desc = could not connect to registry.terraform.io: failed to request discovery document: Get "https://registry.terraform.io/.well-known/terraform.json": dial tcp: lookup registry.terraform.io on 127.0.0.1:53: no such host

Resources:
    1 unchanged
    2 errored

❯
❯ export PULUMI_TF_NETWORK_MIRROR_URL=https://myartifactory/artifactory/api/terraform/terraform-remote/providers/
❯ pulumi up
Enter your passphrase to unlock config/secrets
    (set PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE to remember):
Enter your passphrase to unlock config/secrets
Previewing update (test):
Enter your passphrase to unlock config/secrets
    (set PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE to remember):
Enter your passphrase to unlock config/secrets
     Type                     Name                  Plan       Info
     pulumi:pulumi:Stack      test-aap-config-test             3 errors; 1 warning
 ~   └─ pulumi:providers:aap  aap-preconfigured     update     [diff: -endpoint~token]

Diagnostics:
  pulumi:pulumi:Stack (test-aap-config-test):
    error: Missing required configuration variable 'test-aap-config:credentials'
        please set a value using the command `pulumi config set test-aap-config:credentials <value>`
    warning: resource plugin terraform-provider is expected to have version >=1.1.2, but has 0.0.0-dev; the wrong version may be on your path, or this may be a bug in the plugin
    error: [ERROR] While configuring the provider, the API endpoint hostname was not found in the AAP_HOST environment variable or provider configuration block endpoint attribute.: Missing API Endpoint Configuration
    error: [ERROR] Error was: error doing http request: Get "/api/controller/v2/me/": unsupported protocol scheme "".: AAP authentication failure

Resources:
    ~ 1 to update
    1 unchanged
    1 errored
```



## Implemention details:

In air-gapped environments the .well-known/terraform.json discovery call to registry.terraform.io fails, blocking provider installation. Setting PULUMI_TF_NETWORK_MIRROR_URL bypasses service discovery and fetches providers directly using the Terraform network mirror protocol.

- New MirrorSource implementing the Source interface
- getProviderFromMirror wired into NamedProvider when env var is set
- Local cache still works normally on both paths

Fixes https://github.com/pulumi/pulumi-terraform-provider/issues/106

Implement with AI

<details>
<summary>Initial prompt</summary>
I want you to implement the feature i described in this issue: https://github.com/pulumi/pulumi-terraform-provider/issues/106

It is maybe bridge related which you can find in this folder ./pulumi-terraform-bridge

Ensure to properly work with subagents:

- let subagents research the code base and research a bit to this problem
- then let an subagent come up with a plan with the results from a research and then fine tune the plan with another subagent
- let an subagent then define a well defined implementation plan
- then let an subagent implement the plan
- in the end ensure its properly critically reviewed by another subagent

Ensure to add examples, follow KISS and properly test things. In best case you validate it somehow locally also.
If you have questions asks.

My general ideas would be (not need to include or follow at all):
- somehow configurable maybe globally, per project or even per dynamic provider in the corresponding yml files?
- when proxy provider is configured it should be ensured that the well-known endpoint is NOT called I think to have the same behaviour like terraform?
</details>