### PR TITLE
Add null check to raw state delta

### DIFF
--- a/pkg/tfbridge/rawstate.go
+++ b/pkg/tfbridge/rawstate.go
@@ -689,16 +689,16 @@ func (ih *rawStateDeltaHelper) computeDeltaAt(
 	case v.IsNull() && pv.IsNull():
 		return RawStateDelta{}, nil
 
-	case v.Type().IsStringType() && pv.IsString() && pv.StringValue() == v.StringValue():
+	case !v.IsNull() && v.Type().IsStringType() && pv.IsString() && pv.StringValue() == v.StringValue():
 		return RawStateDelta{}, nil
 
-	case v.Type().IsBooleanType() && pv.IsBool() && pv.BoolValue() == v.BoolValue():
+	case !v.IsNull() && v.Type().IsBooleanType() && pv.IsBool() && pv.BoolValue() == v.BoolValue():
 		return RawStateDelta{}, nil
 
-	case v.Type().IsNumberType() && pv.IsNumber() && isSimilarNumber(pv.NumberValue(), v.BigFloatValue()):
+	case !v.IsNull() && v.Type().IsNumberType() && pv.IsNumber() && isSimilarNumber(pv.NumberValue(), v.BigFloatValue()):
 		return RawStateDelta{}, nil
 
-	case v.Type().IsNumberType() && pv.IsString():
+	case !v.IsNull() && v.Type().IsNumberType() && pv.IsString():
 		return RawStateDelta{Num: &numDelta{}}, nil
 
 	case v.Type().IsListType() && !v.IsNull():

--- a/pkg/tfbridge/rawstate_test.go
+++ b/pkg/tfbridge/rawstate_test.go
@@ -443,6 +443,29 @@ func Test_rawstate_delta_turnaround(t *testing.T) {
 	}
 }
 
+func Test_rawstate_delta_writeonly_null_string(t *testing.T) {
+	t.Parallel()
+
+	cv := cty.NullVal(cty.String)
+	pv := resource.NewStringProperty("write-only-value")
+
+	ih := rawStateDeltaHelper{}
+	ih.schemaType = valueshim.FromHCtyType(cv.Type())
+
+	delta := ih.delta(pv, valueshim.FromHCtyValue(cv))
+
+	recoveredValue, err := delta.Recover(pv)
+	require.NoError(t, err)
+
+	recoveredValueJSON, err := json.Marshal(recoveredValue)
+	require.NoError(t, err)
+
+	cvJSON, err := ctyjson.Marshal(cv, cv.Type())
+	require.NoError(t, err)
+
+	require.Equal(t, string(cvJSON), string(recoveredValueJSON))
+}
+
 func Test_rawstate_delta_serialization(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Write-only Terraform fields are stored as null in the Terraform state, but the user-provided value is
retained in the Pulumi property map. This produces a non-null Pulumi string paired with a null,
string-typed cty value. A null cty value still reports its declared type, so v.Type().IsStringType() is true. An extra null check is needed.

Fixes pulumi/pulumi-terraform-bridge#3488.
