### PR TITLE
Add OTEL traces for dynamic schema generation

### DIFF
--- a/dynamic/main.go
+++ b/dynamic/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/spf13/afero"
+	"go.opentelemetry.io/otel"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/dynamic/internal/shim/run"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/dynamic/parameterize"
@@ -44,6 +45,9 @@ const (
 	// The name of this *unparameterized* provider.
 	baseProviderName = "terraform-provider"
 )
+
+// getSchemaTracer instruments the dynamic provider's GetSchema handler.
+var getSchemaTracer = otel.Tracer("pulumi-terraform-bridge/dynamic")
 
 func main() {
 	ctx := context.Background()
@@ -84,21 +88,25 @@ func initialSetup() (info.Provider, pfbridge.ProviderMetadata, func() error) {
 	var indexDocOutDir string
 	metadata = pfbridge.ProviderMetadata{
 		XGetSchema: func(ctx context.Context, req plugin.GetSchemaRequest) ([]byte, error) {
+			ctx, span := getSchemaTracer.Start(ctx, "XGetSchema")
+			defer span.End()
 			// Create a custom generator for schema. Examples will only be generated if `fullDocs` is set.
+			newGenCtx, newGenSpan := getSchemaTracer.Start(ctx, "NewGenerator")
 			g, err := tfgen.NewGenerator(tfgen.GeneratorOptions{
 				Package:       info.Name,
 				Version:       info.Version,
 				Language:      tfgen.Schema,
 				ProviderInfo:  info,
 				Root:          afero.NewMemMapFs(),
-				Sink:          loggerSink{tfbridge.GetLogger(ctx)},
+				Sink:          loggerSink{tfbridge.GetLogger(newGenCtx)},
 				XInMemoryDocs: !fullDocs,
 				SkipExamples:  !fullDocs,
 			})
+			newGenSpan.End()
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to create generator")
 			}
-			packageSchema, err := g.Generate()
+			packageSchema, err := g.Generate(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -123,7 +131,7 @@ func initialSetup() (info.Provider, pfbridge.ProviderMetadata, func() error) {
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to create generator")
 				}
-				_, err = indexGenerator.Generate()
+				_, err = indexGenerator.Generate(ctx)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/pf/tfgen/main.go
+++ b/pkg/pf/tfgen/main.go
@@ -15,6 +15,7 @@
 package tfgen
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -60,7 +61,7 @@ func Main(provider string, info sdkBridge.ProviderInfo) {
 		if err := check.Provider(nil, g.Sink(), info); err != nil {
 			return err
 		}
-		_, err = g.Generate()
+		_, err = g.Generate(context.Background())
 
 		return err
 	})
@@ -125,7 +126,7 @@ func MainWithMuxer(provider string, info sdkBridge.ProviderInfo) {
 			return err
 		}
 
-		_, err = g.Generate()
+		_, err = g.Generate(context.Background())
 		return err
 	})
 }

--- a/pkg/tests/schema_generation_test.go
+++ b/pkg/tests/schema_generation_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -169,7 +170,7 @@ func Test_Generate(t *testing.T) { //nolint:paralleltest // Cannot run in parall
 	})
 	require.NoError(t, err)
 
-	schemaResult, err := schemaGen.Generate()
+	schemaResult, err := schemaGen.Generate(context.Background())
 	require.NoError(t, err)
 
 	// Write the schema to the expected location
@@ -199,7 +200,7 @@ func Test_Generate(t *testing.T) { //nolint:paralleltest // Cannot run in parall
 	})
 	require.NoError(t, err)
 
-	_, err = gen.Generate()
+	_, err = gen.Generate(context.Background())
 	require.NoError(t, err)
 
 	_, err = afero.ReadFile(root, "test.ts")
@@ -427,7 +428,7 @@ func Test_GenerateWithOverlay(t *testing.T) { //nolint:paralleltest // Cannot ru
 			})
 			require.NoError(t, err)
 
-			schemaResult, err := schemaGen.Generate()
+			schemaResult, err := schemaGen.Generate(context.Background())
 			require.NoError(t, err)
 
 			// Write the schema to the expected location
@@ -457,7 +458,7 @@ func Test_GenerateWithOverlay(t *testing.T) { //nolint:paralleltest // Cannot ru
 			})
 			require.NoError(t, err)
 
