### PR TITLE
fix(tfbridge): retain null timeouts in raw state delta recovery

### DIFF
--- a/pkg/pf/tests/schema_and_program_test.go
+++ b/pkg/pf/tests/schema_and_program_test.go
@@ -118,6 +118,72 @@ resources:
 	pt.Up(t)
 }
 
+// Regression test for the timeouts retention branch added in #3248. When the schema defines a read
+// timeout (the shape produced by terraform-plugin-framework-timeouts with Read enabled) and the
+// program sets other timeouts but omits read, the Terraform state carries timeouts.read=null while
+// the Pulumi outputs do not. The raw state delta must still round-trip.
+func TestTimeoutsWithUnsetReadTimeout(t *testing.T) {
+	t.Parallel()
+	provBuilder := pb.NewProvider(
+		pb.NewProviderArgs{
+			AllResources: []pb.Resource{
+				pb.NewResource(pb.NewResourceArgs{
+					ResourceSchema: rschema.Schema{
+						Attributes: map[string]rschema.Attribute{
+							"name": rschema.StringAttribute{Optional: true},
+							"timeouts": rschema.SingleNestedAttribute{
+								Optional: true,
+								Attributes: map[string]rschema.Attribute{
+									"create": rschema.StringAttribute{Optional: true},
+									"read":   rschema.StringAttribute{Optional: true},
+									"update": rschema.StringAttribute{Optional: true},
+									"delete": rschema.StringAttribute{Optional: true},
+								},
+							},
+						},
+					},
+				}),
+			},
+		})
+
+	prov := provBuilder.ToProviderInfo()
+
+	program := `
+name: test
+runtime: yaml
+resources:
+    mainRes:
+        type: testprovider:index:Test
+        properties:
+            name: "v1"
+            timeouts:
+                create: "60m"
+                update: "60m"
+                delete: "60m"
+`
+
+	pt, err := pulcheck.PulCheck(t, prov, program)
+	require.NoError(t, err)
+
+	pt.Up(t)
+
+	pt.WritePulumiYaml(t, `
+name: test
+runtime: yaml
+resources:
+    mainRes:
+        type: testprovider:index:Test
+        properties:
+            name: "v2"
+            timeouts:
+                create: "60m"
+                update: "60m"
+                delete: "60m"
+`)
+
+	pt.Up(t)
+}
+
 func TestComputedSetNoDiffWhenElementRemoved(t *testing.T) {
 	t.Parallel()
 	// Regression test for [pulumi/pulumi-terraform-bridge#2192]

--- a/pkg/tfbridge/rawstate.go
+++ b/pkg/tfbridge/rawstate.go
@@ -652,12 +652,15 @@ func (ih *rawStateDeltaHelper) computeDeltaAt(
 	isUnknown := pv.IsComputed() || pv.IsOutput() && !pv.OutputValue().Known
 	contract.Assertf(!isUnknown, "rawStateDeltaHelper cannot process unknown PropertyValue values")
 
-	// Timeouts are a special property that accidentally gets pushed here for historical reasons; it is not
-	// relevant for the permanent RawState storage. Ignore it for now.
+	// Timeouts are a special property injected by Terraform. When the outputs do not carry
+	// timeouts, [RawStateComputeDelta] strips this delta, so its contents do not matter. When they
+	// do, the raw state retains the full Terraform timeouts value, which includes schema-defined
+	// timeouts that were never configured and appear as null (e.g. read); such keys are absent from
+	// the Pulumi value and must be encoded so that Recover re-materializes them.
 	if len(path) == 1 {
 		if step, ok := path[0].(walk.GetAttrStep); ok {
 			if step.Name == "timeouts" {
-				return RawStateDelta{Obj: &objDelta{PropertyDeltas: map[resource.PropertyKey]RawStateDelta{}}}, nil
+				return ih.timeoutsDeltaAt(path, pv, v), nil
 			}
 		}
 	}
@@ -876,6 +879,53 @@ func (ih *rawStateDeltaHelper) computeDeltaAt(
 	default:
 		return RawStateDelta{}, fmt.Errorf("no efficient delta for type %s", v.Type().GoString())
 	}
+}
+
+// Computes the delta for the timeouts property. Mirrors the generic object handling in
+// [computeDeltaAt] but uses default property naming for the timeouts sub-keys, since they are not
+// routed through the resource schema's name-mapping context here (timeouts may be schema-defined,
+// e.g. via terraform-plugin-framework-timeouts in the Plugin Framework path). Keys present in the
+// Terraform value but missing from the Pulumi value (typically schema-defined timeouts left
+// unconfigured, which Terraform stores as null) are encoded as replace deltas so that Recover
+// reproduces them.
+func (ih *rawStateDeltaHelper) timeoutsDeltaAt(
+	path walk.SchemaPath,
+	pv resource.PropertyValue,
+	v valueshim.Value,
+) RawStateDelta {
+	oDelta := objDelta{PropertyDeltas: map[resource.PropertyKey]RawStateDelta{}}
+	if v.IsNull() || (!v.Type().IsObjectType() && !v.Type().IsMapType()) {
+		return RawStateDelta{Obj: &oDelta}
+	}
+	if !pv.IsObject() {
+		return ih.replaceDeltaAt(path, pv, v, errors.New("expected an Object PropertyValue for timeouts"))
+	}
+
+	pvElements := pv.ObjectValue()
+	elements := v.AsValueMap()
+
+	for k, ev := range elements {
+		key := resource.PropertyKey(k)
+		var d RawStateDelta
+		if subPV, ok := pvElements[key]; ok {
+			d = ih.deltaAt(path.GetAttr(k), subPV, ev)
+		} else {
+			d = ih.replaceDeltaAt(path.GetAttr(k), resource.NewNullProperty(), ev,
+				fmt.Errorf("No PropertyValue at timeouts key %q", k))
+		}
+		oDelta.set(k, key, d)
+	}
+
+	for k := range pvElements {
+		if reservedkeys.IsBridgeReservedKey(string(k)) {
+			continue
+		}
+		if _, ok := elements[string(k)]; !ok {
+			oDelta.ignore(k)
+		}
+	}
+
+	return RawStateDelta{Obj: &oDelta}
 }
 
 func newRawStateFromValue(schemaType valueshim.Type, v valueshim.Value) rawstate.RawState {

--- a/pkg/tfbridge/rawstate_test.go
+++ b/pkg/tfbridge/rawstate_test.go
@@ -466,6 +466,53 @@ func Test_rawstate_delta_writeonly_null_string(t *testing.T) {
 	require.Equal(t, string(cvJSON), string(recoveredValueJSON))
 }
 
+// When the outputs include timeouts, the raw state retains the full Terraform timeouts value,
+// which contains every schema-defined timeout; unset ones appear as null. Keys like read=null are
+// absent from the Pulumi property bag, so the delta must re-materialize them on Recover or the
+// turnaround check fails. This is a follow-up to the timeouts retention branch added in #3248.
+func Test_rawstate_delta_timeouts_with_null_read(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	schemaMap := sdkv2.NewSchemaMap(map[string]*schema.Schema{
+		"name": {Type: schema.TypeString, Optional: true},
+	})
+
+	cv := cty.ObjectVal(map[string]cty.Value{
+		"name": cty.StringVal("v1"),
+		"timeouts": cty.ObjectVal(map[string]cty.Value{
+			"create": cty.StringVal("60m"),
+			"delete": cty.StringVal("60m"),
+			"read":   cty.NullVal(cty.String),
+			"update": cty.StringVal("60m"),
+		}),
+	})
+
+	outMap := resource.PropertyMap{
+		"name": resource.NewStringProperty("v1"),
+		"timeouts": resource.NewObjectProperty(resource.PropertyMap{
+			"create": resource.NewStringProperty("60m"),
+			"delete": resource.NewStringProperty("60m"),
+			"update": resource.NewStringProperty("60m"),
+		}),
+	}
+
+	schemaType := valueshim.FromHCtyType(cv.Type())
+	delta, err := RawStateComputeDelta(ctx, schemaMap, nil, outMap, schemaType, valueshim.FromHCtyValue(cv))
+	require.NoError(t, err)
+
+	recovered, err := delta.Recover(resource.NewObjectProperty(outMap))
+	require.NoError(t, err)
+
+	recoveredJSON, err := json.Marshal(recovered)
+	require.NoError(t, err)
+
+	cvJSON, err := ctyjson.Marshal(cv, cv.Type())
+	require.NoError(t, err)
+
+	require.Equal(t, string(cvJSON), string(recoveredJSON))
+}
+
 func Test_rawstate_delta_serialization(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- The raw state delta dropped schema-defined timeouts that were left unconfigured. Terraform stores these as null (e.g. `timeouts.read`), but they are absent from the Pulumi property bag, so `Recover` failed to re-materialize them and the byte-for-byte turnaround check broke.
- `computeDeltaAt` previously discarded the entire `timeouts` delta. It now delegates to a dedicated `timeoutsDeltaAt` that walks the Terraform value and encodes keys missing from the Pulumi value (typically null timeouts) as replace deltas so recovery reproduces them exactly.
- Keys present only in the Pulumi value (bridge-reserved keys) continue to be ignored, preserving existing behavior when outputs omit timeouts entirely.

## Test plan

- [x] `Test_rawstate_delta_timeouts_with_null_read` asserts a cty value with `timeouts.read=null` round-trips byte-for-byte
- [x] `TestTimeoutsWithUnsetReadTimeout` (PF) exercises a real program that sets create/update/delete but omits read
- [x] `make lint` passes with zero issues
- [x] `make test` passes for affected packages

## Changes

### Modified files

- `pkg/tfbridge/rawstate.go` - Replace the timeouts short-circuit in `computeDeltaAt` with a new `timeoutsDeltaAt` helper that mirrors the generic object handling using default property naming, encoding Terraform-only keys as replace deltas.
- `pkg/tfbridge/rawstate_test.go` - Add a turnaround unit test covering null `timeouts.read` recovery.
- `pkg/pf/tests/schema_and_program_test.go` - Add a Plugin Framework regression test covering an unset read timeout across an update.

Closes #3481