### PR TITLE
Round-trip non-UTF-8 strings through the PF bridge

### DIFF
--- a/pkg/convert/dynamic.go
+++ b/pkg/convert/dynamic.go
@@ -41,7 +41,11 @@ func (enc *dynamicEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.
 	case p.IsNumber():
 		return tftypes.NewValue(tftypes.Number, p.NumberValue()), nil
 	case p.IsString():
-		return tftypes.NewValue(tftypes.String, p.StringValue()), nil
+		s, err := unescapeNonUTF8String(p.StringValue())
+		if err != nil {
+			return tftypes.Value{}, err
+		}
+		return tftypes.NewValue(tftypes.String, s), nil
 	case p.IsArray():
 		var result []tftypes.Value
 		for _, e := range p.ArrayValue() {
@@ -130,7 +134,7 @@ func (dec *dynamicDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyVa
 		if err != nil {
 			return resource.PropertyValue{}, err
 		}
-		return resource.NewStringProperty(s), nil
+		return resource.NewStringProperty(escapeNonUTF8String(s)), nil
 	case v.Type().Is(tftypes.List{}):
 		var elements []tftypes.Value
 		err := v.As(&elements)

--- a/pkg/convert/string.go
+++ b/pkg/convert/string.go
@@ -15,12 +15,44 @@
 package convert
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strconv"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
+
+// Terraform's wire protocol is msgpack-encoded cty, whose strings carry arbitrary bytes,
+// but Pulumi's property protocol uses proto3 string fields that require valid UTF-8.
+// Strings that are not valid UTF-8 cross into Pulumi as base64 with this marker prefix
+// and are decoded back to the original bytes on the way into Terraform, so the provider
+// always observes the exact bytes it produced. The embedded UUID guards against
+// collisions with ordinary user data, in the same spirit as Pulumi's special-value
+// signature keys.
+const nonUTF8StringSig = "__pulumi_non_utf8_string_aebc5fa583744d97a0ee9bb6e0c0e9c2:"
+
+func escapeNonUTF8String(s string) string {
+	if utf8.ValidString(s) && !strings.HasPrefix(s, nonUTF8StringSig) {
+		return s
+	}
+	return nonUTF8StringSig + base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+func unescapeNonUTF8String(s string) (string, error) {
+	rest, ok := strings.CutPrefix(s, nonUTF8StringSig)
+	if !ok {
+		return s, nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(rest)
+	if err != nil {
+		return "", fmt.Errorf("string starts with the %q marker but is not valid base64: %w",
+			nonUTF8StringSig, err)
+	}
+	return string(decoded), nil
+}
 
 type (
 	stringEncoder struct{}
@@ -79,7 +111,11 @@ func (*stringEncoder) fromPropertyValue(p resource.PropertyValue) (tftypes.Value
 		return tftypes.NewValue(tftypes.String, strconv.FormatFloat(p.NumberValue(), 'f', -1, 64)), nil
 
 	case p.IsString():
-		return tftypes.NewValue(tftypes.String, p.StringValue()), nil
+		s, err := unescapeNonUTF8String(p.StringValue())
+		if err != nil {
+			return tftypes.NewValue(tftypes.String, nil), err
+		}
+		return tftypes.NewValue(tftypes.String, s), nil
 
 	default:
 		return tftypes.NewValue(tftypes.String, nil),
@@ -99,5 +135,5 @@ func (*stringDecoder) toPropertyValue(v tftypes.Value) (resource.PropertyValue, 
 		return resource.PropertyValue{},
 			fmt.Errorf("tftypes.Value.As(string) failed: %w", err)
 	}
-	return resource.NewStringProperty(s), nil
+	return resource.NewStringProperty(escapeNonUTF8String(s)), nil
 }

--- a/pkg/convert/string_test.go
+++ b/pkg/convert/string_test.go
@@ -1,0 +1,113 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+func TestNonUTF8StringRoundTrip(outerT *testing.T) {
+	outerT.Parallel()
+
+	converters := []struct {
+		name string
+		enc  Encoder
+		dec  Decoder
+	}{
+		{"string", newStringEncoder(), newStringDecoder()},
+		{"dynamic", newDynamicEncoder(), newDynamicDecoder()},
+	}
+
+	for _, c := range converters {
+		outerT.Run(c.name, func(outerT *testing.T) {
+			outerT.Parallel()
+			rapid.Check(outerT, func(t *rapid.T) {
+				b := rapid.SliceOf(rapid.Byte()).Draw(t, "bytes")
+				// The marker-prefixed variant exercises the collision escape.
+				for _, s := range []string{string(b), nonUTF8StringSig + string(b)} {
+					tf := tftypes.NewValue(tftypes.String, s)
+
+					prop, err := c.dec.toPropertyValue(tf)
+					require.NoError(t, err)
+					require.True(t, utf8.ValidString(prop.StringValue()))
+
+					if utf8.ValidString(s) && !strings.HasPrefix(s, nonUTF8StringSig) {
+						assert.Equal(t, s, prop.StringValue())
+					}
+
+					back, err := c.enc.fromPropertyValue(prop)
+					require.NoError(t, err)
+					require.Equal(t, tf, back)
+				}
+			})
+		})
+	}
+}
+
+// The escaped form is persisted in Pulumi state files, so it must not change between
+// bridge versions.
+func TestNonUTF8StringRepresentation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		tf   string
+		prop string
+	}{
+		{
+			name: "plain string is unchanged",
+			tf:   "hello",
+			prop: "hello",
+		},
+		{
+			name: "invalid UTF-8 (gzip magic)",
+			tf:   "\x1f\x8b\x08\x00binary",
+			prop: nonUTF8StringSig + "H4sIAGJpbmFyeQ==",
+		},
+		{
+			name: "valid string colliding with the marker",
+			tf:   nonUTF8StringSig + "looks escaped but is user data",
+			prop: nonUTF8StringSig +
+				"X19wdWx1bWlfbm9uX3V0Zjhfc3RyaW5nX2FlYmM1ZmE1ODM3NDRkOTdhMGVlOWJiNmUwYzBlOWMyOmxv" +
+				"b2tzIGVzY2FwZWQgYnV0IGlzIHVzZXIgZGF0YQ==",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			prop, err := newStringDecoder().toPropertyValue(
+				tftypes.NewValue(tftypes.String, c.tf))
+			require.NoError(t, err)
+			require.Equal(t, resource.NewStringProperty(c.prop), prop)
+		})
+	}
+}
+
+func TestNonUTF8StringInvalidBase64(t *testing.T) {
+	t.Parallel()
+
+	_, err := newStringEncoder().fromPropertyValue(
+		resource.NewStringProperty(nonUTF8StringSig + "!!! not base64 !!!"))
+	require.ErrorContains(t, err, "not valid base64")
+}

--- a/pkg/pf/tests/provider_create_test.go
+++ b/pkg/pf/tests/provider_create_test.go
@@ -15,12 +15,22 @@
 package tfbridgetests
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"testing"
+	"unicode/utf8"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	fwres "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	testutils "github.com/pulumi/providertest/replay"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -28,6 +38,7 @@ import (
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/providerbuilder"
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/pulcheck"
 )
 
 func TestCreateWithComputedOptionals(t *testing.T) {
@@ -356,4 +367,83 @@ func TestPFCreateDynamicAttribute(t *testing.T) {
 	crosstests.Create(t, res, map[string]cty.Value{
 		"hello": cty.StringVal("world"),
 	})
+}
+
+// Terraform's msgpack-based protocol permits strings that are not valid UTF-8, but
+// Pulumi's property protocol (proto3 structpb) requires valid UTF-8, so a provider
+// returning such a string in its post-create state must not break the Create response
+// or lose the created resource. The resource below mirrors aws_instance.user_data,
+// where gzipped cloud-init data enters as valid base64 but is decoded to raw gzip
+// bytes on read-back. This is specific to the Plugin Framework path: the SDKv2 shim
+// goes through go-cty, which replaces invalid bytes with U+FFFD.
+func TestCreateNonUTF8StringInState(t *testing.T) {
+	t.Parallel()
+
+	var gzipped bytes.Buffer
+	gz := gzip.NewWriter(&gzipped)
+	_, err := gz.Write([]byte("#!/bin/sh\necho hello\n"))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+	require.False(t, utf8.Valid(gzipped.Bytes()))
+	userDataBase64 := base64.StdEncoding.EncodeToString(gzipped.Bytes())
+
+	provBuilder := pb.NewProvider(pb.NewProviderArgs{
+		AllResources: []pb.Resource{
+			pb.NewResource(pb.NewResourceArgs{
+				ResourceSchema: schema.Schema{
+					Attributes: map[string]schema.Attribute{
+						"user_data_base64": schema.StringAttribute{Required: true},
+						"user_data":        schema.StringAttribute{Computed: true},
+					},
+				},
+				CreateFunc: func(ctx context.Context, req fwres.CreateRequest, resp *fwres.CreateResponse) {
+					resp.State = tfsdk.State(req.Plan)
+					resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), "id-1")...)
+					var b64 types.String
+					resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("user_data_base64"), &b64)...)
+					if resp.Diagnostics.HasError() {
+						return
+					}
+					decoded, err := base64.StdEncoding.DecodeString(b64.ValueString())
+					if err != nil {
+						resp.Diagnostics.AddError("invalid base64 user_data_base64", err.Error())
+						return
+					}
+					resp.Diagnostics.Append(
+						resp.State.SetAttribute(ctx, path.Root("user_data"), string(decoded))...)
+				},
+			}),
+		},
+	})
+
+	program := fmt.Sprintf(`
+name: test
+runtime: yaml
+resources:
+  mainRes:
+    type: testprovider:index:Test
+    properties:
+      userDataBase64: %q
+`, userDataBase64)
+
+	pt, err := pulcheck.PulCheck(t, provBuilder.ToProviderInfo(), program)
+	require.NoError(t, err)
+	pt.Up(t)
+
+	stack := pt.ExportStack(t)
+	var deployment apitype.DeploymentV3
+	require.NoError(t, json.Unmarshal(stack.Deployment, &deployment))
+	var created *apitype.ResourceV3
+	for i, r := range deployment.Resources {
+		if r.Type == "testprovider:index/test:Test" {
+			created = &deployment.Resources[i]
+		}
+	}
+	require.NotNil(t, created, "the created resource must be recorded in the stack state")
+	require.Equal(t, "id-1", string(created.ID))
+
+	// A second up sees no diff only if the provider gets back the exact bytes it
+	// returned from Create.
+	res := pt.Up(t)
+	require.Equal(t, &map[string]int{"same": 2}, res.Summary.ResourceChanges)
 }


