### PR TITLE
Replay default fixups from runtime metadata

### DIFF
--- a/docs/specs/gh-3430-default-token-fixup-laziness.md
+++ b/docs/specs/gh-3430-default-token-fixup-laziness.md
@@ -1,0 +1,237 @@
+# GH-3430 Default Token Fixup Laziness
+
+## Summary
+
+Issue [#3430](https://github.com/pulumi/pulumi-terraform-bridge/issues/3430)
+tracks a remaining broad-schema-load path after lazy Terraform Plugin Framework
+schema loading. In muxed SDKv2/PF providers, provider startup can still load
+every PF resource schema while computing tokens and default compatibility
+fixups, even when the Pulumi program uses only SDKv2 resources.
+
+The desired behavior is:
+
+1. Token/resource metadata initialization may enumerate resource names.
+2. Startup must not call `Schema()` for every PF resource.
+3. Existing default compatibility behavior for `id`, missing IDs, `urn`, and
+   `pulumi` remains available for resources that need it.
+4. A selected PF resource may load its own schema as part of the normal PF RPC
+   path; unused PF resources must remain unloaded.
+
+This is a runtime memory behavior change. It should not change generated
+Pulumi schema output.
+
+## Current Flow
+
+Downstream providers commonly call `ProviderInfo.MustComputeTokens` during
+provider initialization. That enters `pkg/tfbridge/tokens.ComputeTokens`, which
+calls `applyDefaultFixups` before default resource and data source token
+computation.
+
+The broad load is in the default fixup pass:
+
+1. `ComputeTokens` calls `applyDefaultFixups` unless `SkipDefaultFixups` is set.
+2. `applyDefaultFixups` calls `fixPropertyConflict` and `fixMissingIDs`.
+3. Both fixups call `walkResources`.
+4. `walkResources` enumerates `p.P.ResourcesMap()`.
+5. `fixPropertyConflict` calls `r.TF.Schema().Range(...)`.
+6. `fixMissingIDs` calls `r.TF.Schema().GetOk("id")`.
+
+On a PF schema-only resource, `schemaOnlyResource.Schema()` delegates to the
+lazy PF schema adapter. Calling it forces the selected resource schema to load.
+Because the current fixup pass walks every resource, a muxed provider pays for
+all PF resource schemas during startup.
+
+Relevant code:
+
+- `pkg/tfbridge/tokens/tokens.go`: `ComputeTokens`.
+- `pkg/tfbridge/tokens/fixups.go`: `applyDefaultFixups`,
+  `fixPropertyConflict`, `fixMissingIDs`, and `walkResources`.
+- `pkg/pf/internal/schemashim/resource.go`: `schemaOnlyResource.Schema`.
+- `pkg/pf/internal/pfutils/lazy_schema.go`: lazy schema load triggers such as
+  `Attrs`, `Type`, and `ResourceProtoSchema`.
+- `pkg/pf/internal/muxer/muxer.go`: PF ownership helpers such as
+  `ResourceIsPF`.
+
+## Desired Semantics
+
+1. Default token computation still creates missing `Resources` and
+   `DataSources` entries from resource and data source names.
+2. Build-time schema-generation paths still run schema-dependent default fixups
+   for PF-owned resources, because those paths already materialize PF schemas.
+3. Runtime startup for generated/static PF-owned resources consumes precomputed
+   fixup metadata and does not inspect every PF resource schema.
+4. SDKv2 resources keep the current eager default fixup behavior.
+5. Startup fixups remain idempotent. If provider code already set a field
+   rename or `ComputeID`, runtime metadata application must preserve it.
+6. `IgnoreMappings` still skips ignored resources.
+7. `SkipDefaultFixups` still disables default fixups globally.
+8. Provider-resource token fixup remains name-based and should not require PF
+   resource schema loading.
+9. `GetMapping` must continue to expose the same field-name compatibility
+   decisions for conversion metadata. A solution that only mutates
+   `ResourceInfo` after a selected runtime RPC is not sufficient unless it first
+   proves those deferred decisions are irrelevant to mapping consumers.
+10. Because `ComputeTokens` is used by both tfgen/build-time and runtime
+    provider startup, any skip capability must be gated by phase or by proven
+    presence of equivalent precomputed metadata. A blind
+    `DeferResourceSchemaFixups` hook would risk changing generated schema
+    output.
+
+## Design
+
+Split default fixups into name-only work, schema-derived field metadata, and
+runtime-only `ComputeID` behavior.
+
+The name-only token path should continue to enumerate `ResourcesMap` and
+`DataSourcesMap` so bridge metadata and dispatch can be built. Enumeration is
+cheap for PF schema-only resources because the lazy PF branch already gathers
+type metadata without calling resource `Schema`.
+
+The schema-dependent resource fixup path should become reusable for one
+resource at a time. The existing `fixID`, `fixURN`, `fixPulumi`, and missing-ID
+logic are already mostly per-resource; the implementation should factor them
+behind a helper that accepts `resourceInfo` and applies the same compatibility
+rules to one resource. Keep the field-name decisions (`SchemaInfo.Name` and
+`SchemaInfo.Type`) separable from runtime-only `ComputeID` functions, because
+`MarshalProviderInfo` persists fields into mapping data but does not persist
+`ComputeID`.
+
+The first-choice implementation is build-time precomputation:
+
+1. During tfgen/schema generation, keep running schema-dependent default fixups
+   for PF-owned resources. This preserves generated Pulumi schema output and
+   mapping field metadata while schemas are already allowed to load.
+2. Persist or preserve the resulting field decisions in generated/provider
+   metadata. At minimum this covers `SchemaInfo.Name` and `SchemaInfo.Type` for
+   `id`, `urn`, and `pulumi` compatibility.
+3. Store compact runtime fixup metadata in `ProviderInfo.MetadataInfo`
+   (`bridge-metadata.json`) under a new bridge-owned key, and declare that key
+   as runtime metadata so `ExtractRuntimeMetadata` copies it into
+   `runtime-bridge-metadata.json` when providers generate a runtime-only
+   metadata file. The metadata should describe the default `ComputeID` decision
+   without embedding functions, for example:
+   - missing ID placeholder;
+   - delegate ID from a concrete Pulumi field name;
+   - no default runtime `ComputeID` needed.
+   `ExtractRuntimeMetadata` should also write a bridge-internal runtime marker
+   into the generated metadata blob. Runtime providers should keep using the
+   existing `tfbridge.NewProviderMetadata(...)` call shape; the shared
+   `ComputeTokens` path should detect runtime metadata from the marker, not from
+   provider call-site changes.
+4. During runtime startup, call a single helper such as
+   `applyPrecomputedDefaultFixups(&info)` immediately after embedded metadata is
+   available and before constructing the RPC provider object or mux mapping
+   closures. The helper mutates the runtime `ProviderInfo` copy once, before
+   `GetMapping`, encoder/decoder setup, defaults, diagnostics, or lifecycle
+   paths can observe `ResourceInfo`.
+
+Only after proving the precomputed metadata is present should runtime startup
+skip schema-dependent live schema inspection for PF-owned resources. Keep PF
+ownership as a narrow signal instead of importing PF internals into
+`pkg/tfbridge/tokens`. This interface is only one input to the runtime decision,
+not the decision itself:
+
+```go
+type precomputedResourceSchemaFixupCandidate interface {
+    ResourceSchemaFixupsMayBePrecomputed(tfToken string) bool
+}
+```
+
+The PF schema-only provider can return true for its resources. The mux provider
+can return true only for resources owned by the PF side, preserving SDKv2 eager
+fixups. The existing mux ownership helper `ResourceIsPF` is the current model
+to mirror. The runtime skip predicate should be closer to:
+
+```text
+runtime mode
+&& resource is a precomputed-fixup candidate
+&& metadata has a resource entry for this tfToken
+```
+
+If any part is false, runtime must keep the existing schema-inspecting behavior
+or fail explicitly rather than silently dropping fixups.
+
+An empty resource entry is meaningful: it means build time inspected that
+resource schema and found no default field rename or `ComputeID` fixup to
+replay. A missing resource entry is different and should not be treated as
+proof that no fixups are required.
+
+The implementation must distinguish build-time/schema-generation from runtime
+startup. Either add an explicit phase or mode to the shared token/fixup path, or
+make the runtime skip conditional on finding equivalent precomputed metadata for
+the PF-owned resource. Without that guard, the same `ComputeTokens` change could
+silently skip schema-derived fixups during tfgen and change generated schema
+output.
+
+Selected-resource runtime fixups are a fallback, not the primary design. Use
+them only if the build-time metadata route cannot represent a specific
+runtime-only decision, and only after proving late mutation cannot affect
+`GetMapping`, encoders/decoders, defaults, diagnostics, schema metadata, or
+other code that expects final `ResourceInfo.Fields`.
+
+Keep the fixup helper idempotent. The existing rules already preserve explicit
+provider decisions such as field-name overrides and custom `ComputeID`; tests
+should keep those protections.
+
+## Compatibility Risks
+
+- `id` handling is the highest-risk behavior. The current eager fixup can rename
+  input IDs, preserve computed string IDs, synthesize `ComputeID`, and install a
+  missing-ID placeholder. Precomputed metadata must cover the same cases without
+  broad runtime PF schema inspection.
+- `urn` and `pulumi` are narrower because they only need to know whether those
+  top-level Terraform properties exist and whether the proposed replacement
+  name is available.
+- Direct PF providers and muxed PF providers should share the same runtime
+  metadata-consumption behavior. SDKv2-only providers should not change.
+- Build-time schema generation still needs full schema materialization and
+  must not use the runtime skip path.
+- `ComputeTokens` is shared by build-time and runtime startup. Any phase/mode
+  split must be explicit enough that tfgen cannot accidentally skip
+  schema-derived fixups.
+- Late selected-resource mutation is risky because mapping data, encoders,
+  decoders, defaults, diagnostics, and schema metadata may already have observed
+  `ResourceInfo`.
+- Dynamic providers or parameterized providers may not have the same static
+  generated-schema assumptions. If a provider cannot safely defer, it should not
+  opt into the deferred-fixup capability.
+
+## Validation
+
+Add focused bridge tests before downstream AWS proof.
+
+1. Unit-test the factored per-resource fixup helper in
+   `pkg/tfbridge/tokens/fixups_test.go` by reusing the existing `id`, missing
+   ID, `urn`, `pulumi`, ignored mapping, and explicit override cases.
+2. Add build-time/schema-generation coverage proving PF schemas still receive
+   schema-dependent default fixups and generated field metadata does not change
+   for `id`, `urn`, and `pulumi` cases.
+3. Add metadata coverage proving the new fixup metadata is written to
+   `bridge-metadata.json`, included by `ExtractRuntimeMetadata` in
+   `runtime-bridge-metadata.json`, reloaded through the existing
+   `NewProviderMetadata(runtimeMetadata)` call shape, and applied before both
+   SDKv2 and PF `GetMapping` marshal `ProviderInfo`.
+4. Add runtime metadata-consumption coverage proving `ComputeTokens` can skip
+   live PF schema inspection only when equivalent precomputed metadata is
+   present.
+5. Add a startup regression in `pkg/pf/tests/mux_lazy_schema_test.go`:
+   construct a muxed SDKv2/PF provider, call `ComputeTokens` or the same
+   provider-info initialization path used by the test provider, and assert the
+   PF counting provider still reports zero resource schema calls.
+6. Extend the same mux test to select one PF resource and assert only that PF
+   resource schema is loaded, not unrelated PF resources.
+7. Add PF metadata cases for:
+   - required or optional/computed `id` needing rename and delegated ID;
+   - no `id` needing missing-ID behavior;
+   - top-level `urn` rename;
+   - top-level `pulumi` rename.
+8. Run targeted tests first:
+
+```bash
+make test RUN_TEST_CMD='./pkg/tfbridge/tokens -run Test'
+make test RUN_TEST_CMD='./pkg/pf/tests -run TestMuxedSDKv2OperationsDoNotLoadPFResourceSchemas'
+```
+
+9. For final confidence, rerun the downstream AWS SDKv2-only S3 memory probe
+   that motivated the issue and verify zero broad PF schema loads during
+   startup.

--- a/pkg/pf/internal/muxer/muxer.go
+++ b/pkg/pf/internal/muxer/muxer.go
@@ -118,6 +118,14 @@ func (m *ProviderShim) ResourceIsPF(token string) bool {
 	return false
 }
 
+// ResourceSchemaFixupsMayBePrecomputed reports whether token is PF-owned and
+// therefore eligible to consume build-time default-fixup metadata at runtime.
+// The caller still requires runtime metadata with an entry for the resource
+// before it skips live schema inspection.
+func (m *ProviderShim) ResourceSchemaFixupsMayBePrecomputed(token string) bool {
+	return m.ResourceIsPF(token)
+}
+
 // Check if a DataSource is served via the Plugin Framework.
 func (m *ProviderShim) DataSourceIsPF(token string) bool {
 	// In an augmented shim.Provider, underlying providers are PF providers iff they

--- a/pkg/pf/internal/schemashim/provider.go
+++ b/pkg/pf/internal/schemashim/provider.go
@@ -98,6 +98,15 @@ func (p *SchemaOnlyProvider) ResourcesMap() shim.ResourceMap {
 	return p.resourceMap
 }
 
+// ResourceSchemaFixupsMayBePrecomputed reports whether tfToken is a PF
+// schema-only resource and therefore eligible to consume build-time
+// default-fixup metadata at runtime. The caller still requires runtime metadata
+// with an entry for the resource before it skips live schema inspection.
+func (p *SchemaOnlyProvider) ResourceSchemaFixupsMayBePrecomputed(tfToken string) bool {
+	_, ok := p.resourceMap.GetOk(tfToken)
+	return ok
+}
+
 func (p *SchemaOnlyProvider) DataSourcesMap() shim.ResourceMap {
 	return p.dataSourceMap
 }

--- a/pkg/pf/tests/mux_lazy_schema_test.go
+++ b/pkg/pf/tests/mux_lazy_schema_test.go
@@ -39,6 +39,7 @@ import (
 
 	tfpf "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	bridgetokens "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	sdkv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/x/muxer"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
@@ -131,6 +132,25 @@ func TestMuxedSDKv2OperationsDoNotLoadPFResourceSchemas(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, aliasCalls, pfProvider.resourceSchemaCalls("alias"))
+}
+
+func TestMuxedRuntimeComputeTokensDoesNotLoadPFResourceSchemas(t *testing.T) {
+	t.Parallel()
+
+	buildInfo := muxLazyProviderInfo(newMuxCountingProvider())
+	require.NoError(t, buildInfo.ComputeTokens(bridgetokens.SingleModule(
+		buildInfo.GetResourcePrefix(), "index", bridgetokens.MakeStandard(buildInfo.Name),
+	)))
+
+	pfProvider := newMuxCountingProvider()
+	runtimeInfo := muxLazyProviderInfo(pfProvider)
+	runtimeMetadata := tfbridge0.ExtractRuntimeMetadata(buildInfo.MetadataInfo)
+	runtimeInfo.MetadataInfo = tfbridge0.NewProviderMetadata(
+		(*metadata.Data)(runtimeMetadata.Data).Marshal())
+	require.NoError(t, runtimeInfo.ComputeTokens(bridgetokens.SingleModule(
+		runtimeInfo.GetResourcePrefix(), "index", bridgetokens.MakeStandard(runtimeInfo.Name),
+	)))
+	pfProvider.requireZeroSchemaCalls(t)
 }
 
 func muxLazyProviderInfo(pfProvider *muxCountingProvider) tfbridge0.ProviderInfo {

--- a/pkg/tfbridge/internal/metadatakeys/keys.go
+++ b/pkg/tfbridge/internal/metadatakeys/keys.go
@@ -1,0 +1,20 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadatakeys
+
+const (
+	DefaultResourceSchemaFixups = "default-resource-schema-fixups"
+	RuntimeMetadata             = "runtime-metadata"
+)

--- a/pkg/tfbridge/metadata.go
+++ b/pkg/tfbridge/metadata.go
@@ -17,7 +17,10 @@ package tfbridge
 import (
 	"sync"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/internal/metadatakeys"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 )
 
@@ -40,8 +43,9 @@ var declaredRuntimeMetadata = struct {
 	keys map[string]struct{}
 	m    sync.Mutex
 }{keys: map[string]struct{}{
-	autoSettingsKey: {},
-	"mux":           {},
+	autoSettingsKey:                          {},
+	metadatakeys.DefaultResourceSchemaFixups: {},
+	"mux":                                    {},
 }}
 
 func declareRuntimeMetadata(label string) {
@@ -50,15 +54,22 @@ func declareRuntimeMetadata(label string) {
 	declaredRuntimeMetadata.keys[label] = struct{}{}
 }
 
-// trim the metadata to just the keys required for the runtime phase
-// in the future this method might also substitute compressed contents within some keys
-func ExtractRuntimeMetadata(info *MetadataInfo) *MetadataInfo {
+// ExtractRuntimeMetadata trims provider metadata to the keys needed by runtime
+// provider startup.
+//
+// The returned metadata includes an internal runtime marker in the blob itself.
+// Runtime consumers intentionally key off that marker, not MetadataInfo.Path,
+// because downstream providers may embed these bytes and still load them through
+// NewProviderMetadata.
+func ExtractRuntimeMetadata(metadataInfo *MetadataInfo) *MetadataInfo {
 	data, _ := metadata.New(nil)
 	declaredRuntimeMetadata.m.Lock()
 	defer declaredRuntimeMetadata.m.Unlock()
 	for k := range declaredRuntimeMetadata.keys {
-		metadata.CloneKey(k, info.Data, data)
+		metadata.CloneKey(k, metadataInfo.Data, data)
 	}
+	err := metadata.Set(data, metadatakeys.RuntimeMetadata, true)
+	contract.AssertNoErrorf(err, "failed to write runtime metadata marker")
 
 	return &MetadataInfo{
 		Path: "runtime-bridge-metadata.json",

--- a/pkg/tfbridge/metadata_test.go
+++ b/pkg/tfbridge/metadata_test.go
@@ -21,6 +21,8 @@ func TestMetadataInfo(t *testing.T) {
 	require.NoError(t, err)
 	err = md.Set(data, autoSettingsKey, []string{"..."})
 	require.NoError(t, err)
+	err = md.Set(data, "default-resource-schema-fixups", []string{"fixups"})
+	require.NoError(t, err)
 	err = md.Set(data, "mux", []string{"a", "b"})
 	require.NoError(t, err)
 
@@ -32,6 +34,9 @@ func TestMetadataInfo(t *testing.T) {
     ],
     "auto-settings": [
         "..."
+    ],
+    "default-resource-schema-fixups": [
+        "fixups"
     ],
     "hi": [
         "hello",
@@ -54,6 +59,9 @@ func TestMetadataInfo(t *testing.T) {
     "auto-settings": [
         "..."
     ],
+    "default-resource-schema-fixups": [
+        "fixups"
+    ],
     "hi": [
         "hello",
         "world"
@@ -71,9 +79,30 @@ func TestMetadataInfo(t *testing.T) {
     "auto-settings": [
         "..."
     ],
+    "default-resource-schema-fixups": [
+        "fixups"
+    ],
     "mux": [
         "a",
         "b"
-    ]
+    ],
+    "runtime-metadata": true
 }`).Equal(t, string(runtimeMarshalled))
+
+	embeddedRuntimeMetadata := NewProviderMetadata((*md.Data)(runtimeMetadata.Data).Marshal())
+	assert.Equal(t, "bridge-metadata.json", embeddedRuntimeMetadata.Path)
+	embeddedRuntimeMarshalled := (*md.Data)(embeddedRuntimeMetadata.Data).MarshalIndent()
+	autogold.Expect(`{
+    "auto-settings": [
+        "..."
+    ],
+    "default-resource-schema-fixups": [
+        "fixups"
+    ],
+    "mux": [
+        "a",
+        "b"
+    ],
+    "runtime-metadata": true
+}`).Equal(t, string(embeddedRuntimeMarshalled))
 }

--- a/pkg/tfbridge/tokens/fixups.go
+++ b/pkg/tfbridge/tokens/fixups.go
@@ -26,41 +26,374 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/internal/metadatakeys"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/internal/naming"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/log"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 )
 
+// applyDefaultFixups installs the bridge's historical default ResourceInfo fixups.
+//
+// Build-time callers still run the schema-inspecting path and record the
+// decisions that are safe to replay. Runtime callers may replay those recorded
+// decisions for PF-owned resources so provider startup can avoid calling
+// Schema() for every PF resource.
 func applyDefaultFixups(p *info.Provider) error {
-	fixCtx := newFixCtx(p)
-	if p.Name == "" {
-		return fixMissingIDs(fixCtx, p)
+	fixCtx, err := newFixCtx(p)
+	if err != nil {
+		return err
 	}
-	return errors.Join(
-		fixPropertyConflict(fixCtx, p),
-		fixMissingIDs(fixCtx, p),
-	)
+	err = walkResources(fixCtx, p, func(r resourceInfo) error {
+		// A true result means runtime metadata had a resource entry and replayed
+		// everything build time learned for this resource. The entry may be empty:
+		// that still proves build time inspected the schema and found no default
+		// fixup to apply.
+		applied, err := fixCtx.applyPrecomputedResourceFixups(p, r.TFName, r.Schema)
+		if err != nil {
+			return err
+		}
+		if applied {
+			return nil
+		}
+
+		// If no precomputed entry handled the resource, run the eager path. The
+		// recorder captures the small set of eager decisions that can be serialized
+		// into provider metadata for future runtime replay.
+		recorder := &resourceFixupRecorder{}
+		r.recorder = recorder
+		if p.Name == "" {
+			err = fixMissingID(r)
+		} else {
+			err = errors.Join(
+				fixPropertyConflictForResource(p, r),
+				fixMissingID(r),
+			)
+		}
+		if err != nil {
+			return err
+		}
+
+		fixCtx.recordResourceFixups(p, r)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return fixCtx.saveResourceFixups()
 }
 
-func newFixCtx(p *info.Provider) fixCtx {
+// newFixCtx builds the phase-aware state used by the resource walk.
+//
+// Runtime mode is detected from the metadata payload, not MetadataInfo.Path,
+// because real providers commonly pass embedded runtime metadata through
+// NewProviderMetadata. Build-time mode rewrites the fixup metadata from the
+// current schema walk; runtime mode only consumes existing metadata.
+func newFixCtx(p *info.Provider) (fixCtx, error) {
 	ignoredMappings := make(map[string]struct{}, len(p.IgnoreMappings))
 	for _, v := range p.IgnoreMappings {
 		ignoredMappings[v] = struct{}{}
 	}
-	return fixCtx{ignoredMappings}
+	ctx := fixCtx{ignoredMappings: ignoredMappings}
+	if p.MetadataInfo == nil || p.MetadataInfo.Data == nil {
+		return ctx, nil
+	}
+	ctx.metadata = p.MetadataInfo.Data
+	// The runtime marker is authoritative. Runtime metadata may still be loaded
+	// through NewProviderMetadata, so MetadataInfo.Path is not a reliable phase
+	// signal.
+	runtimeMode, foundRuntimeMarker, err := metadata.Get[bool](
+		p.MetadataInfo.Data, metadatakeys.RuntimeMetadata)
+	if err != nil {
+		return ctx, err
+	}
+	ctx.runtimeMode = foundRuntimeMarker && runtimeMode
+	if !ctx.runtimeMode {
+		// Build time starts from an empty set so stale resource entries disappear
+		// naturally when schemas or ownership change. If the key existed already,
+		// mark the context dirty so saveResourceFixups can also delete the key when
+		// this build records no eligible resources.
+		ctx.defaultFixups = defaultResourceSchemaFixups{
+			Resources: map[string]defaultResourceSchemaFixup{},
+		}
+		previousFixups, found, err := metadata.Get[defaultResourceSchemaFixups](
+			p.MetadataInfo.Data, metadatakeys.DefaultResourceSchemaFixups)
+		if err != nil {
+			return ctx, err
+		}
+		if found {
+			ctx.previousDefaultFixups = previousFixups
+		}
+		ctx.defaultChanged = found
+		return ctx, nil
+	}
+	// Runtime never creates or refreshes these records. If the runtime marker or
+	// the fixup key is absent, callers fall back to the eager schema-inspecting
+	// path for compatibility.
+	fixups, found, err := metadata.Get[defaultResourceSchemaFixups](
+		p.MetadataInfo.Data, metadatakeys.DefaultResourceSchemaFixups)
+	if err != nil {
+		return ctx, err
+	}
+	if fixups.Resources == nil {
+		fixups.Resources = map[string]defaultResourceSchemaFixup{}
+	}
+	ctx.defaultFixups = fixups
+	ctx.hasDefaultFixups = found
+	return ctx, nil
 }
 
+// fixCtx is the shared state for one default-fixup pass. It keeps runtime replay
+// and build-time recording behind the same resource walk without letting runtime
+// mutate generated metadata.
 type fixCtx struct {
 	ignoredMappings map[string]struct{}
+
+	// defaultFixups is either the build-time output being assembled or the
+	// runtime input being replayed.
+	defaultFixups    defaultResourceSchemaFixups
+	hasDefaultFixups bool
+	// previousDefaultFixups is build-time only. It lets repeated fixup passes
+	// preserve serialized ComputeID decisions that were already installed on
+	// ResourceInfo before the recorder was attached.
+	previousDefaultFixups defaultResourceSchemaFixups
+	// defaultChanged is build-time only. It is set when the metadata key needs to
+	// be written or removed after the walk.
+	defaultChanged bool
+	// runtimeMode is true only when the loaded metadata explicitly says it is
+	// runtime metadata.
+	runtimeMode bool
+	// metadata is retained so build-time callers can persist rewritten fixups.
+	metadata info.ProviderMetadata
 }
 
+// resourceInfo bundles the Pulumi ResourceInfo with the Terraform shim resource
+// currently being fixed. recorder is non-nil only while the eager path is
+// running and is used to capture replayable ComputeID decisions.
 type resourceInfo struct {
-	Schema *info.Resource
-	TF     shim.Resource
-	TFName string
+	Schema   *info.Resource
+	TF       shim.Resource
+	TFName   string
+	recorder *resourceFixupRecorder
 }
 
-func fixMissingIDs(fixCtx fixCtx, p *info.Provider) error {
+// defaultResourceSchemaFixups is generated bridge metadata that records the
+// schema-derived default fixup decisions made at build time. A resource entry
+// may be empty; that still means build time inspected the schema and found no
+// default field rename or ComputeID fixup to replay at runtime.
+type defaultResourceSchemaFixups struct {
+	Resources map[string]defaultResourceSchemaFixup `json:"resources,omitempty"`
+}
+
+// defaultResourceSchemaFixup is the runtime replay payload for one Terraform
+// resource token. An all-zero value is still meaningful when it is stored in the
+// Resources map: it means build time inspected the resource and had nothing to
+// replay, so runtime does not need to inspect the schema again.
+type defaultResourceSchemaFixup struct {
+	Fields    map[string]defaultSchemaFieldFixup `json:"fields,omitempty"`
+	ComputeID *defaultComputeIDFixup             `json:"computeID,omitempty"`
+}
+
+// defaultSchemaFieldFixup stores only the ResourceInfo.Fields attributes that
+// default property-conflict fixups synthesize. Those fields are consumed by
+// mapping, encoding, decoding, and schema metadata before any runtime schema
+// load would happen.
+type defaultSchemaFieldFixup struct {
+	Name string       `json:"name,omitempty"`
+	Type ptokens.Type `json:"type,omitempty"`
+}
+
+// defaultComputeIDFixup describes a ComputeID closure that can be rebuilt at
+// runtime. Function values are not serializable, so the metadata stores only the
+// default-fixup kind and, for delegated IDs, the Pulumi field to read.
+type defaultComputeIDFixup struct {
+	Kind  string `json:"kind"`
+	Field string `json:"field,omitempty"`
+}
+
+const (
+	// These kinds intentionally cover only ComputeID functions synthesized by
+	// this file's default fixups.
+	defaultComputeIDMissing  = "missing"
+	defaultComputeIDDelegate = "delegate"
+
+	pulumiTerraformProviderRepoURL = "https://github.com/pulumi/pulumi-terraform-provider"
+)
+
+const (
+	defaultFixupPropertyID     = "id"
+	defaultFixupPropertyPulumi = "pulumi"
+	defaultFixupPropertyURN    = "urn"
+)
+
+// precomputedResourceSchemaFixupCandidate identifies resources that may use
+// build-time fixup metadata at runtime. This is only an eligibility signal:
+// runtime skips schema inspection only when the runtime metadata marker exists
+// and the metadata contains an entry for the resource, even if that entry is
+// empty because no fixup was needed.
+type precomputedResourceSchemaFixupCandidate interface {
+	ResourceSchemaFixupsMayBePrecomputed(tfToken string) bool
+}
+
+// resourceFixupRecorder is attached while eager fixups run so they can record
+// the serializable form of any default ComputeID they install. It avoids
+// re-deriving the same decision from a resource schema during runtime startup.
+type resourceFixupRecorder struct {
+	computeID *defaultComputeIDFixup
+}
+
+// recordComputeIDFixup is a no-op outside the eager path used for build-time
+// recording.
+func (r resourceInfo) recordComputeIDFixup(kind, field string) {
+	if r.recorder == nil {
+		return
+	}
+	r.recorder.computeID = &defaultComputeIDFixup{Kind: kind, Field: field}
+}
+
+// applyPrecomputedResourceFixups replays build-time fixup metadata for one
+// runtime resource. It returns true once a metadata entry handles the resource,
+// even when that entry is empty, because the entry itself is the proof that
+// build time already inspected the schema.
+func (ctx fixCtx) applyPrecomputedResourceFixups(
+	p *info.Provider, tfToken string, res *info.Resource,
+) (bool, error) {
+	// Runtime replay requires all three gates: a runtime metadata payload, a
+	// provider/resource that is eligible for precomputed fixups, and a generated
+	// fixup section to read from.
+	if !ctx.runtimeMode || !ctx.resourceSchemaFixupsMayBePrecomputed(p, tfToken) || !ctx.hasDefaultFixups {
+		return false, nil
+	}
+	fixup, ok := ctx.defaultFixups.Resources[tfToken]
+	if !ok {
+		return false, nil
+	}
+
+	// Fill only fields that the provider has not set explicitly. The replay path
+	// should reproduce build-time defaults, not override provider-authored
+	// ResourceInfo.
+	for key, field := range fixup.Fields {
+		schema := getField(&res.Fields, key)
+		if schema.Name == "" {
+			schema.Name = field.Name
+		}
+		if schema.Type == "" {
+			schema.Type = field.Type
+		}
+	}
+
+	// Rebuild only the ComputeID functions produced by default fixups. Any other
+	// provider-authored ComputeID must come from normal ResourceInfo.
+	if fixup.ComputeID != nil {
+		switch fixup.ComputeID.Kind {
+		case defaultComputeIDMissing:
+			if res.ComputeID == nil {
+				res.ComputeID = missingIDComputeID()
+			}
+		case defaultComputeIDDelegate:
+			if fixup.ComputeID.Field == "" {
+				return false, fmt.Errorf("precomputed default fixup for %s has delegate ComputeID without a field", tfToken)
+			}
+			if res.ComputeID == nil {
+				res.ComputeID = delegateIDField(resource.PropertyKey(fixup.ComputeID.Field), p.Name,
+					pulumiTerraformProviderRepoURL)
+			}
+		default:
+			return false, fmt.Errorf("precomputed default fixup for %s has unknown ComputeID kind %q",
+				tfToken, fixup.ComputeID.Kind)
+		}
+	}
+	return true, nil
+}
+
+// resourceSchemaFixupsMayBePrecomputed asks the provider whether this Terraform
+// token is a valid candidate for metadata replay. It is only an eligibility
+// signal; runtime still requires a concrete metadata entry before skipping
+// schema inspection.
+func (ctx fixCtx) resourceSchemaFixupsMayBePrecomputed(p *info.Provider, tfToken string) bool {
+	candidate, ok := p.P.(precomputedResourceSchemaFixupCandidate)
+	return ok && candidate.ResourceSchemaFixupsMayBePrecomputed(tfToken)
+}
+
+// recordResourceFixups writes one build-time resource entry after eager fixups
+// have run. Empty entries are kept deliberately so runtime can distinguish
+// "schema inspected, no fixup needed" from "no build-time proof, use eager
+// fallback."
+func (ctx *fixCtx) recordResourceFixups(p *info.Provider, r resourceInfo) {
+	if ctx.runtimeMode || ctx.metadata == nil || !ctx.resourceSchemaFixupsMayBePrecomputed(p, r.TFName) {
+		return
+	}
+
+	if ctx.defaultFixups.Resources == nil {
+		ctx.defaultFixups.Resources = map[string]defaultResourceSchemaFixup{}
+	}
+	fixup := captureResourceFixup(r)
+	if fixup.ComputeID == nil && r.Schema.ComputeID != nil {
+		// A build may call ComputeTokens more than once on the same ProviderInfo.
+		// The first pass installs the default ComputeID; later passes see it
+		// already present and therefore do not call recordComputeIDFixup again.
+		// Reuse the previous metadata for this current resource so a second pass
+		// does not rewrite a replayable ComputeID into an empty entry.
+		previous := ctx.previousDefaultFixups.Resources[r.TFName]
+		if previous.ComputeID != nil {
+			computeID := *previous.ComputeID
+			fixup.ComputeID = &computeID
+		}
+	}
+	ctx.defaultFixups.Resources[r.TFName] = fixup
+	ctx.defaultChanged = true
+}
+
+// saveResourceFixups persists the build-time records assembled by the walk.
+// Passing nil clears a stale metadata key when the current build has no
+// precomputable resources left.
+func (ctx fixCtx) saveResourceFixups() error {
+	if !ctx.defaultChanged {
+		return nil
+	}
+	if len(ctx.defaultFixups.Resources) == 0 {
+		return metadata.Set(ctx.metadata, metadatakeys.DefaultResourceSchemaFixups, nil)
+	}
+	return metadata.Set(ctx.metadata, metadatakeys.DefaultResourceSchemaFixups, ctx.defaultFixups)
+}
+
+// captureResourceFixup extracts the narrow set of eager default-fixup decisions
+// that runtime needs before any schema load: synthesized field metadata for
+// reserved Terraform property names, plus the default ComputeID decision.
+func captureResourceFixup(r resourceInfo) defaultResourceSchemaFixup {
+	var fixup defaultResourceSchemaFixup
+	for _, propertyFixup := range defaultPropertyFixups {
+		key := propertyFixup.key
+		field := captureSchemaFieldFixup(r.Schema.Fields[key])
+		if field == (defaultSchemaFieldFixup{}) {
+			continue
+		}
+		if fixup.Fields == nil {
+			fixup.Fields = map[string]defaultSchemaFieldFixup{}
+		}
+		fixup.Fields[key] = field
+	}
+
+	if r.recorder != nil && r.recorder.computeID != nil {
+		computeID := *r.recorder.computeID
+		fixup.ComputeID = &computeID
+	}
+	return fixup
+}
+
+// captureSchemaFieldFixup copies only field metadata that the default fixups may
+// synthesize and that runtime replay can safely restore.
+func captureSchemaFieldFixup(field *info.Schema) defaultSchemaFieldFixup {
+	if field == nil {
+		return defaultSchemaFieldFixup{}
+	}
+	return defaultSchemaFieldFixup{Name: field.Name, Type: field.Type}
+}
+
+// fixMissingID preserves the historical bridge default for Terraform resources
+// without a usable string ID property. When it installs a default ComputeID, the
+// recorder notes the serializable kind for build-time metadata.
+func fixMissingID(r resourceInfo) error {
 	getIDType := func(r *info.Resource) ptokens.Type {
 		s := r.Fields["id"]
 		if s == nil {
@@ -68,37 +401,35 @@ func fixMissingIDs(fixCtx fixCtx, p *info.Provider) error {
 		}
 		return s.Type
 	}
-	return walkResources(fixCtx, p, func(r resourceInfo) error {
-		id, hasID := r.TF.Schema().GetOk("id")
-		if !hasID {
-			if r.Schema.ComputeID == nil {
-				r.Schema.ComputeID = missingIDComputeID()
-			}
-			return nil
-		}
-
-		ok := (id.Type() == shim.TypeString || getIDType(r.Schema) == "string") && id.Computed()
-		if !ok && r.Schema.ComputeID == nil {
+	id, hasID := r.TF.Schema().GetOk("id")
+	if !hasID {
+		if r.Schema.ComputeID == nil {
 			r.Schema.ComputeID = missingIDComputeID()
+			r.recordComputeIDFixup(defaultComputeIDMissing, "")
 		}
 		return nil
-	})
+	}
+
+	ok := (id.Type() == shim.TypeString || getIDType(r.Schema) == "string") && id.Computed()
+	if !ok && r.Schema.ComputeID == nil {
+		r.Schema.ComputeID = missingIDComputeID()
+		r.recordComputeIDFixup(defaultComputeIDMissing, "")
+	}
+	return nil
 }
 
-func fixPropertyConflict(fixCtx fixCtx, p *info.Provider) error {
-	return walkResources(fixCtx, p, func(r resourceInfo) error {
-		var retError []error
-		r.TF.Schema().Range(func(key string, _ shim.Schema) bool {
-			if fix := badPropertyName(p.Name, p.GetResourcePrefix(), key); fix != nil {
-				err := fix(r)
-				if err != nil {
-					retError = append(retError, fmt.Errorf("%s: %w", key, err))
-				}
+func fixPropertyConflictForResource(p *info.Provider, r resourceInfo) error {
+	var retError []error
+	r.TF.Schema().Range(func(key string, _ shim.Schema) bool {
+		if fix := badPropertyName(p.Name, p.GetResourcePrefix(), key); fix != nil {
+			err := fix(r)
+			if err != nil {
+				retError = append(retError, fmt.Errorf("%s: %w", key, err))
 			}
-			return true
-		})
-		return errors.Join(retError...)
+		}
+		return true
 	})
+	return errors.Join(retError...)
 }
 
 func getField(i *map[string]*info.Schema, name string) *info.Schema {
@@ -116,17 +447,39 @@ func getField(i *map[string]*info.Schema, name string) *info.Schema {
 
 type fixupProperty func(resourceInfo) error
 
+type defaultPropertyFixupFactory func(providerName, tokenPrefix string) fixupProperty
+
+var defaultPropertyFixups = [...]struct {
+	key     string
+	factory defaultPropertyFixupFactory
+}{
+	{
+		key: defaultFixupPropertyID,
+		factory: func(providerName, tokenPrefix string) fixupProperty {
+			return fixID(providerName, tokenPrefix)
+		},
+	},
+	{
+		key: defaultFixupPropertyPulumi,
+		factory: func(_, _ string) fixupProperty {
+			return fixPulumi()
+		},
+	},
+	{
+		key: defaultFixupPropertyURN,
+		factory: func(providerName, _ string) fixupProperty {
+			return fixURN(providerName)
+		},
+	},
+}
+
 func badPropertyName(providerName, tokenPrefix, key string) fixupProperty {
-	switch key {
-	case "urn":
-		return fixURN(providerName)
-	case "id":
-		return fixID(providerName, tokenPrefix)
-	case "pulumi":
-		return fixPulumi()
-	default:
-		return nil
+	for _, propertyFixup := range defaultPropertyFixups {
+		if propertyFixup.key == key {
+			return propertyFixup.factory(providerName, tokenPrefix)
+		}
 	}
+	return nil
 }
 
 func fixID(providerName, tokenPrefix string) fixupProperty {
@@ -184,7 +537,10 @@ func fixID(providerName, tokenPrefix string) fixupProperty {
 			if (tfIDProperty.Required() || (tfIDProperty.Optional() && tfIDProperty.Computed())) &&
 				r.Schema.ComputeID == nil {
 				r.Schema.ComputeID = delegateIDField(resource.PropertyKey(newIDField), providerName,
-					"https://github.com/pulumi/pulumi-terraform-provider")
+					pulumiTerraformProviderRepoURL)
+				// The delegate closure cannot be serialized, so record the field
+				// name needed to rebuild it during runtime replay.
+				r.recordComputeIDFixup(defaultComputeIDDelegate, newIDField)
 			}
 
 			return nil

--- a/pkg/tfbridge/tokens/fixups_test.go
+++ b/pkg/tfbridge/tokens/fixups_test.go
@@ -16,6 +16,7 @@ package tokens
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -24,8 +25,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/internal/metadatakeys"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+	md "github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
 )
 
 func TestFixMissingID(t *testing.T) {
@@ -491,4 +494,323 @@ func TestFixMissingIDsWithIgnoredMappings(t *testing.T) {
 	assert.NotContains(t, p.Resources, "test_ignored")
 	assert.Contains(t, p.Resources, "test_processed")
 	assert.NotNil(t, p.Resources["test_processed"].ComputeID)
+}
+
+func TestDefaultFixupsTolerateMetadataInfoWithoutData(t *testing.T) {
+	t.Parallel()
+
+	var schemaCalls atomic.Int32
+	p := info.Provider{
+		Name: "test",
+		P: countingResourceProvider(schema.SchemaMap{
+			"some_property": (&schema.Schema{Type: shim.TypeString}).Shim(),
+		}, &schemaCalls),
+		MetadataInfo: &info.Metadata{Path: "must be non-empty"},
+	}
+	require.NoError(t, applyDefaultFixups(&p))
+	require.Positive(t, schemaCalls.Load())
+	require.NotNil(t, p.Resources["test_res"].ComputeID)
+}
+
+func TestPrecomputedDefaultFixupsAvoidResourceSchema(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		schema schema.SchemaMap
+		verify func(*testing.T, *info.Resource)
+	}{
+		{
+			name: "missing ID",
+			schema: schema.SchemaMap{
+				"some_property": (&schema.Schema{Type: shim.TypeString}).Shim(),
+			},
+			verify: func(t *testing.T, res *info.Resource) {
+				t.Helper()
+				require.NotNil(t, res.ComputeID)
+				got, err := res.ComputeID(context.Background(), resource.PropertyMap{})
+				require.NoError(t, err)
+				assert.Equal(t, resource.ID("missing ID"), got)
+				assert.Empty(t, res.Fields)
+			},
+		},
+		{
+			name: "required ID delegates to renamed field",
+			schema: schema.SchemaMap{
+				"id": (&schema.Schema{
+					Type:     shim.TypeString,
+					Required: true,
+				}).Shim(),
+			},
+			verify: func(t *testing.T, res *info.Resource) {
+				t.Helper()
+				require.Equal(t, "resId", res.Fields["id"].Name)
+				require.NotNil(t, res.ComputeID)
+				got, err := res.ComputeID(context.Background(), resource.PropertyMap{
+					"resId": resource.NewStringProperty("abc"),
+				})
+				require.NoError(t, err)
+				assert.Equal(t, resource.ID("abc"), got)
+			},
+		},
+		{
+			name: "computed non-string ID uses missing ID",
+			schema: schema.SchemaMap{
+				"id": (&schema.Schema{
+					Type:     shim.TypeInt,
+					Computed: true,
+				}).Shim(),
+			},
+			verify: func(t *testing.T, res *info.Resource) {
+				t.Helper()
+				require.Equal(t, "resId", res.Fields["id"].Name)
+				require.NotNil(t, res.ComputeID)
+				got, err := res.ComputeID(context.Background(), resource.PropertyMap{})
+				require.NoError(t, err)
+				assert.Equal(t, resource.ID("missing ID"), got)
+			},
+		},
+		{
+			name: "reserved property names",
+			schema: schema.SchemaMap{
+				"id": (&schema.Schema{
+					Type:     shim.TypeString,
+					Computed: true,
+				}).Shim(),
+				"urn":    (&schema.Schema{Type: shim.TypeString}).Shim(),
+				"pulumi": (&schema.Schema{Type: shim.TypeString}).Shim(),
+			},
+			verify: func(t *testing.T, res *info.Resource) {
+				t.Helper()
+				assert.Equal(t, "testUrn", res.Fields["urn"].Name)
+				assert.Equal(t, "pulumiInfo", res.Fields["pulumi"].Name)
+				assert.Nil(t, res.ComputeID)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			metadataData, err := md.New(nil)
+			require.NoError(t, err)
+			var buildSchemaCalls atomic.Int32
+			build := info.Provider{
+				Name:         "test",
+				P:            precomputedFixupProvider{Provider: countingResourceProvider(tt.schema, &buildSchemaCalls)},
+				MetadataInfo: &info.Metadata{Data: metadataData, Path: "bridge-metadata.json"},
+			}
+			require.NoError(t, applyDefaultFixups(&build))
+			require.Positive(t, buildSchemaCalls.Load(), "build-time fixups should inspect the schema")
+
+			var runtimeSchemaCalls atomic.Int32
+			runtime := info.Provider{
+				Name: "test",
+				P: precomputedFixupProvider{
+					Provider: countingResourceProvider(tt.schema, &runtimeSchemaCalls),
+				},
+				MetadataInfo: info.NewProviderMetadata(
+					runtimeMetadataBytes(t, build.MetadataInfo.Data)),
+			}
+			require.NoError(t, applyDefaultFixups(&runtime))
+			require.Zero(t, runtimeSchemaCalls.Load(), "runtime fixups should use metadata instead of Schema()")
+			require.NotNil(t, runtime.Resources["test_res"])
+			tt.verify(t, runtime.Resources["test_res"])
+
+			buildMapping := info.MarshalProvider(&build)
+			runtimeMapping := info.MarshalProvider(&runtime)
+			require.Contains(t, buildMapping.Resources, "test_res")
+			require.Contains(t, runtimeMapping.Resources, "test_res")
+			assert.Equal(t,
+				buildMapping.Resources["test_res"].Fields,
+				runtimeMapping.Resources["test_res"].Fields,
+				"runtime metadata replay should preserve mapping field metadata")
+		})
+	}
+}
+
+func TestDefaultFixupMetadataPreservesComputeIDAcrossRepeatedBuildPasses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		schema schema.SchemaMap
+		verify func(*testing.T, *info.Resource)
+	}{
+		{
+			name: "missing ID",
+			schema: schema.SchemaMap{
+				"some_property": (&schema.Schema{Type: shim.TypeString}).Shim(),
+			},
+			verify: func(t *testing.T, res *info.Resource) {
+				t.Helper()
+				require.NotNil(t, res.ComputeID)
+				got, err := res.ComputeID(context.Background(), resource.PropertyMap{})
+				require.NoError(t, err)
+				assert.Equal(t, resource.ID("missing ID"), got)
+			},
+		},
+		{
+			name: "delegate ID",
+			schema: schema.SchemaMap{
+				"id": (&schema.Schema{
+					Type:     shim.TypeString,
+					Required: true,
+				}).Shim(),
+			},
+			verify: func(t *testing.T, res *info.Resource) {
+				t.Helper()
+				require.Equal(t, "resId", res.Fields["id"].Name)
+				require.NotNil(t, res.ComputeID)
+				got, err := res.ComputeID(context.Background(), resource.PropertyMap{
+					"resId": resource.NewStringProperty("abc"),
+				})
+				require.NoError(t, err)
+				assert.Equal(t, resource.ID("abc"), got)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			metadataData, err := md.New(nil)
+			require.NoError(t, err)
+			var buildSchemaCalls atomic.Int32
+			build := info.Provider{
+				Name:         "test",
+				P:            precomputedFixupProvider{Provider: countingResourceProvider(tt.schema, &buildSchemaCalls)},
+				MetadataInfo: &info.Metadata{Data: metadataData, Path: "bridge-metadata.json"},
+			}
+
+			require.NoError(t, applyDefaultFixups(&build))
+			first, found, err := md.Get[defaultResourceSchemaFixups](
+				metadataData, metadatakeys.DefaultResourceSchemaFixups)
+			require.NoError(t, err)
+			require.True(t, found)
+			require.NotNil(t, first.Resources["test_res"].ComputeID)
+
+			require.NoError(t, applyDefaultFixups(&build))
+			second, found, err := md.Get[defaultResourceSchemaFixups](
+				metadataData, metadatakeys.DefaultResourceSchemaFixups)
+			require.NoError(t, err)
+			require.True(t, found)
+			require.NotNil(t, second.Resources["test_res"].ComputeID)
+			assert.Equal(t, *first.Resources["test_res"].ComputeID, *second.Resources["test_res"].ComputeID)
+
+			var runtimeSchemaCalls atomic.Int32
+			runtime := info.Provider{
+				Name: "test",
+				P: precomputedFixupProvider{
+					Provider: countingResourceProvider(tt.schema, &runtimeSchemaCalls),
+				},
+				MetadataInfo: info.NewProviderMetadata(
+					runtimeMetadataBytes(t, metadataData)),
+			}
+			require.NoError(t, applyDefaultFixups(&runtime))
+			require.Zero(t, runtimeSchemaCalls.Load(), "runtime fixups should use metadata instead of Schema()")
+			tt.verify(t, runtime.Resources["test_res"])
+		})
+	}
+}
+
+func TestDefaultFixupMetadataRewritesCurrentResources(t *testing.T) {
+	t.Parallel()
+
+	metadataData, err := md.New(nil)
+	require.NoError(t, err)
+	require.NoError(t, md.Set(metadataData, metadatakeys.DefaultResourceSchemaFixups, defaultResourceSchemaFixups{
+		Resources: map[string]defaultResourceSchemaFixup{
+			"test_stale": {
+				ComputeID: &defaultComputeIDFixup{Kind: defaultComputeIDMissing},
+			},
+		},
+	}))
+
+	var schemaCalls atomic.Int32
+	build := info.Provider{
+		Name: "test",
+		P: precomputedFixupProvider{Provider: countingResourceProvider(schema.SchemaMap{
+			"some_property": (&schema.Schema{Type: shim.TypeString}).Shim(),
+		}, &schemaCalls)},
+		MetadataInfo: &info.Metadata{Data: metadataData, Path: "bridge-metadata.json"},
+	}
+	require.NoError(t, applyDefaultFixups(&build))
+	require.Positive(t, schemaCalls.Load(), "build-time fixups should inspect the schema")
+
+	fixups, found, err := md.Get[defaultResourceSchemaFixups](
+		metadataData, metadatakeys.DefaultResourceSchemaFixups)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Contains(t, fixups.Resources, "test_res")
+	assert.NotContains(t, fixups.Resources, "test_stale")
+}
+
+func TestDefaultFixupMetadataClearsWhenNoCurrentResources(t *testing.T) {
+	t.Parallel()
+
+	metadataData, err := md.New(nil)
+	require.NoError(t, err)
+	require.NoError(t, md.Set(metadataData, metadatakeys.DefaultResourceSchemaFixups, defaultResourceSchemaFixups{
+		Resources: map[string]defaultResourceSchemaFixup{
+			"test_stale": {
+				ComputeID: &defaultComputeIDFixup{Kind: defaultComputeIDMissing},
+			},
+		},
+	}))
+
+	build := info.Provider{
+		Name: "test",
+		P: precomputedFixupProvider{
+			Provider: (&schema.Provider{ResourcesMap: schema.ResourceMap{}}).Shim(),
+		},
+		MetadataInfo: &info.Metadata{Data: metadataData, Path: "bridge-metadata.json"},
+	}
+	require.NoError(t, applyDefaultFixups(&build))
+
+	_, found, err := md.Get[defaultResourceSchemaFixups](
+		metadataData, metadatakeys.DefaultResourceSchemaFixups)
+	require.NoError(t, err)
+	assert.False(t, found)
+}
+
+func runtimeMetadataBytes(t *testing.T, data info.ProviderMetadata) []byte {
+	t.Helper()
+	runtimeMetadata := md.Clone((*md.Data)(data))
+	require.NoError(t, md.Set(runtimeMetadata, metadatakeys.RuntimeMetadata, true))
+	return runtimeMetadata.Marshal()
+}
+
+func countingResourceProvider(resourceSchema schema.SchemaMap, calls *atomic.Int32) shim.Provider {
+	return (&schema.Provider{
+		ResourcesMap: schema.ResourceMap{
+			"test_res": countingResource{
+				Resource: (&schema.Resource{Schema: resourceSchema}).Shim(),
+				calls:    calls,
+			},
+		},
+	}).Shim()
+}
+
+type precomputedFixupProvider struct {
+	shim.Provider
+}
+
+func (p precomputedFixupProvider) ResourceSchemaFixupsMayBePrecomputed(tfToken string) bool {
+	_, ok := p.ResourcesMap().GetOk(tfToken)
+	return ok
+}
+
+type countingResource struct {
+	shim.Resource
+	calls *atomic.Int32
+}
+
+func (r countingResource) Schema() shim.SchemaMap {
+	r.calls.Add(1)
+	return r.Resource.Schema()
 }


### PR DESCRIPTION
## Context

This PR is stacked on top of #3435 and addresses #3430.

#3435 makes Plugin Framework resource schemas lazy at runtime so muxed providers do not have to materialize every PF resource schema during provider startup. That exposes one remaining eager path in the bridge: `ComputeTokens` runs the bridge's default ResourceInfo fixups, and those fixups historically inspect each Terraform resource schema to decide whether to rename reserved fields like `id`, `urn`, and `pulumi`, or to synthesize a default `ComputeID`.

That schema inspection is fine during build-time schema generation, where provider schemas are expected to be available. It is not fine as a runtime startup requirement for PF-owned resources, because it defeats the lazy schema boundary from the lower PR. The important compatibility constraint is that runtime paths such as `GetMapping`, encoders/decoders, defaults, diagnostics, and schema metadata still need to see the same final `ResourceInfo.Fields` decisions that build time would have produced.

## What changed

The bridge now treats the default schema-dependent fixups as build-time decisions that can be recorded into provider metadata and replayed at runtime. During build-time/schema-generation paths, the existing eager behavior remains in place: the fixups inspect schemas, mutate ResourceInfo as before, and record the replayable facts under `default-resource-schema-fixups`.

At runtime, when the provider metadata is explicitly marked as runtime metadata and the PF muxer says a resource's fixups may be precomputed, `ComputeTokens` can replay the recorded field metadata and default `ComputeID` decision without calling the PF resource's `Schema()` method. A resource entry may be empty; that is still meaningful because it means build time inspected the resource and found no default fixup to apply. If the runtime marker, the generated fixup section, or the per-resource entry is missing, the bridge falls back to the existing schema-inspecting behavior rather than guessing.

The implementation also moves the runtime/build-time distinction away from `MetadataInfo.Path`. Real providers can and do pass embedded runtime metadata through `NewProviderMetadata`, so path-based detection would only prove the prototype path. Runtime metadata is now marked centrally when it is extracted, and `ComputeTokens` keys off that marker.

## Design decisions and compatibility

The main decision here is to keep schema-dependent fixups as a build-time concern first. Runtime startup consumes precomputed metadata; it does not broadly mutate PF ResourceInfo late after other runtime systems may already have observed it. Selected-resource schema inspection remains the fallback for compatibility when metadata is unavailable or stale.

SDKv2 behavior remains eager. SDKv2 providers are not the target of the PF lazy-schema optimization, and the new provider capability only marks resources whose default fixup decisions may be precomputed. Build-time schema generation also remains eager so generated schema output continues to be derived from the real schemas.

The metadata is rewritten from the current build-time resource set rather than merged forever. That matters because PF ownership can change and resources can disappear; stale fixup entries should not silently keep runtime skipping schema inspection for resources that build time no longer proves.

## Validation

Focused validation run locally:

- `make test RUN_TEST_CMD='./pkg/tfbridge/tokens -run TestDefault'`
- `make test RUN_TEST_CMD='./pkg/tfbridge/tokens -run TestPrecomputedDefaultFixupsAvoidResourceSchema'`
- `make test RUN_TEST_CMD='./pkg/pf/tests -run TestMuxedRuntimeComputeTokensDoesNotLoadPFResourceSchemas'`

I also ran `gofmt` and `git diff --check` after the final documentation pass.