### PR TITLE
Fix detailed diff matching for reordered nested sets

### DIFF
--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_end_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_end_unordered.golden
@@ -45,10 +45,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                        [0]: "val2"
-                        [1]: "val3"
                       + [2]: "val1"
                     ]
                 }
@@ -57,5 +54,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_front_unordered.golden
@@ -45,11 +45,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                      ~ [0]: "val1" => "val2"
-                        [1]: "val3"
-                      + [2]: "val1"
+                      + [0]: "val2"
                     ]
                 }
         ]
@@ -57,5 +54,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/added_middle_unordered.golden
@@ -45,11 +45,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                      ~ [0]: "val1" => "val2"
-                      ~ [1]: "val2" => "val3"
-                      + [2]: "val1"
+                      + [1]: "val3"
                     ]
                 }
         ]
@@ -57,5 +54,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_front_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_front_unordered.golden
@@ -45,11 +45,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                      ~ [0]: "val1" => "val3"
-                      ~ [1]: "val2" => "val1"
-                      - [2]: "val3"
+                      - [1]: "val2"
                     ]
                 }
         ]
@@ -57,5 +54,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_middle_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/removed_middle_unordered.golden
@@ -45,11 +45,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                      ~ [0]: "val1" => "val3"
-                      ~ [1]: "val2" => "val1"
-                      - [2]: "val3"
+                      - [1]: "val2"
                     ]
                 }
         ]
@@ -57,5 +54,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/same_element_updated.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/same_element_updated.golden
@@ -47,11 +47,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                        [0]: "val1"
                       ~ [1]: "val2" => "val4"
-                        [2]: "val3"
                     ]
                 }
         ]
@@ -59,5 +56,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[1]": map[string]interface{}{"kind": "UPDATE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/same_element_updated_unordered.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/same_element_updated_unordered.golden
@@ -47,11 +47,9 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                      ~ [0]: "val1" => "val2"
-                      ~ [1]: "val2" => "val4"
-                      ~ [2]: "val3" => "val1"
+                      + [1]: "val4"
+                      - [2]: "val3"
                     ]
                 }
         ]
@@ -59,5 +57,8 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProps[1]": map[string]interface{}{},
+		"props[0].nestedProps[2]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_end.golden
@@ -45,10 +45,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                      ~ [0]: "val1" => "val2"
-                      ~ [1]: "val2" => "val1"
                       + [2]: "val3"
                     ]
                 }
@@ -57,5 +54,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[2]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_front.golden
@@ -45,11 +45,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                      ~ [0]: "val2" => "val1"
-                        [1]: "val3"
-                      + [2]: "val2"
+                      + [0]: "val1"
                     ]
                 }
         ]
@@ -57,5 +54,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[0]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_added_middle.golden
@@ -45,11 +45,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                      ~ [0]: "val1" => "val3"
-                      ~ [1]: "val3" => "val2"
-                      + [2]: "val1"
+                      + [1]: "val2"
                     ]
                 }
         ]
@@ -57,5 +54,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[1]": map[string]interface{}{}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_end.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_end.golden
@@ -45,10 +45,7 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                      ~ [0]: "val1" => "val2"
-                      ~ [1]: "val2" => "val1"
                       - [2]: "val3"
                     ]
                 }
@@ -57,5 +54,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[2]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_front.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_front.golden
@@ -45,11 +45,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                      ~ [0]: "val1" => "val3"
-                        [1]: "val2"
-                      - [2]: "val3"
+                      - [0]: "val1"
                     ]
                 }
         ]
@@ -57,5 +54,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[0]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_middle.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/shuffled_removed_middle.golden
@@ -45,11 +45,8 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                      ~ [0]: "val1" => "val3"
-                      ~ [1]: "val2" => "val1"
-                      - [2]: "val3"
+                      - [1]: "val2"
                     ]
                 }
         ]
@@ -57,5 +54,5 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{"props[0].nestedProps[1]": map[string]interface{}{"kind": "DELETE"}},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_no_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_no_overlaps.golden
@@ -51,12 +51,11 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                      ~ [0]: "val1" => "val5"
-                      ~ [1]: "val2" => "val6"
-                      ~ [2]: "val3" => "val1"
-                      ~ [3]: "val4" => "val2"
+                      + [0]: "val5"
+                      + [1]: "val6"
+                      - [2]: "val3"
+                      - [3]: "val4"
                     ]
                 }
         ]