### PR DESCRIPTION
Observed via pulumi-terraform-provider: https://github.com/pulumi-labs/pulumi-hcl/issues/268

## Problem

Terraform's wire protocol is msgpack-encoded cty, whose strings may carry arbitrary bytes, but Pulumi's property protocol uses proto3 string fields that require valid UTF-8. When a Plugin Framework or dynamically bridged provider returns a string containing invalid UTF-8 in its post-create state, the bridge converts it into Pulumi properties unchanged and the gRPC `CreateResponse` fails to marshal:

```
error: grpc: error while marshaling: string field contains invalid UTF-8
```

The resource has already been created at that point, so every failed update leaks an unmanaged resource that is never recorded in the Pulumi state. Hit in the wild by `aws_instance.user_data` fed from `data.cloudinit_config` with `gzip = true, base64_encode = true` (e.g. the RaJiska/fck-nat module): the AWS provider base64-decodes `user_data` on read-back, leaving raw gzip bytes as a "string" in state.

## Fix

In the PF value conversion layer (`pkg/convert`), strings that are not valid UTF-8 — or that collide with the marker — cross into Pulumi as base64 with a marker prefix, and are decoded back to the original bytes on the way into Terraform. Applied in both the typed string converters and the `DynamicPseudoType` converters, covering all state-carrying directions for the PF bridge and the dynamic provider.