-			_, err = gen.Generate()
+			_, err = gen.Generate(context.Background())
 			require.NoError(t, err)
 
 			content, err := afero.ReadFile(root, tc.overlayFileName)

--- a/pkg/tfgen/convert_cli_test.go
+++ b/pkg/tfgen/convert_cli_test.go
@@ -16,6 +16,7 @@ package tfgen
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -178,7 +179,7 @@ output "someOutput" {
 		})
 		assert.NoError(t, err)
 
-		_, err = g.Generate()
+		_, err = g.Generate(context.Background())
 		assert.NoError(t, err)
 
 		d, err := os.ReadFile(filepath.Join(tempdir, "schema.json"))
@@ -291,7 +292,7 @@ resource "azurerm_web_pubsub_custom_certificate" "test" {
 		})
 		require.NoError(t, err)
 
-		_, err = g.Generate()
+		_, err = g.Generate(context.Background())
 		require.NoError(t, err)
 	})
 
@@ -345,7 +346,7 @@ This is some intentionally broken HCL that should not convert.
 		})
 		require.NoError(t, err)
 
-		_, err = g.Generate()
+		_, err = g.Generate(context.Background())
 		require.NoError(t, err)
 
 		autogold.Expect("").Equal(t, stdout.String())
@@ -421,7 +422,7 @@ This is some intentionally broken HCL that should not convert.
 		})
 		require.NoError(t, err)
 
-		_, err = g.Generate()
+		_, err = g.Generate(context.Background())
 		require.NoError(t, err)
 
 		require.NotContains(t, stdout.String(), cliConverterErrUnexpectedHCLSnippet)
@@ -499,7 +500,7 @@ output "some_output" {
 				}),
 			})
 			require.NoError(t, err)
-			_, err = g.Generate()
+			_, err = g.Generate(context.Background())
 			require.NoError(t, err)
 			d, err := os.ReadFile(filepath.Join(dir, "schema.json"))
 			require.NoError(t, err)

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -17,6 +17,7 @@ package tfgen
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2486,7 +2487,7 @@ throw new Exception("!");
 	})
 	assert.NoError(t, err)
 
-	_, err = g.Generate()
+	_, err = g.Generate(context.Background())
 	assert.NoError(t, err)
 
 	f, err := inmem.Open("schema.json")

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1139,8 +1139,8 @@ func (g *Generator) generateSchemaResult(ctx context.Context) (*GenerateSchemaRe
 	}
 
 	// Convert the package to a Pulumi schema.
