### PR TITLE
Default nested fields to optional when wire schema lacks optionality (SchemaConfigModeAttr)

### DIFF
--- a/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
+++ b/dynamic/testdata/TestSchemaGeneration/Backblaze/b2-0.8.9.golden
@@ -238,18 +238,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "bucketId",
-                "bucketName",
-                "capabilities",
-                "namePrefix"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "b2:index/getBucketCorsRule:getBucketCorsRule": {
             "properties": {
@@ -284,20 +273,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "allowedHeaders",
-                "allowedOperations",
-                "allowedOrigins",
-                "corsRuleName",
-                "exposeHeaders",
-                "maxAgeSeconds"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "b2:index/getBucketDefaultServerSideEncryption:getBucketDefaultServerSideEncryption": {
             "properties": {
@@ -308,16 +284,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "algorithm",
-                "mode"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "b2:index/getBucketFileFileVersion:getBucketFileFileVersion": {
             "properties": {
@@ -361,25 +328,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "action",
-                "bucketId",
-                "contentMd5",
-                "contentSha1",
-                "contentType",
-                "fileId",
-                "fileInfo",
-                "fileName",
-                "serverSideEncryptions",
-                "size",
-                "uploadTimestamp"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "b2:index/getBucketFileFileVersionServerSideEncryption:getBucketFileFileVersionServerSideEncryption": {
             "properties": {
@@ -390,16 +339,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "algorithm",
-                "mode"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "b2:index/getBucketFileLockConfiguration:getBucketFileLockConfiguration": {
             "properties": {
@@ -413,16 +353,7 @@
                     "type": "boolean"
                 }
             },
-            "type": "object",
-            "required": [
-                "defaultRetentions",
-                "isFileLockEnabled"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "b2:index/getBucketFileLockConfigurationDefaultRetention:getBucketFileLockConfigurationDefaultRetention": {
             "properties": {
@@ -436,16 +367,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "mode",
-                "periods"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "b2:index/getBucketFileLockConfigurationDefaultRetentionPeriod:getBucketFileLockConfigurationDefaultRetentionPeriod": {
             "properties": {
@@ -456,16 +378,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "duration",
-                "unit"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "b2:index/getBucketFilesFileVersion:getBucketFilesFileVersion": {
             "properties": {
@@ -509,25 +422,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "action",
-                "bucketId",
-                "contentMd5",
-                "contentSha1",
-                "contentType",
-                "fileId",
-                "fileInfo",
-                "fileName",
-                "serverSideEncryptions",
-                "size",
-                "uploadTimestamp"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "b2:index/getBucketFilesFileVersionServerSideEncryption:getBucketFilesFileVersionServerSideEncryption": {
             "properties": {
@@ -538,16 +433,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "algorithm",
-                "mode"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "b2:index/getBucketLifecycleRule:getBucketLifecycleRule": {
             "properties": {
@@ -561,17 +447,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "daysFromHidingToDeleting",
-                "daysFromUploadingToHiding",
-                "fileNamePrefix"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         }
     },
     "provider": {

--- a/dynamic/testdata/TestSchemaGeneration/BunnyWay/bunnynet-0.5.1.golden
+++ b/dynamic/testdata/TestSchemaGeneration/BunnyWay/bunnynet-0.5.1.golden
@@ -76,13 +76,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "parameter1",
-                "parameter2",
-                "parameter3",
-                "type"
-            ]
+            "type": "object"
         },
         "bunnynet:index/PullzoneEdgeruleTrigger:PullzoneEdgeruleTrigger": {
             "properties": {
@@ -105,14 +99,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "matchType",
-                "parameter1",
-                "parameter2",
-                "patterns",
-                "type"
-            ]
+            "type": "object"
         },
         "bunnynet:index/PullzoneOrigin:PullzoneOrigin": {
             "properties": {
@@ -230,12 +217,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "end",
-                "start",
-                "title"
-            ]
+            "type": "object"
         },
         "bunnynet:index/StreamVideoMoment:StreamVideoMoment": {
             "properties": {
@@ -246,11 +228,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "label",
-                "timestamp"
-            ]
+            "type": "object"
         }
     },
     "provider": {

--- a/dynamic/testdata/TestSchemaGeneration/databricks/databricks-1.50.0.golden
+++ b/dynamic/testdata/TestSchemaGeneration/databricks/databricks-1.50.0.golden
@@ -6900,15 +6900,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "continuousUpdateStatuses",
-                "detailedState",
-                "failedStatuses",
-                "message",
-                "provisioningStatuses",
-                "triggeredUpdateStatuses"
-            ]
+            "type": "object"
         },
         "databricks:index/OnlineTableStatusContinuousUpdateStatus:OnlineTableStatusContinuousUpdateStatus": {
             "properties": {
@@ -6925,12 +6917,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "initialPipelineSyncProgresses",
-                "lastProcessedCommitVersion",
-                "timestamp"
-            ]
+            "type": "object"
         },
         "databricks:index/OnlineTableStatusContinuousUpdateStatusInitialPipelineSyncProgress:OnlineTableStatusContinuousUpdateStatusInitialPipelineSyncProgress": {
             "properties": {
@@ -6950,14 +6937,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "estimatedCompletionTimeSeconds",
-                "latestVersionCurrentlyProcessing",
-                "syncProgressCompletion",
-                "syncedRowCount",
-                "totalRowCount"
-            ]
+            "type": "object"
         },
         "databricks:index/OnlineTableStatusFailedStatus:OnlineTableStatusFailedStatus": {
             "properties": {
@@ -6968,11 +6948,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "lastProcessedCommitVersion",
-                "timestamp"
-            ]
+            "type": "object"
         },
         "databricks:index/OnlineTableStatusProvisioningStatus:OnlineTableStatusProvisioningStatus": {
             "properties": {
@@ -6983,10 +6959,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "initialPipelineSyncProgresses"
-            ]
+            "type": "object"
         },
         "databricks:index/OnlineTableStatusProvisioningStatusInitialPipelineSyncProgress:OnlineTableStatusProvisioningStatusInitialPipelineSyncProgress": {
             "properties": {
@@ -7006,14 +6979,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "estimatedCompletionTimeSeconds",
-                "latestVersionCurrentlyProcessing",
-                "syncProgressCompletion",
-                "syncedRowCount",
-                "totalRowCount"
-            ]
+            "type": "object"
         },
         "databricks:index/OnlineTableStatusTriggeredUpdateStatus:OnlineTableStatusTriggeredUpdateStatus": {
             "properties": {
@@ -7030,12 +6996,7 @@
                     }
                 }
             },
-            "type": "object",
-            "required": [
-                "lastProcessedCommitVersion",
-                "timestamp",
-                "triggeredUpdateProgresses"
-            ]
+            "type": "object"
         },
         "databricks:index/OnlineTableStatusTriggeredUpdateStatusTriggeredUpdateProgress:OnlineTableStatusTriggeredUpdateStatusTriggeredUpdateProgress": {
             "properties": {
@@ -7055,14 +7016,7 @@
                     "type": "number"
                 }
             },
-            "type": "object",
-            "required": [
-                "estimatedCompletionTimeSeconds",
-                "latestVersionCurrentlyProcessing",
-                "syncProgressCompletion",
-                "syncedRowCount",
-                "totalRowCount"
-            ]
+            "type": "object"
         },
         "databricks:index/OnlineTableTimeouts:OnlineTableTimeouts": {
             "properties": {
@@ -8164,14 +8118,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "details",
-                "failureReasons",
-                "message",
-                "status",
-                "summary"
-            ]
+            "type": "object"
         },
         "databricks:index/SqlEndpointHealthFailureReason:SqlEndpointHealthFailureReason": {
             "properties": {
@@ -8188,12 +8135,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "code",
-                "parameters",
-                "type"
-            ]
+            "type": "object"
         },
         "databricks:index/SqlEndpointOdbcParam:SqlEndpointOdbcParam": {
             "properties": {
@@ -8210,13 +8152,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "hostname",
-                "path",
-                "port",
-                "protocol"
-            ]
+            "type": "object"
         },
         "databricks:index/SqlEndpointTags:SqlEndpointTags": {
             "properties": {
@@ -8863,11 +8799,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "message",
-                "state"
-            ]
+            "type": "object"
         },
         "databricks:index/VectorSearchEndpointTimeouts:VectorSearchEndpointTimeouts": {
             "properties": {
@@ -8992,13 +8924,7 @@
                     "type": "boolean"
                 }
             },
-            "type": "object",
-            "required": [
-                "indexUrl",
-                "indexedRowCount",
-                "message",
-                "ready"
-            ]
+            "type": "object"
         },
         "databricks:index/VectorSearchIndexTimeouts:VectorSearchIndexTimeouts": {
             "properties": {
@@ -10314,16 +10240,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "fileSize",
-                "path"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getExternalLocationExternalLocationInfo:getExternalLocationExternalLocationInfo": {
             "properties": {
@@ -14858,16 +14775,7 @@
                     "type": "string"
                 }
             },
-            "type": "object",
-            "required": [
-                "language",
-                "path"
-            ],
-            "language": {
-                "nodejs": {
-                    "requiredInputs": []
-                }
-            }
+            "type": "object"
         },
         "databricks:index/getSchemaSchemaInfo:getSchemaSchemaInfo": {
             "properties": {

--- a/pkg/pf/proto/element.go
+++ b/pkg/pf/proto/element.go
@@ -127,17 +127,46 @@ func (m elementObjectMap) GetOk(key string) (shim.Schema, bool) {
 	if !ok {
 		return nil, false
 	}
-	_, optional := m.OptionalAttributes[key]
-	return newElement(v, optional), true
+	return newElement(v, m.optional(key)), true
 }
 
 func (m elementObjectMap) Range(each func(key string, value shim.Schema) bool) {
 	for k, v := range m.AttributeTypes {
-		_, optional := m.OptionalAttributes[k]
-		if !each(k, newElement(v, optional)) {
+		if !each(k, newElement(v, m.optional(k))) {
 			return
 		}
 	}
+}
+
+// optional reports whether the named attribute of this object type should be
+// treated as optional.
+//
+// The plugin wire protocol expresses per-field optionality of an object type
+// only through [tftypes.Object.OptionalAttributes]. An SDKv2 provider that
+// serializes an attribute-as-blocks shape (a block with
+// ConfigMode: SchemaConfigModeAttr) does not populate it, so the per-field
+// optionality is simply absent from the wire schema. When no attribute is
+// marked optional we cannot distinguish "every field is required" from
+// "optionality is unknown", so we default to optional rather than incorrectly
+// marking every field required.
+//
+// This loss is intentional upstream, not a bug we can fix in SDKv2. SDKv2
+// lowers a ConfigMode: SchemaConfigModeAttr block to a typed attribute whose
+// type is computed by configschema.Block.ImpliedType. That method builds a
+// plain cty.Object from each nested attribute's type and discards its
+// Optional/Required flag (it never emits cty.ObjectWithOptionalAttrs). Terraform
+// itself never relies on the implied type for this: it validates configuration
+// against the block's decoder spec, which retains optionality, while the wire
+// protocol only carries the lossy implied type. The bridge has access only to
+// the wire schema, so defaulting to optional is the closest we can get. The
+// Plugin Framework path is unaffected because it serializes nested objects as
+// NestedType, carrying per-field Optional flags (handled by [object]).
+func (m elementObjectMap) optional(key string) bool {
+	if len(m.OptionalAttributes) == 0 {
+		return true
+	}
+	_, optional := m.OptionalAttributes[key]
+	return optional
 }
 
 func (m elementObjectMap) Validate() error { return nil }

--- a/pkg/pf/proto/protov6_test.go
+++ b/pkg/pf/proto/protov6_test.go
@@ -150,6 +150,48 @@ func TestBlockSchemaGeneration(t *testing.T) {
 		"Blocks should map to input properties")
 }
 
+// TestAttributeAsBlocksRequired asserts that when no required/optional information is present, then we fall back to
+// assuming all fields are optional.
+func TestAttributeAsBlocksRequired(t *testing.T) {
+	t.Parallel()
+	p := proto.New(t.Context(), providerServer{
+		SchemaResponse: &tfprotov6.GetProviderSchemaResponse{
+			ResourceSchemas: map[string]*tfprotov6.Schema{
+				"testprov_my_res": {Block: &tfprotov6.SchemaBlock{
+					Attributes: []*tfprotov6.SchemaAttribute{{
+						Name:     "ingress",
+						Optional: true,
+						Type: tftypes.List{ElementType: tftypes.Object{
+							AttributeTypes: map[string]tftypes.Type{
+								"from_port":   tftypes.Number,
+								"to_port":     tftypes.Number,
+								"protocol":    tftypes.String,
+								"description": tftypes.String,
+								"cidr_blocks": tftypes.List{ElementType: tftypes.String},
+							},
+						}},
+					}},
+				}},
+			},
+		},
+	})
+	providerInfo := info.Provider{
+		P:    p,
+		Name: "testprov",
+		Resources: map[string]*info.Resource{
+			"testprov_my_res": {
+				Tok: "testprov:index:MyRes",
+			},
+		},
+	}
+	nilSink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+	spec, err := tfgen.GenerateSchema(providerInfo, nilSink)
+	require.NoError(t, err)
+
+	typ := spec.Types["testprov:index/MyResIngress:MyResIngress"]
+	autogold.Expect([]string{}).Equal(t, typ.Required)
+}
+
 type providerServer struct {
 	tfprotov6.ProviderServer // This will panic if un-overridden methods are called
 

--- a/pkg/pf/tests/attribute_as_blocks_test.go
+++ b/pkg/pf/tests/attribute_as_blocks_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"io"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	sdkschema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/proto"
+	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+)
+
+// An SDKv2 block declared with ConfigMode: SchemaConfigModeAttr ("attribute-as-blocks") is not
+// serialized as a NestedBlock over the Terraform plugin wire protocol. Instead it becomes an
+// Attribute whose type is a List<Object>. The per-field Optional/Required information that exists
+// in the SDKv2 Go source is *not* encoded into that object type: the wire type carries no
+// OptionalAttributes.
+func TestSDKv2AttributeAsBlocksOptionalityLostOverWire(t *testing.T) {
+	t.Parallel()
+
+	sdkProv := &sdkschema.Provider{
+		ResourcesMap: map[string]*sdkschema.Resource{
+			"testprovider_sg": {
+				Schema: map[string]*sdkschema.Schema{
+					"ingress": {
+						Type:       sdkschema.TypeList,
+						Optional:   true,
+						ConfigMode: sdkschema.SchemaConfigModeAttr,
+						Elem: &sdkschema.Resource{
+							Schema: map[string]*sdkschema.Schema{
+								"from_port": {Type: sdkschema.TypeInt, Required: true},
+								"to_port":   {Type: sdkschema.TypeInt, Required: true},
+								"protocol":  {Type: sdkschema.TypeString, Required: true},
+								// description is optional in the SDKv2 source. This is the field
+								// whose optionality is lost over the wire.
+								"description": {Type: sdkschema.TypeString, Optional: true},
+								"cidr_blocks": {
+									Type:     sdkschema.TypeList,
+									Optional: true,
+									Elem:     &sdkschema.Schema{Type: sdkschema.TypeString},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v6server, err := tf5to6server.UpgradeServer(t.Context(), func() tfprotov5.ProviderServer {
+		return sdkProv.GRPCProvider()
+	})
+	require.NoError(t, err)
+
+	// Part 1: show the root cause directly on the wire schema.
+	schemaResp, err := v6server.GetProviderSchema(t.Context(), &tfprotov6.GetProviderSchemaRequest{})
+	require.NoError(t, err)
+	var ingressAttr *tfprotov6.SchemaAttribute
+	for _, a := range schemaResp.ResourceSchemas["testprovider_sg"].Block.Attributes {
+		if a.Name == "ingress" {
+			ingressAttr = a
+		}
+	}
+	require.NotNil(t, ingressAttr, "ConfigMode attr block should appear as an attribute, not a block")
+	require.Nil(t, ingressAttr.NestedType, "attribute-as-blocks is typed, not a NestedType, over the wire")
+
+	listType, ok := ingressAttr.Type.(tftypes.List)
+	require.True(t, ok, "ingress should be a List, got %v", ingressAttr.Type)
+	objType, ok := listType.ElementType.(tftypes.Object)
+	require.True(t, ok, "ingress element should be an Object, got %v", listType.ElementType)
+
+	// The object carries all five field types but no per-field optionality: this is the
+	// information the bridge cannot recover.
+	require.Len(t, objType.AttributeTypes, 5)
+	require.Empty(t, objType.OptionalAttributes,
+		"SDKv2 does not encode per-field optionality for attribute-as-blocks over the wire")
+
+	// Part 2: show that the dynamic bridge defaults to optional rather than required.
+	info := tfbridge0.ProviderInfo{
+		Name:         "testprovider",
+		Version:      "0.0.1",
+		P:            proto.New(t.Context(), v6server),
+		MetadataInfo: &tfbridge0.MetadataInfo{},
+		Resources: map[string]*tfbridge0.ResourceInfo{
+			"testprovider_sg": {Tok: "testprovider:index:Sg"},
+		},
+	}
+
+	nilSink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+	spec, err := tfgen.GenerateSchema(info, nilSink)
+	require.NoError(t, err)
+
+	require.Empty(t, spec.Types["testprovider:index/SgIngress:SgIngress"].Required)
+}


### PR DESCRIPTION
## Problem

When a Terraform provider is **dynamically bridged** (schema sourced from the provider's plugin-protocol wire schema rather than tfgen'd from SDKv2 Go source), a `ConfigMode: schema.SchemaConfigModeAttr` block has **every** nested field marked required in the generated Pulumi schema. Genuinely-optional fields aree reported as required.

This surfaced downstream in [pulumi-hcl#204](https://github.com/pulumi-labs/pulumi-hcl/issues/204), where an inline rule like:

```hcl
ingress {
  from_port   = 0
  to_port     = 0
  protocol    = "-1"
  cidr_blocks = ["10.0.0.0/16"]
}
```

was rejected with `Missing required argument; The argument "description" is required` even though it plans cleanly under OpenTofu. The required-set was baked into the bridged schema itself, so the problem was in the bridge, not the consumer.

Repro against `hashicorp/aws`:

```console
$ pulumi package get-schema terraform-provider hashicorp/aws \
    | jq '.types["aws:index/SecurityGroupIngress:SecurityGroupIngress"].required'
[ "cidrBlocks", "description", "fromPort", "ipv6CidrBlocks", "prefixListIds",
  "protocol", "securityGroups", "self", "toPort" ]
```

## Root cause

An SDKv2 block declared with `ConfigMode: SchemaConfigModeAttr` is **not** serialized as a `NestedBlock` over the Terraform plugin wire protocol. It becomes an `Attribute` whose type is a `List<Object>`. The per-field `Optional`/`Required` information that exists in the SDKv2 Go source is **not** encoded into that object type — the wire `tftypes.Object` carries no `OptionalAttributes`.

The dynamic bridge consumes only the wire schema (`pkg/pf/proto`). In `elementObjectMap`, optionality was derived solely from `tftypes.Object.OptionalAttributes`, so a field absent from that (always-empty) set was treated as **required**.

The information is genuinely absent from the wire schema, so it cannot be recovered.

<details>

<summary> Why not fix this upstream in SDKv2? </summary>

This loss is **intentional, long-standing Terraform behavior, not an SDKv2 bug.** The chain is:

1. SDKv2 lowers a `ConfigMode: SchemaConfigModeAttr` block to a typed attribute whose cty type is computed by `coreConfigSchemaType` → `set.coreConfigSchema().ImpliedType()` (`helper/schema/core_schema.go`).
2. `configschema.Block.ImpliedType()` builds a plain `cty.Object` from each nested attribute's `Type` and **discards its `Optional`/`Required` flag** — it never emits `cty.ObjectWithOptionalAttrs`:

   ```go
   for name, attrS := range b.Attributes {
       atys[name] = attrS.Type   // only the type; optionality dropped
   }
   return cty.Object(atys)        // => every field required
   ```

This is by design. Terraform/OpenTofu's own `Block.ImpliedType` doc comment states the returned type has "no objects with optional attributes, since this value is not to be used for the decoding of configuration." Optionality instead lives in the block's *decoder spec* (`hcldec.Spec`), which is used to decode HCL bodies into cty values.

But the decoder spec is **never serialized over the wire**. The plugin protocol's `Schema` message (see `terraform-plugin-go`'s `SchemaBlock`/`SchemaAttribute`) carries only the cty `Type`, the PF-style `NestedType`, and flat `Optional`/`Required`/`Computed` flags on the attribute itself — nothing that re-encodes the per-field optionality of a plain `cty.Object` attribute type. The decoder spec is recomputed locally from a `configschema.Block` on whichever side needs it. So Terraform core hits the *same* loss: when it rebuilds a `configschema.Block` from the wire schema via `ProtoToConfigSchema` and calls `DecoderSpec()`, the nested object is all-required there too.

Terraform avoids the symptom not by recovering optionality, but via its `lang/blocktoattr` fixup. When decoding block syntax for an attribute-as-blocks, it synthesizes an ephemeral schema from the attribute's cty element type in which **every nested attribute is marked optional** (`SchemaForCtyElementType`):

```go
// terraform: internal/lang/blocktoattr/schema.go
for name, aty := range atys {
    ret.Attributes[name] = &configschema.Attribute{
        Type:     aty,
        Optional: true,   // every nested field treated as optional
    }
}
```

So Terraform's own behavior for these is "treat all nested fields as optional" — which is exactly what this PR does in the bridge. Defaulting to optional is therefore the faithful behavior, not a workaround.

cty *can* express per-field optionality (`cty.ObjectWithOptionalAttrs`), and the modern path does: Plugin Framework nested objects serialize as `NestedType` with per-field `Optional` flags over the wire (work tracked in [terraform-plugin-go#48](https://github.com/hashicorp/terraform-plugin-go/issues/48)). That's why this bug is specific to SDKv2 attribute-as-blocks and never affects PF providers — the bridge's `object`/`attrMap` path reads those flags correctly. SDKv2's legacy attribute-as-blocks predates optional object attributes and was never migrated.

So there's no upstream fix to wait on, and changing `ImpliedType` upstream would break a deliberately-stable representation.

</details>

## Solution

In `pkg/pf/proto/element.go`, when an object type's `OptionalAttributes` set is empty we cannot distinguish "every field is required" from "optionality is unknown", so we default to **optional** rather than incorrectly marking every field required. When `OptionalAttributes` *is* populated we honor it exactly, preserving genuine cty optional-attribute semantics.

This means that genuinely-required fields (`fromPort`, `protocol`, `toPort`) also become optional under the dynamic bridge, since their requiredness isn't recoverable from the wire schema. Defaulting to optional is a better trade-off then defaulting to required, since it allows users to express all valid input shapes.

Fixes https://github.com/pulumi/pulumi-terraform-bridge/issues/3467
Fixes https://github.com/pulumi-labs/pulumi-hcl/issues/204