Properties of the encoding:

- The provider always observes the exact bytes it produced; encode∘decode is the identity for every string (valid strings that happen to start with the marker are escaped too, so decoding is unambiguous).
- Deterministic, so repeated `pulumi up` sees no diff.
- The Pulumi-side value stays a plain string, so no schema or SDK changes are needed.

The SDKv2 shim path is unaffected: go-cty normalizes invalid bytes to U+FFFD before they reach the bridge, matching Terraform core's own behavior, so it neither fails nor can carry the raw bytes.

## Tests

- `TestNonUTF8StringRoundTrip` (`pkg/convert`): rapid property test over arbitrary byte strings (and marker-prefixed variants) through both converter pairs, asserting the Pulumi side is always valid UTF-8 and the round trip is byte-identical.
- `TestNonUTF8StringRepresentation`: pins the exact escaped forms, since they are persisted in state files.
- `TestNonUTF8StringInvalidBase64`: marker-prefixed strings that are not valid base64 are rejected.
- `TestCreateNonUTF8StringInState` (`pkg/pf/tests`): end-to-end repro mirroring the `aws_instance.user_data` scenario over a real gRPC connection. Without the fix it fails with the marshal error above; with it, the create succeeds, the resource is recorded, and a second `pulumi up` reports no changes.

Full `pkg/convert` and `pkg/pf/tests` suites pass.