-	_, schemaSpan := tfgenTracer.Start(ctx, "genPulumiSchema")
-	pulumiPackageSpec, err := genPulumiSchema(pack, g.pkg, g.version, g.info, g.sink,
+	schemaCtx, schemaSpan := tfgenTracer.Start(ctx, "genPulumiSchema")
+	pulumiPackageSpec, err := genPulumiSchema(schemaCtx, pack, g.pkg, g.version, g.info, g.sink,
 		pschema.NewPluginLoader(g.pluginContext))
 	schemaSpan.End()
 	if err != nil {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -45,6 +45,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/spf13/afero"
+	"go.opentelemetry.io/otel"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tf2pulumi/il"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
@@ -1077,14 +1078,21 @@ type GenerateOptions struct {
 	ModuleFormat string
 }
 
+// tfgenTracer instruments schema generation so the phases of a GetSchema call —
+// gathering the Terraform package and converting it to a Pulumi schema — are
+// visible in traces.
+var tfgenTracer = otel.Tracer("pulumi-terraform-bridge/pkg/tfgen")
+
 // Generate creates Pulumi packages from the information it was initialized with.
-func (g *Generator) Generate() (*GenerateSchemaResult, error) {
+func (g *Generator) Generate(ctx context.Context) (*GenerateSchemaResult, error) {
 	if g.language == "schema" || g.language == "registry-docs" || g.language == "pulumi" {
-		genSchemaResult, err := g.generateSchemaResult(context.Background())
+		genSchemaResult, err := g.generateSchemaResult(ctx)
 		if err != nil {
 			return nil, err
 		}
 		// Now push the schema through the rest of the generator.
+		_, span := tfgenTracer.Start(ctx, "UnstableGenerateFromSchema")
+		defer span.End()
 		return g.UnstableGenerateFromSchema(genSchemaResult)
 	}
 	// Read the provider schema from file
@@ -1112,20 +1120,29 @@ func (g *Generator) Generate() (*GenerateSchemaResult, error) {
 }
 
 func (g *Generator) generateSchemaResult(ctx context.Context) (*GenerateSchemaResult, error) {
-	err := g.info.Validate(ctx)
+	ctx, span := tfgenTracer.Start(ctx, "generateSchemaResult")
+	defer span.End()
+
+	validateCtx, validateSpan := tfgenTracer.Start(ctx, "info.Validate")
+	err := g.info.Validate(validateCtx)
+	validateSpan.End()
 	if err != nil {
 		return nil, err
 	}
 	// First gather up the entire package contents. This structure is complete and sufficient to hand off to the
 	// language-specific generators to create the full output.
+	_, gatherSpan := tfgenTracer.Start(ctx, "gatherPackage")
 	pack, err := g.gatherPackage()
+	gatherSpan.End()
 	if err != nil {
 		return nil, pkgerrors.Wrapf(err, "failed to gather package metadata")
 	}
 
 	// Convert the package to a Pulumi schema.
+	_, schemaSpan := tfgenTracer.Start(ctx, "genPulumiSchema")
 	pulumiPackageSpec, err := genPulumiSchema(pack, g.pkg, g.version, g.info, g.sink,
 		pschema.NewPluginLoader(g.pluginContext))
+	schemaSpan.End()
 	if err != nil {
 		return nil, pkgerrors.Wrapf(err, "failed to create Pulumi schema")
 	}

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1078,9 +1078,6 @@ type GenerateOptions struct {
 	ModuleFormat string
 }
 
-// tfgenTracer instruments schema generation so the phases of a GetSchema call —
-// gathering the Terraform package and converting it to a Pulumi schema — are
-// visible in traces.
 var tfgenTracer = otel.Tracer("pulumi-terraform-bridge/pkg/tfgen")
 
 // Generate creates Pulumi packages from the information it was initialized with.

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl/v2"
@@ -39,6 +40,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -58,6 +60,12 @@ type schemaGenerator struct {
 	info     tfbridge.ProviderInfo
 	language Language
 	loader   pschema.Loader
+
+	// docCommentDur/docCommentN accumulate time spent rendering doc comments, so a
+	// trace can show whether documentation processing is a meaningful share of
+	// schema generation.
+	docCommentDur time.Duration
+	docCommentN   int
 }
 
 type schemaNestedType struct {
@@ -230,6 +238,7 @@ func rawMessage(v interface{}) pschema.RawMessage {
 }
 
 func genPulumiSchema(
+	ctx context.Context,
 	pack *pkg, name tokens.Package, version string, info tfbridge.ProviderInfo,
 	logSink diag.Sink, loader pschema.Loader,
 ) (pschema.PackageSpec, error) {
@@ -240,12 +249,11 @@ func genPulumiSchema(
 		language: pack.language,
 		loader:   loader,
 	}
-	pulumiPackageSpec, err := g.genPackageSpec(pack, logSink)
+	pulumiPackageSpec, err := g.genPackageSpec(ctx, pack, logSink)
 	if err != nil {
 		return pschema.PackageSpec{}, err
 	}
 
-	ctx := context.Background()
 	if len(info.MuxWith) > 0 {
 		md := info.GetMetadata()
 		muxSchemas := make([]pschema.PackageSpec, len(info.MuxWith)+1)
@@ -270,7 +278,12 @@ func genPulumiSchema(
 	return pulumiPackageSpec, nil
 }
 
-func (g *schemaGenerator) genPackageSpec(pack *pkg, sink diag.Sink) (pschema.PackageSpec, error) {
+func (g *schemaGenerator) genPackageSpec(ctx context.Context, pack *pkg, sink diag.Sink) (pschema.PackageSpec, error) {
+	_, span := tfgenTracer.Start(ctx, "genPackageSpec")
+	defer span.End()
+	var typesDur, resourcesDur, functionsDur, gatherNestedDur, bindDur time.Duration
+	var typesN, resourcesN, functionsN int
+
 	spec := pschema.PackageSpec{
 		Name:              g.pkg.String(),
 		Version:           g.version,
@@ -301,9 +314,15 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg, sink diag.Sink) (pschema.Pac
 	var config []*variable
 	for _, mod := range pack.modules.values() {
 		// Generate nested types.
-		for _, t := range gatherSchemaNestedTypesForModule(mod) {
+		gn0 := time.Now()
+		nestedTypes := gatherSchemaNestedTypesForModule(mod)
+		gatherNestedDur += time.Since(gn0)
+		for _, t := range nestedTypes {
 			tok := g.genObjectTypeToken(t)
+			t0 := time.Now()
 			ts := g.genObjectType(t, false)
+			typesDur += time.Since(t0)
+			typesN++
 			spec.Types[tok] = pschema.ComplexTypeSpec{
 				ObjectTypeSpec: ts,
 			}
@@ -313,15 +332,33 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg, sink diag.Sink) (pschema.Pac
 		for _, member := range mod.members {
 			switch t := member.(type) {
 			case *resourceType:
+				t0 := time.Now()
 				spec.Resources[string(t.info.Tok)] = g.genResourceType(mod.name, t)
+				resourcesDur += time.Since(t0)
+				resourcesN++
 			case *resourceFunc:
+				t0 := time.Now()
 				spec.Functions[string(t.info.Tok)] = g.genDatasourceFunc(mod.name, t)
+				functionsDur += time.Since(t0)
+				functionsN++
 			case *variable:
 				contract.Assertf(mod.config(), `mod.config()`)
 				config = append(config, t)
 			}
 		}
 	}
+
+	span.SetAttributes(
+		attribute.Int("resources.count", resourcesN),
+		attribute.Int64("resources.ms", resourcesDur.Milliseconds()),
+		attribute.Int("nestedTypes.count", typesN),
+		attribute.Int64("nestedTypes.ms", typesDur.Milliseconds()),
+		attribute.Int64("gatherNestedTypes.ms", gatherNestedDur.Milliseconds()),
+		attribute.Int("functions.count", functionsN),
+		attribute.Int64("functions.ms", functionsDur.Milliseconds()),
+		attribute.Int("docComment.count", g.docCommentN),
+		attribute.Int64("docComment.ms", g.docCommentDur.Milliseconds()),
+	)
 
 	if len(config) != 0 {
 		spec.Config = g.genConfig(config)
@@ -453,9 +490,12 @@ func (g *schemaGenerator) genPackageSpec(pack *pkg, sink diag.Sink) (pschema.Pac
 	if g.info.NoDanglingReferences {
 		allowDanglingReferences = false
 	}
+	bind0 := time.Now()
 	_, diags, err := pschema.BindSpec(spec, g.loader, pschema.ValidationOptions{
 		AllowDanglingReferences: allowDanglingReferences,
 	})
+	bindDur += time.Since(bind0)
+	span.SetAttributes(attribute.Int64("bindSpec.ms", bindDur.Milliseconds()))
 	if err != nil {
 		return pschema.PackageSpec{}, err
 	}
@@ -673,6 +713,8 @@ func getDefaultReadme(pulumiPackageName tokens.Package, tfProviderShortName stri
 }
 
 func (g *schemaGenerator) genDocComment(comment string) string {
+	t0 := time.Now()
+	defer func() { g.docCommentDur += time.Since(t0); g.docCommentN++ }()
 	buffer := &bytes.Buffer{}
 	lines := strings.Split(comment, "\n")
 	for i, docLine := range lines {

--- a/pkg/tfgen/generate_test.go
+++ b/pkg/tfgen/generate_test.go
@@ -15,6 +15,7 @@
 package tfgen
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -875,7 +876,7 @@ func TestExtraMappingError(t *testing.T) {
 			require.NoError(t, err)
 
 			// Generate schema
-			_, err = g.Generate()
+			_, err = g.Generate(context.Background())
 
 			if tc.expectError {
 				require.Error(t, err)

--- a/pkg/tfgen/main.go
+++ b/pkg/tfgen/main.go
@@ -15,6 +15,7 @@
 package tfgen
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -49,7 +50,7 @@ func Main(pkg string, version string, prov tfbridge.ProviderInfo) {
 		}
 
 		// Let's generate some code!
-		_, err = g.Generate()
+		_, err = g.Generate(context.Background())
 		return err
 	})
 }


### PR DESCRIPTION
I'm trying to reduce the time it takes to generate dynamic schemas, so I'm adding OTEL traces.