@@ -64,5 +63,10 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProps[0]": map[string]interface{}{},
+		"props[0].nestedProps[1]": map[string]interface{}{},
+		"props[0].nestedProps[2]": map[string]interface{}{"kind": "DELETE"},
+		"props[0].nestedProps[3]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_one_overlaps.golden
+++ b/pkg/tests/diff_test/testdata/TestSDKv2DetailedDiffNestedSets/nested_set/two_added_and_two_removed_shuffled,_one_overlaps.golden
@@ -51,12 +51,10 @@ Plan: 0 to add, 1 to change, 0 to destroy.
         [urn=urn:pulumi:test::project::crossprovider:index/testRes:TestRes::example]
       ~ props: [
           ~ [0]: {
-                  + __defaults : []
                   ~ nestedProps: [
-                        [0]: "val1"
-                      ~ [1]: "val2" => "val5"
+                      + [1]: "val5"
                       ~ [2]: "val3" => "val6"
-                      ~ [3]: "val4" => "val2"
+                      - [3]: "val4"
                     ]
                 }
         ]
@@ -64,5 +62,9 @@ Resources:
     ~ 1 to update
     1 unchanged
 `,
-	detailedDiff: map[string]interface{}{"props": map[string]interface{}{"kind": "UPDATE"}},
+	detailedDiff: map[string]interface{}{
+		"props[0].nestedProps[1]": map[string]interface{}{},
+		"props[0].nestedProps[2]": map[string]interface{}{"kind": "UPDATE"},
+		"props[0].nestedProps[3]": map[string]interface{}{"kind": "DELETE"},
+	},
 }

--- a/pkg/tests/regress_aws_1423_test.go
+++ b/pkg/tests/regress_aws_1423_test.go
@@ -20,6 +20,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	testutils "github.com/pulumi/providertest/replay"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/require"
 
 	webaclschema "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/internal/webaclschema"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
@@ -258,4 +261,64 @@ func TestRegressAws1423(t *testing.T) {
 		// diffs.
 		testutils.Replay(t, server, testCase2CreatePreview)
 	})
+}
+
+func TestRegressAws3495DetailedDiffMatchesWAFV2NestedSets(t *testing.T) {
+	t.Parallel()
+
+	rule := func(name string, textTransformations []interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"name":     name,
+			"priority": 0,
+			"action": map[string]interface{}{
+				"allow": map[string]interface{}{},
+			},
+			"statement": map[string]interface{}{
+				"byteMatchStatement": map[string]interface{}{
+					"fieldToMatch": map[string]interface{}{
+						"method": map[string]interface{}{},
+					},
+					"positionalConstraint": "EXACTLY",
+					"searchString":         "example",
+					"textTransformation":   textTransformations,
+				},
+			},
+			"visibilityConfig": map[string]interface{}{
+				"cloudwatchMetricsEnabled": true,
+				"metricName":               "rule-metric",
+				"sampledRequestsEnabled":   true,
+			},
+		}
+	}
+
+	noneTransform := map[string]interface{}{
+		"priority": 0,
+		"type":     "NONE",
+	}
+	lowercaseTransform := map[string]interface{}{
+		"priority": 1,
+		"type":     "LOWERCASE",
+	}
+
+	tfs := shimv2.NewSchemaMap(webaclschema.ResourceWebACL().SchemaFunc())
+	priorState := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"rules": []interface{}{
+			rule("rule-before", []interface{}{noneTransform, lowercaseTransform}),
+		},
+	})
+	plannedState := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"rules": []interface{}{
+			rule("rule-after", []interface{}{lowercaseTransform, noneTransform}),
+		},
+	})
+	newInputs := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"rules": []interface{}{
+			rule("rule-after", []interface{}{noneTransform, lowercaseTransform}),
+		},
+	})
+
+	actual := tfbridge.MakeDetailedDiffV2(context.Background(), tfs, nil, priorState, plannedState, newInputs, nil)
+	require.Equal(t, map[string]*pulumirpc.PropertyDiff{
+		"rules[0].name": {Kind: pulumirpc.PropertyDiff_UPDATE},
+	}, actual)
 }

--- a/pkg/tfbridge/detailed_diff.go
+++ b/pkg/tfbridge/detailed_diff.go
@@ -163,7 +163,6 @@ func makeBaseDiff(old, new resource.PropertyValue) baseDiff {
 // Under the hood, it walks the plan and the inputs and checks that all differences stem from computed properties.
 // Any differences coming from properties which are not computed will be rejected.
 // Note that we are relying on the fact that the inputs will have defaults already applied.
-// Also note that nested sets will only get matched if they are exactly the same.
 func validInputsFromPlan(
 	path propertyPath,
 	inputs resource.PropertyValue,
@@ -171,6 +170,59 @@ func validInputsFromPlan(
 	tfs shim.SchemaMap,
 	ps map[string]*info.Schema,
 ) bool {
+	validSetInputsFromPlan := func(
+		path propertyPath,
+		inputs resource.PropertyValue,
+		plan resource.PropertyValue,
+		tfs shim.SchemaMap,
+		ps map[string]*info.Schema,
+	) bool {
+		inputsList := inputs.ArrayValue()
+		planList := plan.ArrayValue()
+		if len(inputsList) != len(planList) {
+			return false
+		}
+
+		candidates := make([][]int, len(inputsList))
+		for inputIndex, input := range inputsList {
+			for planIndex, plan := range planList {
+				if validInputsFromPlan(path.Index(planIndex), input, plan, tfs, ps) {
+					candidates[inputIndex] = append(candidates[inputIndex], planIndex)
+				}
+			}
+			if len(candidates[inputIndex]) == 0 {
+				return false
+			}
+		}
+
+		matchedInputForPlan := make([]int, len(planList))
+		for i := range matchedInputForPlan {
+			matchedInputForPlan[i] = -1
+		}
+
+		var match func(int, []bool) bool
+		match = func(inputIndex int, seen []bool) bool {
+			for _, planIndex := range candidates[inputIndex] {
+				if seen[planIndex] {
+					continue
+				}
+				seen[planIndex] = true
+				if matchedInputForPlan[planIndex] == -1 || match(matchedInputForPlan[planIndex], seen) {
+					matchedInputForPlan[planIndex] = inputIndex
+					return true
+				}
+			}
+			return false
+		}
+
+		for inputIndex := range inputsList {
+			if !match(inputIndex, make([]bool, len(planList))) {
+				return false
+			}
+		}
+		return true
+	}
+
 	abortErr := errors.New("abort")
 	visitor := func(
 		subpath propertyPath, inputsSubVal, planSubVal resource.PropertyValue,
@@ -183,19 +235,17 @@ func validInputsFromPlan(
 			return SkipChildrenError{}
 		}
 
-		tfs, _, err := lookupSchemas(subpath, tfs, ps)
+		currentTFS, _, err := lookupSchemas(subpath, tfs, ps)
 		if err != nil {
 			return abortErr
 		}
 
-		if tfs.Computed() && inputsSubVal.IsNull() {
+		if currentTFS.Computed() && inputsSubVal.IsNull() {
 			// This is a computed property populated by the plan. We should not recurse into it.
 			return SkipChildrenError{}
 		}
 
-		if tfs.Type() == shim.TypeList || tfs.Type() == shim.TypeSet {
-			// Note that nested sets will likely get their elements reordered.
-			// This means that nested sets will not be matched correctly but that should be a rare case.
+		if currentTFS.Type() == shim.TypeList || currentTFS.Type() == shim.TypeSet {
 			if inputsSubVal.IsNull() {
 				// The plan is allowed to populate a nil list with an empty value.
 				if (planSubVal.IsArray() && len(planSubVal.ArrayValue()) == 0) || planSubVal.IsNull() {
@@ -212,11 +262,18 @@ func validInputsFromPlan(
 				return abortErr
 			}
 
-			// all non-empty lists will get their element values checked.
+			if currentTFS.Type() == shim.TypeSet {
+				if validSetInputsFromPlan(subpath, inputsSubVal, planSubVal, tfs, ps) {
+					return SkipChildrenError{}
+				}
+				return abortErr
+			}
+
+			// all non-empty lists will get their element values checked positionally.
 			return nil
 		}
 
-		if tfs.Type() == shim.TypeMap {
+		if currentTFS.Type() == shim.TypeMap {
 			if inputsSubVal.IsNull() {
 				// The plan is allowed to populate a nil map with an empty value.
 				if (planSubVal.IsObject() && len(planSubVal.ObjectValue()) == 0) || planSubVal.IsNull() {

--- a/pkg/tfbridge/detailed_diff.go
+++ b/pkg/tfbridge/detailed_diff.go
@@ -159,6 +159,60 @@ func makeBaseDiff(old, new resource.PropertyValue) baseDiff {
 	return undecidedDiff
 }
 
+// validSetInputsFromPlan returns true if each input set element can be paired with a distinct compatible plan element.
+func validSetInputsFromPlan(
+	path propertyPath,
+	inputs resource.PropertyValue,
+	plan resource.PropertyValue,
+	tfs shim.SchemaMap,
+	ps map[string]*info.Schema,
+) bool {
+	inputsList := inputs.ArrayValue()
+	planList := plan.ArrayValue()
+	if len(inputsList) != len(planList) {
+		return false
+	}
+
+	candidates := make([][]int, len(inputsList))
+	for inputIndex, input := range inputsList {
+		for planIndex, plan := range planList {
+			if validInputsFromPlan(path.Index(planIndex), input, plan, tfs, ps) {
+				candidates[inputIndex] = append(candidates[inputIndex], planIndex)
+			}
+		}
+		if len(candidates[inputIndex]) == 0 {
+			return false
+		}
+	}
+
+	matchedInputForPlan := make([]int, len(planList))
+	for i := range matchedInputForPlan {
+		matchedInputForPlan[i] = -1
+	}
+
+	var match func(int, []bool) bool
+	match = func(inputIndex int, seen []bool) bool {
+		for _, planIndex := range candidates[inputIndex] {
+			if seen[planIndex] {
+				continue
+			}
+			seen[planIndex] = true
+			if matchedInputForPlan[planIndex] == -1 || match(matchedInputForPlan[planIndex], seen) {
+				matchedInputForPlan[planIndex] = inputIndex
+				return true
+			}
+		}
+		return false
+	}
+
+	for inputIndex := range inputsList {
+		if !match(inputIndex, make([]bool, len(planList))) {
+			return false
+		}
+	}
+	return true
+}
+
 // validInputsFromPlan returns true if the given plan property value could originate from the given inputs.
 // Under the hood, it walks the plan and the inputs and checks that all differences stem from computed properties.
 // Any differences coming from properties which are not computed will be rejected.
@@ -170,59 +224,6 @@ func validInputsFromPlan(
 	tfs shim.SchemaMap,
 	ps map[string]*info.Schema,
 ) bool {
-	validSetInputsFromPlan := func(
-		path propertyPath,
-		inputs resource.PropertyValue,
-		plan resource.PropertyValue,
-		tfs shim.SchemaMap,
-		ps map[string]*info.Schema,
-	) bool {
-		inputsList := inputs.ArrayValue()
-		planList := plan.ArrayValue()
-		if len(inputsList) != len(planList) {
-			return false
-		}
-
-		candidates := make([][]int, len(inputsList))
-		for inputIndex, input := range inputsList {
-			for planIndex, plan := range planList {
-				if validInputsFromPlan(path.Index(planIndex), input, plan, tfs, ps) {
-					candidates[inputIndex] = append(candidates[inputIndex], planIndex)
-				}
-			}
-			if len(candidates[inputIndex]) == 0 {
-				return false
-			}
-		}
-
-		matchedInputForPlan := make([]int, len(planList))
-		for i := range matchedInputForPlan {
-			matchedInputForPlan[i] = -1
-		}
-
-		var match func(int, []bool) bool
-		match = func(inputIndex int, seen []bool) bool {
-			for _, planIndex := range candidates[inputIndex] {
-				if seen[planIndex] {
-					continue
-				}
-				seen[planIndex] = true
-				if matchedInputForPlan[planIndex] == -1 || match(matchedInputForPlan[planIndex], seen) {
-					matchedInputForPlan[planIndex] = inputIndex
-					return true
-				}
-			}
-			return false
-		}
-
-		for inputIndex := range inputsList {
-			if !match(inputIndex, make([]bool, len(planList))) {
-				return false
-			}
-		}
-		return true
-	}
-
 	abortErr := errors.New("abort")
 	visitor := func(
 		subpath propertyPath, inputsSubVal, planSubVal resource.PropertyValue,

--- a/pkg/tfbridge/detailed_diff.go
+++ b/pkg/tfbridge/detailed_diff.go
@@ -236,7 +236,7 @@ func validInputsFromPlan(
 			return SkipChildrenError{}
 		}
 
-		currentTFS, _, err := lookupSchemas(subpath, tfs, ps)
+		currentTFS, currentPS, err := lookupSchemas(subpath, tfs, ps)
 		if err != nil {
 			return abortErr
 		}
@@ -247,6 +247,25 @@ func validInputsFromPlan(
 		}
 
 		if currentTFS.Type() == shim.TypeList || currentTFS.Type() == shim.TypeSet {
+			if IsMaxItemsOne(currentTFS, currentPS) && !inputsSubVal.IsArray() && !planSubVal.IsArray() {
+				if inputsSubVal.IsNull() {
+					if planSubVal.IsNull() {
+						return nil
+					}
+					return abortErr
+				}
+				if planSubVal.IsNull() {
+					return abortErr
+				}
+				if inputsSubVal.IsObject() && planSubVal.IsObject() {
+					return nil
+				}
+				if inputsSubVal.DeepEquals(planSubVal) {
+					return nil
+				}
+				return abortErr
+			}
+
 			if inputsSubVal.IsNull() {
 				// The plan is allowed to populate a nil list with an empty value.
 				if (planSubVal.IsArray() && len(planSubVal.ArrayValue()) == 0) || planSubVal.IsNull() {

--- a/pkg/tfbridge/detailed_diff_test.go
+++ b/pkg/tfbridge/detailed_diff_test.go
@@ -87,7 +87,7 @@ func TestValidInputsFromPlan(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "set requires exact match",
+			name: "set does not require exact order",
 			path: newPropertyPath("set"),
 			inputValue: resource.NewArrayProperty([]resource.PropertyValue{
 				resource.NewStringProperty("a"),
@@ -106,7 +106,46 @@ func TestValidInputsFromPlan(t *testing.T) {
 					},
 				},
 			},
-			want: false,
+			want: true,
+		},
+		{
+			name: "nested set does not require exact order",
+			path: newPropertyPath("obj"),
+			inputValue: resource.NewArrayProperty(
+				[]resource.PropertyValue{
+					resource.NewObjectProperty(resource.PropertyMap{
+						"nested": resource.NewArrayProperty([]resource.PropertyValue{
+							resource.NewStringProperty("a"),
+							resource.NewStringProperty("b"),
+						}),
+					}),
+				},
+			),
+			planValue: resource.NewArrayProperty(
+				[]resource.PropertyValue{
+					resource.NewObjectProperty(resource.PropertyMap{
+						"nested": resource.NewArrayProperty([]resource.PropertyValue{
+							resource.NewStringProperty("b"),
+							resource.NewStringProperty("a"),
+						}),
+					}),
+				},
+			),
+			sdkv2Schema: map[string]*schema.Schema{
+				"obj": {
+					Type: schema.TypeSet,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"nested": {
+								Type:     schema.TypeSet,
+								Optional: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
+			},
+			want: true,
 		},
 		{
 			name: "missing non-computed property",
@@ -3398,6 +3437,60 @@ func TestMakeSetDiffElementResult(t *testing.T) {
 			require.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestDetailedDiffMatchesSetElementsWithReorderedNestedSets(t *testing.T) {
+	t.Parallel()
+
+	tfs := shimv2.NewSchemaMap(map[string]*schema.Schema{
+		"rules": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"statements": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem:     &schema.Schema{Type: schema.TypeString},
+					},
+				},
+			},
+		},
+	})
+
+	priorState := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"rules": []interface{}{
+			map[string]interface{}{
+				"name":       "before",
+				"statements": []interface{}{"a", "b"},
+			},
+		},
+	})
+	plannedState := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"rules": []interface{}{
+			map[string]interface{}{
+				"name":       "after",
+				"statements": []interface{}{"b", "a"},
+			},
+		},
+	})
+	newInputs := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"rules": []interface{}{
+			map[string]interface{}{
+				"name":       "after",
+				"statements": []interface{}{"a", "b"},
+			},
+		},
+	})
+
+	actual := MakeDetailedDiffV2(context.Background(), tfs, nil, priorState, plannedState, newInputs, nil)
+	require.Equal(t, map[string]*pulumirpc.PropertyDiff{
+		"rules[0].name": {Kind: pulumirpc.PropertyDiff_UPDATE},
+	}, actual)
 }
 
 func TestDetailedDiffAssets(t *testing.T) {

--- a/pkg/tfbridge/detailed_diff_test.go
+++ b/pkg/tfbridge/detailed_diff_test.go
@@ -148,6 +148,58 @@ func TestValidInputsFromPlan(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "max items one block uses flattened object",
+			path: newPropertyPath("obj"),
+			inputValue: resource.NewArrayProperty(
+				[]resource.PropertyValue{
+					resource.NewObjectProperty(resource.PropertyMap{
+						"single": resource.NewObjectProperty(resource.PropertyMap{
+							"nested": resource.NewArrayProperty([]resource.PropertyValue{
+								resource.NewStringProperty("a"),
+								resource.NewStringProperty("b"),
+							}),
+						}),
+					}),
+				},
+			),
+			planValue: resource.NewArrayProperty(
+				[]resource.PropertyValue{
+					resource.NewObjectProperty(resource.PropertyMap{
+						"single": resource.NewObjectProperty(resource.PropertyMap{
+							"nested": resource.NewArrayProperty([]resource.PropertyValue{
+								resource.NewStringProperty("b"),
+								resource.NewStringProperty("a"),
+							}),
+						}),
+					}),
+				},
+			),
+			sdkv2Schema: map[string]*schema.Schema{
+				"obj": {
+					Type: schema.TypeSet,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"single": {
+								Type:     schema.TypeList,
+								Optional: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"nested": {
+											Type:     schema.TypeSet,
+											Optional: true,
+											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "set matching reassigns an ambiguous pairing",
 			path: newPropertyPath("items"),
 			inputValue: resource.NewArrayProperty([]resource.PropertyValue{

--- a/pkg/tfbridge/detailed_diff_test.go
+++ b/pkg/tfbridge/detailed_diff_test.go
@@ -148,6 +148,108 @@ func TestValidInputsFromPlan(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "set matching reassigns an ambiguous pairing",
+			path: newPropertyPath("items"),
+			inputValue: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name": resource.NewStringProperty("shared"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":   resource.NewStringProperty("shared"),
+					"system": resource.NewStringProperty("fixed"),
+				}),
+			}),
+			planValue: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":   resource.NewStringProperty("shared"),
+					"system": resource.NewStringProperty("fixed"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":   resource.NewStringProperty("shared"),
+					"system": resource.NewStringProperty("generated"),
+				}),
+			}),
+			sdkv2Schema: map[string]*schema.Schema{
+				"items": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+						"name":   {Type: schema.TypeString, Optional: true},
+						"system": {Type: schema.TypeString, Optional: true, Computed: true},
+					}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "set elements cannot share one plan match",
+			path: newPropertyPath("items"),
+			inputValue: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":   resource.NewStringProperty("shared"),
+					"system": resource.NewStringProperty("fixed"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":   resource.NewStringProperty("shared"),
+					"system": resource.NewStringProperty("fixed"),
+				}),
+			}),
+			planValue: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":   resource.NewStringProperty("shared"),
+					"system": resource.NewStringProperty("fixed"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":   resource.NewStringProperty("shared"),
+					"system": resource.NewStringProperty("generated"),
+				}),
+			}),
+			sdkv2Schema: map[string]*schema.Schema{
+				"items": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+						"name":   {Type: schema.TypeString, Optional: true},
+						"system": {Type: schema.TypeString, Optional: true, Computed: true},
+					}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "reordered set allows auto-filled fields",
+			path: newPropertyPath("items"),
+			inputValue: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name": resource.NewStringProperty("first"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name": resource.NewStringProperty("second"),
+				}),
+			}),
+			planValue: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":   resource.NewStringProperty("second"),
+					"system": resource.NewStringProperty("generated-second"),
+				}),
+				resource.NewObjectProperty(resource.PropertyMap{
+					"name":   resource.NewStringProperty("first"),
+					"system": resource.NewStringProperty("generated-first"),
+				}),
+			}),
+			sdkv2Schema: map[string]*schema.Schema{
+				"items": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+						"name":   {Type: schema.TypeString, Optional: true},
+						"system": {Type: schema.TypeString, Optional: true, Computed: true},
+					}},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "missing non-computed property",
 			path: newPropertyPath("obj"),
 			inputValue: resource.NewArrayProperty(


### PR DESCRIPTION
## Summary

Resolves #3495

This updates detailed diff input-to-plan validation so `TypeSet` values are matched by set membership instead of array position.

The reported WAFv2 case can reorder nested `TypeSet` blocks during planning. Before this change, `validInputsFromPlan` compared those nested sets positionally, failed to match the planned set element back to the user input, and `makeSetDiff` fell back to a whole-set `UPDATE`.

With this change, set values are matched against any compatible planned element while lists continue to use positional matching. That lets detailed diff keep reporting the real changed path instead of falling back to the whole set.

## Tests

- `go test ./pkg/tfbridge -run 'TestValidInputsFromPlan|TestDetailedDiffMatchesSetElementsWithReorderedNestedSets' -count=1`
- `go test ./pkg/tfbridge -count=1`

Not run locally:

- `go test ./pkg/tests/diff_test -run 'TestSDKv2DetailedDiffNestedSets' -count=1` requires the Terraform CLI in `PATH`.

## Breaking changes

None.