### PR TITLE
Fix dropping optional fields with schema defaults

### DIFF
--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -2000,7 +2000,7 @@ func extractSchemaInputsObject(
 		if allowDrop && !etfs.Required() && isDefaultOrZeroValue(etfs, eps, ev) {
 			// If the field has a schema default, keep it rather than dropping.
 			// Dropping causes spurious diffs on next preview when PlanResourceChange
-			// re-applies the same default. See pulumi/pulumi-terraform-bridge#2436.
+			// re-applies the same default.
 			if getDefaultValue(etfs, eps) == nil {
 				pulumilog.V(9).Infof("skipping '%v' (not required + zero value, no schema default)", k)
 				continue
@@ -2013,8 +2013,12 @@ func extractSchemaInputsObject(
 		// PlanResourceChange will apply the default, causing a null → default diff.
 		if ev.IsNull() && allowDrop && !etfs.Required() {
 			if dv := getDefaultValue(etfs, eps); dv != nil {
-				v[k] = resource.NewPropertyValue(dv)
-				continue
+				// getDefaultValue may return an error as interface{} on DefaultFunc
+				// failure; skip injection in that case to avoid corrupting state.
+				if _, isErr := dv.(error); !isErr {
+					v[k] = resource.NewPropertyValue(dv)
+					continue
+				}
 			}
 		}
 

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1998,8 +1998,24 @@ func extractSchemaInputsObject(
 		ev := extractSchemaInputs(e, etfs, eps)
 
 		if allowDrop && !etfs.Required() && isDefaultOrZeroValue(etfs, eps, ev) {
-			pulumilog.V(9).Infof("skipping '%v' (not required + default or zero value)", k)
-			continue
+			// If the field has a schema default, keep it rather than dropping.
+			// Dropping causes spurious diffs on next preview when PlanResourceChange
+			// re-applies the same default. See pulumi/pulumi-terraform-bridge#2436.
+			if getDefaultValue(etfs, eps) == nil {
+				pulumilog.V(9).Infof("skipping '%v' (not required + zero value, no schema default)", k)
+				continue
+			}
+			// Fall through to keep ev (which already equals the default).
+		}
+
+		// If ev is null and the field has a schema default, inject the default.
+		// This handles the case where Read didn't populate the field but
+		// PlanResourceChange will apply the default, causing a null → default diff.
+		if ev.IsNull() && allowDrop && !etfs.Required() {
+			if dv := getDefaultValue(etfs, eps); dv != nil {
+				v[k] = resource.NewPropertyValue(dv)
+				continue
+			}
 		}
 
 		v[k] = ev

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -2717,9 +2717,8 @@ func TestExtractDefaultSecretInputs(t *testing.T) {
 		reservedkeys.Defaults: []interface{}{},
 		"inputA":              "input_a_read",
 		"inputC":              "input_c_read",
-		// With the fix for #2436, inputD is retained because its value
-		// matches the schema default. Previously it was dropped, causing
-		// a spurious diff on next preview.
+		// inputD is retained: its value matches the schema default, and dropping it would
+		// cause a spurious diff when PlanResourceChange re-applies the default on next preview.
 		"inputD": "input_d_default",
 	})
 	assert.Equal(t, expected, ins)
@@ -2792,8 +2791,8 @@ func TestExtractDefaultIntegerInputs(t *testing.T) {
 	assert.NoError(t, err)
 	expected := resource.NewPropertyMapFromMap(map[string]interface{}{
 		reservedkeys.Defaults: []interface{}{},
-		// With the fix for #2436, inputC and inputD are retained because
-		// their values match the schema defaults (-1). Previously dropped.
+		// inputC and inputD are retained: their values match the schema defaults (-1),
+		// and dropping them would cause spurious diffs on next preview.
 		"inputC": -1,
 		"inputD": -1,
 	})
@@ -3657,9 +3656,9 @@ func TestExtractInputsFromOutputsSdkv2(t *testing.T) {
 			}),
 		},
 		{
-			// With the fix for #2436, fields whose value matches the schema default
-			// are retained rather than dropped. Dropping them caused spurious diffs
-			// when PlanResourceChange re-applied the same default on next preview.
+			// Fields whose value matches the schema default are retained rather than
+			// dropped. Dropping them would cause spurious diffs when PlanResourceChange
+			// re-applies the same default on next preview.
 			name:  "string attribute matching default is retained",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{"foo": "baz"}),
 			schemaMap: map[string]*schemav2.Schema{

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -2717,6 +2717,10 @@ func TestExtractDefaultSecretInputs(t *testing.T) {
 		reservedkeys.Defaults: []interface{}{},
 		"inputA":              "input_a_read",
 		"inputC":              "input_c_read",
+		// With the fix for #2436, inputD is retained because its value
+		// matches the schema default. Previously it was dropped, causing
+		// a spurious diff on next preview.
+		"inputD": "input_d_default",
 	})
 	assert.Equal(t, expected, ins)
 }
@@ -2788,6 +2792,10 @@ func TestExtractDefaultIntegerInputs(t *testing.T) {
 	assert.NoError(t, err)
 	expected := resource.NewPropertyMapFromMap(map[string]interface{}{
 		reservedkeys.Defaults: []interface{}{},
+		// With the fix for #2436, inputC and inputD are retained because
+		// their values match the schema defaults (-1). Previously dropped.
+		"inputC": -1,
+		"inputD": -1,
 	})
 	assert.Equal(t, expected, ins)
 }
@@ -3649,14 +3657,20 @@ func TestExtractInputsFromOutputsSdkv2(t *testing.T) {
 			}),
 		},
 		{
-			name:  "string attribute with defaults not extracted",
+			// With the fix for #2436, fields whose value matches the schema default
+			// are retained rather than dropped. Dropping them caused spurious diffs
+			// when PlanResourceChange re-applied the same default on next preview.
+			name:  "string attribute matching default is retained",
 			props: resource.NewPropertyMapFromMap(map[string]interface{}{"foo": "baz"}),
 			schemaMap: map[string]*schemav2.Schema{
 				"foo": {Type: schemav2.TypeString, Optional: true, Default: "baz"},
 			},
-			expected: autogold.Expect(resource.PropertyMap{resource.PropertyKey(reservedkeys.Defaults): resource.PropertyValue{
-				V: []resource.PropertyValue{},
-			}}),
+			expected: autogold.Expect(resource.PropertyMap{
+				resource.PropertyKey(reservedkeys.Defaults): resource.PropertyValue{
+					V: []resource.PropertyValue{},
+				},
+				resource.PropertyKey("foo"): resource.PropertyValue{V: "baz"},
+			}),
 		},
 		{
 			name:  "string attribute with empty value not extracted",
@@ -3915,6 +3929,230 @@ func TestExtractInputsFromOutputsSdkv2(t *testing.T) {
 			tc.expected.Equal(t, result)
 		})
 	}
