### PR TITLE
Skip redundant schema validation during schema generation

### DIFF
--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -180,6 +180,10 @@ type Provider struct {
 	DisableRequiredWithDefaultTurningOptional bool
 
 	// Check generated schema for dangling references. Newer providers should opt into this.
+	//
+	// This is not consistently enforced. Providers authors should prefer to run:
+	//
+	//	pulumi schema check ./bin/pulumi-resource-<your-provider> --allow-dangling-references=false
 	NoDanglingReferences bool
 
 	// SkipDefaultFixups temporarily disables the default bridge fixup pass that

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1137,8 +1137,7 @@ func (g *Generator) generateSchemaResult(ctx context.Context) (*GenerateSchemaRe
 
 	// Convert the package to a Pulumi schema.
 	schemaCtx, schemaSpan := tfgenTracer.Start(ctx, "genPulumiSchema")
-	pulumiPackageSpec, err := genPulumiSchema(schemaCtx, pack, g.pkg, g.version, g.info, g.sink,
-		pschema.NewPluginLoader(g.pluginContext))
+	pulumiPackageSpec, err := genPulumiSchema(schemaCtx, pack, g.pkg, g.version, g.info)
 	schemaSpan.End()
 	if err != nil {
 		return nil, pkgerrors.Wrapf(err, "failed to create Pulumi schema")

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1224,13 +1224,9 @@ func (g *Generator) UnstableGenerateFromSchema(genSchemaResult *GenerateSchemaRe
 			files[path] = code
 		}
 	default:
-		allowDanglingRefernces := true
-		if g.info.NoDanglingReferences {
-			allowDanglingRefernces = false
-		}
 		pulumiPackage, diags, err := pschema.BindSpec(
 			pulumiPackageSpec, pschema.NewPluginLoader(g.pluginContext), pschema.ValidationOptions{
-				AllowDanglingReferences: allowDanglingRefernces,
+				AllowDanglingReferences: !g.info.NoDanglingReferences,
 			},
 		)
 		if err != nil {

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/inflector"
 	csgen "github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
@@ -37,7 +36,6 @@ import (
 	tsgen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
 	pygen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"go.opentelemetry.io/otel/attribute"
@@ -59,7 +57,6 @@ type schemaGenerator struct {
 	version  string
 	info     tfbridge.ProviderInfo
 	language Language
-	loader   pschema.Loader
 
 	// docCommentDur/docCommentN accumulate time spent rendering doc comments, so a
 	// trace can show whether documentation processing is a meaningful share of
@@ -240,16 +237,14 @@ func rawMessage(v interface{}) pschema.RawMessage {
 func genPulumiSchema(
 	ctx context.Context,
 	pack *pkg, name tokens.Package, version string, info tfbridge.ProviderInfo,
-	logSink diag.Sink, loader pschema.Loader,
 ) (pschema.PackageSpec, error) {
 	g := &schemaGenerator{
 		pkg:      name,
 		version:  version,
 		info:     info,
 		language: pack.language,
-		loader:   loader,
 	}
-	pulumiPackageSpec, err := g.genPackageSpec(ctx, pack, logSink)
+	pulumiPackageSpec, err := g.genPackageSpec(ctx, pack)
 	if err != nil {
 		return pschema.PackageSpec{}, err
 	}
@@ -278,10 +273,10 @@ func genPulumiSchema(
 	return pulumiPackageSpec, nil
 }
 
-func (g *schemaGenerator) genPackageSpec(ctx context.Context, pack *pkg, sink diag.Sink) (pschema.PackageSpec, error) {
+func (g *schemaGenerator) genPackageSpec(ctx context.Context, pack *pkg) (pschema.PackageSpec, error) {
 	_, span := tfgenTracer.Start(ctx, "genPackageSpec")
 	defer span.End()
-	var typesDur, resourcesDur, functionsDur, gatherNestedDur, bindDur time.Duration
+	var typesDur, resourcesDur, functionsDur, gatherNestedDur time.Duration
 	var typesN, resourcesN, functionsN int
 
 	spec := pschema.PackageSpec{
@@ -484,90 +479,7 @@ func (g *schemaGenerator) genPackageSpec(ctx context.Context, pack *pkg, sink di
 		spec.Language["java"] = javaLanguageExtensions(&g.info)
 	}
 
-	// Validate the schema.
-
-	allowDanglingReferences := true
-	if g.info.NoDanglingReferences {
-		allowDanglingReferences = false
-	}
-	bind0 := time.Now()
-	_, diags, err := pschema.BindSpec(spec, g.loader, pschema.ValidationOptions{
-		AllowDanglingReferences: allowDanglingReferences,
-	})
-	bindDur += time.Since(bind0)
-	span.SetAttributes(attribute.Int64("bindSpec.ms", bindDur.Milliseconds()))
-	if err != nil {
-		return pschema.PackageSpec{}, err
-	}
-
-	sinkHclDiagnostics(sink, diags)
-
-	if diags.HasErrors() {
-		return pschema.PackageSpec{}, diags
-	}
-
 	return spec, nil
-}
-
-// sinkHclDiagnostics takes a diagnostic sink and writes the diagnostics to it.
-//
-// sinkHclDiagnostics should be called at the end of the diagnostic generation process,
-// with the full list of diagnostics to display. It handles throttling the number of
-// diagnostics displayed to the user so they are not overwhelmed by giant page of
-// diagnostics.
-func sinkHclDiagnostics(sink diag.Sink, diags hcl.Diagnostics) {
-	diagsToDisplay := 6         // The total number of diagnostics to show.
-	var undisplayedErrors int   // The number of errors that were elided.
-	var undisplayedWarnings int // The number of warnings that were elided.
-
-	// log is used to actually write the diagnostic to the sink, or elided it if the
-	// sink has overflown.
-	log := func(sev diag.Severity, d *hcl.Diagnostic) {
-		msg := d.Summary
-		if d.Detail != "" {
-			msg += ": " + d.Detail
-		}
-
-		if diagsToDisplay <= 0 {
-			switch sev {
-			case diag.Error:
-				undisplayedErrors++
-			case diag.Warning:
-				undisplayedWarnings++
-			default:
-				panic("impossible")
-			}
-			return
-		}
-
-		diagsToDisplay--
-		sink.Logf(sev, &diag.Diag{Message: msg})
-	}
-
-	// Iterate the diagnostics and write them. We prioritize errors over warnings.
-
-	for _, d := range diags {
-		if d.Severity == hcl.DiagError {
-			log(diag.Error, d)
-		}
-	}
-
-	for _, d := range diags {
-		if d.Severity == hcl.DiagWarning {
-			log(diag.Warning, d)
-		}
-	}
-
-	// If we have failed to display any number of messages, write a message of the
-	// appropriate type indicating that there is more to display.
-
-	if undisplayedErrors > 0 {
-		sink.Errorf(&diag.Diag{Message: "%d additional errors"}, undisplayedErrors)
-	}
-
-	if undisplayedWarnings > 0 {
-		sink.Warningf(&diag.Diag{Message: "%d additional warnings"}, undisplayedWarnings)
-	}
 }
 
 func javaLanguageExtensions(providerInfo *tfbridge.ProviderInfo) pschema.RawMessage {

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -17,14 +17,12 @@ package tfgen
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"runtime"
 	"sort"
 	"testing"
 	"text/template"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hexops/autogold/v2"
 	csgen "github.com/pulumi/pulumi-dotnet/pulumi-language-dotnet/v3/codegen"
@@ -772,155 +770,4 @@ func Test_DynamicAttributeHandling(t *testing.T) {
 		assert.NotNil(t, result, "Result should not be nil")
 		assert.Empty(t, result, "Dynamic attributes should not generate nested types")
 	})
-}
-
-func TestSinkHclDiagnostics(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		input    hcl.Diagnostics
-		expected autogold.Value
-	}{
-		{
-			name:     "No diagnostics",
-			input:    hcl.Diagnostics{},
-			expected: autogold.Expect(captureDiagSink{}),
-		},
-		{
-			name: "Only errors, fewer than the threshold",
-			input: hcl.Diagnostics{
-				{Severity: hcl.DiagError, Summary: "Error 1", Detail: "Detail 1"},
-				{Severity: hcl.DiagError, Summary: "Error 2", Detail: "Detail 2"},
-			},
-			expected: autogold.Expect(captureDiagSink{
-				{Diag: &diag.Diag{Message: "Error 1: Detail 1"}, Sev: diag.Error},
-				{Diag: &diag.Diag{Message: "Error 2: Detail 2"}, Sev: diag.Error},
-			}),
-		},
-		{
-			name: "Only errors, more than the threshold",
-			input: hcl.Diagnostics{
-				{Severity: hcl.DiagError, Summary: "Error 1", Detail: "Detail 1"},
-				{Severity: hcl.DiagError, Summary: "Error 2", Detail: "Detail 2"},
-				{Severity: hcl.DiagError, Summary: "Error 3", Detail: "Detail 3"},
-				{Severity: hcl.DiagError, Summary: "Error 4", Detail: "Detail 4"},
-				{Severity: hcl.DiagError, Summary: "Error 5", Detail: "Detail 5"},
-				{Severity: hcl.DiagError, Summary: "Error 6", Detail: "Detail 6"},
-				{Severity: hcl.DiagError, Summary: "Error 7", Detail: "Detail 7"},
-			},
-			expected: autogold.Expect(captureDiagSink{
-				{Diag: &diag.Diag{Message: "Error 1: Detail 1"}, Sev: diag.Error},
-				{Diag: &diag.Diag{Message: "Error 2: Detail 2"}, Sev: diag.Error},
-				{Diag: &diag.Diag{Message: "Error 3: Detail 3"}, Sev: diag.Error},
-				{Diag: &diag.Diag{Message: "Error 4: Detail 4"}, Sev: diag.Error},
-				{Diag: &diag.Diag{Message: "Error 5: Detail 5"}, Sev: diag.Error},
-				{Diag: &diag.Diag{Message: "Error 6: Detail 6"}, Sev: diag.Error},
-				{Diag: &diag.Diag{Message: "1 additional errors"}, Sev: diag.Error},
-			}),
-		},
-		{
-			name: "Only warnings, fewer than the threshold",
-			input: hcl.Diagnostics{
-				{Severity: hcl.DiagWarning, Summary: "Warning 1", Detail: "Detail 1"},
-				{Severity: hcl.DiagWarning, Summary: "Warning 2", Detail: "Detail 2"},
-			},
-			expected: autogold.Expect(captureDiagSink{
-				{Diag: &diag.Diag{Message: "Warning 1: Detail 1"}, Sev: diag.Warning},
-				{Diag: &diag.Diag{Message: "Warning 2: Detail 2"}, Sev: diag.Warning},
-			}),
-		},
-		{
-			name: "Only warnings, more than the threshold",
-			input: hcl.Diagnostics{
-				{Severity: hcl.DiagWarning, Summary: "Warning 1", Detail: "Detail 1"},
-				{Severity: hcl.DiagWarning, Summary: "Warning 2", Detail: "Detail 2"},
-				{Severity: hcl.DiagWarning, Summary: "Warning 3", Detail: "Detail 3"},
-				{Severity: hcl.DiagWarning, Summary: "Warning 4", Detail: "Detail 4"},
-				{Severity: hcl.DiagWarning, Summary: "Warning 5", Detail: "Detail 5"},
-				{Severity: hcl.DiagWarning, Summary: "Warning 6", Detail: "Detail 6"},
-				{Severity: hcl.DiagWarning, Summary: "Warning 7", Detail: "Detail 7"},
-			},
-			expected: autogold.Expect(captureDiagSink{
-				{Diag: &diag.Diag{Message: "Warning 1: Detail 1"}, Sev: diag.Warning},
-				{Diag: &diag.Diag{Message: "Warning 2: Detail 2"}, Sev: diag.Warning},
-				{Diag: &diag.Diag{Message: "Warning 3: Detail 3"}, Sev: diag.Warning},
-				{Diag: &diag.Diag{Message: "Warning 4: Detail 4"}, Sev: diag.Warning},
-				{Diag: &diag.Diag{Message: "Warning 5: Detail 5"}, Sev: diag.Warning},
-				{Diag: &diag.Diag{Message: "Warning 6: Detail 6"}, Sev: diag.Warning},
-				{Diag: &diag.Diag{Message: "1 additional warnings"}, Sev: diag.Warning},
-			}),
-		},
-		{
-			name: "Mix of errors and warnings, fewer than the threshold",
-			input: hcl.Diagnostics{
-				{Severity: hcl.DiagError, Summary: "Error 1", Detail: "Detail 1"},
-				{Severity: hcl.DiagError, Summary: "Error 2", Detail: "Detail 2"},
-				{Severity: hcl.DiagWarning, Summary: "Warning 1", Detail: "Detail 1"},
-				{Severity: hcl.DiagWarning, Summary: "Warning 2", Detail: "Detail 2"},
-			},
-			expected: autogold.Expect(captureDiagSink{
-				{Diag: &diag.Diag{Message: "Error 1: Detail 1"}, Sev: diag.Error},
-				{Diag: &diag.Diag{Message: "Error 2: Detail 2"}, Sev: diag.Error},
-				{Diag: &diag.Diag{Message: "Warning 1: Detail 1"}, Sev: diag.Warning},
-				{Diag: &diag.Diag{Message: "Warning 2: Detail 2"}, Sev: diag.Warning},
-			}),
-		},
-		{
-			name: "Mix of errors and warnings, exceeding the threshold",
-			input: hcl.Diagnostics{
-				{Severity: hcl.DiagError, Summary: "Error 1", Detail: "Detail 1"},
-				{Severity: hcl.DiagError, Summary: "Error 2", Detail: "Detail 2"},
-				{Severity: hcl.DiagError, Summary: "Error 3", Detail: "Detail 3"},
-				{Severity: hcl.DiagError, Summary: "Error 4", Detail: "Detail 4"},
-				{Severity: hcl.DiagWarning, Summary: "Warning 1", Detail: "Detail 1"},
-				{Severity: hcl.DiagWarning, Summary: "Warning 2", Detail: "Detail 2"},
-				{Severity: hcl.DiagWarning, Summary: "Warning 3", Detail: "Detail 3"},
-				{Severity: hcl.DiagWarning, Summary: "Warning 4", Detail: "Detail 4"},
-			},
-			expected: autogold.Expect(captureDiagSink{
-				{Diag: &diag.Diag{Message: "Error 1: Detail 1"}, Sev: diag.Error},
-				{Diag: &diag.Diag{Message: "Error 2: Detail 2"}, Sev: diag.Error},
-				{Diag: &diag.Diag{Message: "Error 3: Detail 3"}, Sev: diag.Error},
-				{Diag: &diag.Diag{Message: "Error 4: Detail 4"}, Sev: diag.Error},
-				{Diag: &diag.Diag{Message: "Warning 1: Detail 1"}, Sev: diag.Warning},
-				{Diag: &diag.Diag{Message: "Warning 2: Detail 2"}, Sev: diag.Warning},
-				{Diag: &diag.Diag{Message: "2 additional warnings"}, Sev: diag.Warning},
-			}),
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			var actual captureDiagSink
-			sinkHclDiagnostics(&actual, tt.input)
-			tt.expected.Equal(t, actual)
-		})
-	}
-}
-
-type captureDiagSink []capturedDiag
-
-type capturedDiag struct {
-	*diag.Diag
-	Sev diag.Severity
-}
-
-var _ diag.Sink = &captureDiagSink{}
-
-func (c *captureDiagSink) Debugf(d *diag.Diag, a ...any)   { c.Logf(diag.Debug, d, a...) }
-func (c *captureDiagSink) Errorf(d *diag.Diag, a ...any)   { c.Logf(diag.Error, d, a...) }
-func (c *captureDiagSink) Infoerrf(d *diag.Diag, a ...any) { c.Logf(diag.Infoerr, d, a...) }
-func (c *captureDiagSink) Infof(d *diag.Diag, a ...any)    { c.Logf(diag.Info, d, a...) }
-func (c *captureDiagSink) Warningf(d *diag.Diag, a ...any) { c.Logf(diag.Warning, d, a...) }
-
-func (c *captureDiagSink) Logf(s diag.Severity, d *diag.Diag, a ...any) {
-	d.Message = fmt.Sprintf(d.Message, a...)
-	*c = append(*c, capturedDiag{d, s})
-}
-
-func (c *captureDiagSink) Stringify(diag.Severity, *diag.Diag, ...any) (string, string) {
-	panic("unimplemented")
 }


### PR DESCRIPTION
`genPackageSpec` bound the generated schema purely to validate it and then discarded the bound package. That `BindSpec` call can dominate `pulumi package add` on large providers. For dynamic AWS, it takes roughly 8.7s. The bridge should generate valid schemas, and that should be enforced with tests, not extremely expensive runtime checks.

The SDK-emission path in `GenerateFromSchema` still binds and validates the spec before emitting, so dropping the check here only affects the schema-only path, which marshals the spec directly. This removes the `BindSpec` call along with the loader field and diagnostic-sink plumbing that existed solely to support it.

This does weaken `NoDanglingReferences`, limiting it to cases where we already pay the expensive binding cost: language specific SDK generation. If authors want the surety back, they should do the check out of the hot path via `pulumi schema check ./bin/pulumi-resource-<your-provider>`.