+}
+
+// TestExtractSchemaInputsDefaultInjection verifies that extractSchemaInputsObject
+// injects schema defaults for null fields and retains fields whose value matches the
+// schema default, instead of dropping them. This prevents spurious null → default diffs
+// after pulumi import. See https://github.com/pulumi/pulumi-terraform-bridge/issues/2436.
+func TestExtractSchemaInputsDefaultInjection(t *testing.T) {
+	t.Parallel()
+
+	defaults := func() resource.PropertyValue {
+		return resource.NewArrayProperty([]resource.PropertyValue{})
+	}
+
+	type testCase struct {
+		name      string
+		props     resource.PropertyMap
+		schemaMap map[string]*schemav2.Schema
+		expected  resource.PropertyMap
+	}
+
+	testCases := []testCase{
+		{
+			// Field absent from state entirely — extractSchemaInputsObject only
+			// iterates fields present in state, so this is not affected.
+			name:  "absent field with default is not synthesized",
+			props: resource.PropertyMap{},
+			schemaMap: map[string]*schemav2.Schema{
+				"force_destroy": {Type: schemav2.TypeBool, Optional: true, Default: false},
+			},
+			expected: resource.PropertyMap{
+				resource.PropertyKey(reservedkeys.Defaults): defaults(),
+			},
+		},
+		{
+			// Read explicitly returns null for a bool field with Default: false.
+			name: "explicit null bool with default false is injected",
+			props: resource.PropertyMap{
+				"force_destroy": resource.NewNullProperty(),
+			},
+			schemaMap: map[string]*schemav2.Schema{
+				"force_destroy": {Type: schemav2.TypeBool, Optional: true, Default: false},
+			},
+			expected: resource.PropertyMap{
+				resource.PropertyKey(reservedkeys.Defaults): defaults(),
+				resource.PropertyKey("force_destroy"):       resource.NewPropertyValue(false),
+			},
+		},
+		{
+			// Read explicitly returns null for an int field with Default: 30.
+			name: "explicit null int with default 30 is injected",
+			props: resource.PropertyMap{
+				"recovery_window": resource.NewNullProperty(),
+			},
+			schemaMap: map[string]*schemav2.Schema{
+				"recovery_window": {Type: schemav2.TypeInt, Optional: true, Default: 30},
+			},
+			expected: resource.PropertyMap{
+				resource.PropertyKey(reservedkeys.Defaults): defaults(),
+				resource.PropertyKey("recovery_window"):     resource.NewNumberProperty(30),
+			},
+		},
+		{
+			// Read returns false for a bool field with Default: false.
+			// The value matches the default — it should be kept, not dropped.
+			name: "bool matching default false is retained",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"force_destroy": false,
+			}),
+			schemaMap: map[string]*schemav2.Schema{
+				"force_destroy": {Type: schemav2.TypeBool, Optional: true, Default: false},
+			},
+			expected: resource.PropertyMap{
+				resource.PropertyKey(reservedkeys.Defaults): defaults(),
+				resource.PropertyKey("force_destroy"):       resource.NewPropertyValue(false),
+			},
+		},
+		{
+			// Read returns "baz" which matches Default: "baz".
+			// The value matches the default — it should be kept, not dropped.
+			name: "string matching default is retained",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": "baz",
+			}),
+			schemaMap: map[string]*schemav2.Schema{
+				"foo": {Type: schemav2.TypeString, Optional: true, Default: "baz"},
+			},
+			expected: resource.PropertyMap{
+				resource.PropertyKey(reservedkeys.Defaults): defaults(),
+				resource.PropertyKey("foo"):                 resource.NewPropertyValue("baz"),
+			},
+		},
+		{
+			// Read returns null for a field with no schema default.
+			// Should still be dropped (no default to inject).
+			name: "null with no default is still dropped",
+			props: resource.PropertyMap{
+				"optional_field": resource.NewNullProperty(),
+			},
+			schemaMap: map[string]*schemav2.Schema{
+				"optional_field": {Type: schemav2.TypeString, Optional: true},
+			},
+			expected: resource.PropertyMap{
+				resource.PropertyKey(reservedkeys.Defaults): defaults(),
+			},
+		},
+		{
+			// Read returns empty string for a field with no schema default.
+			// Should still be dropped (zero value, no default).
+			name: "zero value string with no default is still dropped",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"optional_field": "",
+			}),
+			schemaMap: map[string]*schemav2.Schema{
+				"optional_field": {Type: schemav2.TypeString, Optional: true},
+			},
+			expected: resource.PropertyMap{
+				resource.PropertyKey(reservedkeys.Defaults): defaults(),
+			},
+		},
+		{
+			// Read returns null for a string field with Default: "something".
+			name: "explicit null string with default is injected",
+			props: resource.PropertyMap{
+				"engine": resource.NewNullProperty(),
+			},
+			schemaMap: map[string]*schemav2.Schema{
+				"engine": {Type: schemav2.TypeString, Optional: true, Default: "mysql"},
+			},
+			expected: resource.PropertyMap{
+				resource.PropertyKey(reservedkeys.Defaults): defaults(),
+				resource.PropertyKey("engine"):              resource.NewPropertyValue("mysql"),
+			},
+		},
+		{
+			// Read returns zero (0) for an int field with Default: 30.
+			// Zero is not the default — it should be kept regardless.
+			name: "int zero value with non-zero default is kept",
+			props: resource.NewPropertyMapFromMap(map[string]interface{}{
+				"recovery_window": 0,
+			}),
+			schemaMap: map[string]*schemav2.Schema{
+				"recovery_window": {Type: schemav2.TypeInt, Optional: true, Default: 30},
+			},
+			expected: resource.PropertyMap{
+				resource.PropertyKey(reservedkeys.Defaults): defaults(),
+				resource.PropertyKey("recovery_window"):     resource.NewNumberProperty(0),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sm := shimv2.NewSchemaMap(tc.schemaMap)
+			err := sm.Validate()
+			require.NoErrorf(t, err, "Invalid test case schema, please fix the testCase")
+
+			result, err := ExtractInputsFromOutputs(nil, tc.props, sm, nil, false)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// TestIsDefaultOrZeroValueBehavior validates our understanding of how isDefaultOrZeroValue
+// handles various combinations of null/zero values with and without schema defaults.
+func TestIsDefaultOrZeroValueBehavior(t *testing.T) {
+	t.Parallel()
+
+	boolSchema := shimv2.NewSchemaMap(map[string]*schemav2.Schema{
+		"f": {Type: schemav2.TypeBool, Optional: true, Default: false},
+	})
+	intSchema := shimv2.NewSchemaMap(map[string]*schemav2.Schema{
+		"f": {Type: schemav2.TypeInt, Optional: true, Default: 30},
+	})
+	noDefaultSchema := shimv2.NewSchemaMap(map[string]*schemav2.Schema{
+		"f": {Type: schemav2.TypeString, Optional: true},
+	})
+
+	getSchema := func(sm shim.SchemaMap) shim.Schema {
+		return sm.Get("f")
+	}
+
+	// Validate getDefaultValue behavior
+	t.Run("getDefaultValue returns false for Default:false", func(t *testing.T) {
+		dv := getDefaultValue(getSchema(boolSchema), nil)
+		// interface{}(false) is NOT nil
+		assert.NotNil(t, dv, "false should not be nil as interface{}")
+		assert.Equal(t, false, dv)
+	})
+
+	t.Run("getDefaultValue returns 30 for Default:30", func(t *testing.T) {
+		dv := getDefaultValue(getSchema(intSchema), nil)
+		assert.NotNil(t, dv)
+		assert.Equal(t, 30, dv)
+	})
+
+	t.Run("getDefaultValue returns nil for no default", func(t *testing.T) {
+		dv := getDefaultValue(getSchema(noDefaultSchema), nil)
+		assert.Nil(t, dv)
+	})
+
+	// Validate isDefaultOrZeroValue behavior
+	t.Run("null with Default:false — isDefaultOrZeroValue returns false", func(t *testing.T) {
+		// Because getDefaultValue returns false (non-nil), isDefaultOrZeroValue
+		// returns dv==v.V which is false==nil → false.
+		// This means null fields with a schema default are NOT considered
+		// default/zero, so they WON'T be dropped — they'll be kept as null.
+		result := isDefaultOrZeroValue(getSchema(boolSchema), nil, resource.NewNullProperty())
+		assert.False(t, result, "null with Default:false returns false (dv==v.V → false==nil → false)")
+	})
+
+	t.Run("false with Default:false — isDefaultOrZeroValue returns true", func(t *testing.T) {
+		// dv==v.V → false==false → true
+		result := isDefaultOrZeroValue(getSchema(boolSchema), nil, resource.NewPropertyValue(false))
+		assert.True(t, result)
+	})
+
+	t.Run("null with no default — isDefaultOrZeroValue returns true", func(t *testing.T) {
+		// getDefaultValue returns nil, falls to switch, v.IsNull() → true
+		result := isDefaultOrZeroValue(getSchema(noDefaultSchema), nil, resource.NewNullProperty())
+		assert.True(t, result)
+	})
 }
 
 func TestMakeSingleTerraformInput(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes `extractSchemaInputsObject` dropping optional fields whose value matches the schema default (e.g. `force_destroy: false` with `Default: false`). Previously these were treated as "zero values" and dropped, causing spurious diffs on next preview when `PlanResourceChange` re-applied the same default.
- When Read returns null for a field that has a schema default, injects the default value to prevent a `null → default` diff after `pulumi import`.

Fixes #2436

## Test plan

- [x] Added `TestExtractSchemaInputsDefaultInjection` covering null injection, default retention, and no-default drop cases
- [x] Added `TestIsDefaultOrZeroValueBehavior` validating understanding of the helper function
- [x] Updated existing `TestExtractDefaultSecretInputs`, `TestExtractDefaultIntegerInputs`, and `TestExtractInputsFromOutputsSdkv2` expectations
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)