### PR TITLE
defer expensive operations until they are needed

### DIFF
--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -98,8 +98,7 @@ type Provider struct {
 	dataSources      map[tokens.ModuleMember]DataSource // a map of Pulumi module tokens to data sources.
 	supportsSecrets  bool                               // true if the engine supports secret property values
 	pulumiSchema     []byte                             // the JSON-encoded Pulumi schema.
-	pulumiSchemaSpec *pschema.PackageSpec
-	pulumiSchemaOnce sync.Once // guards lazy decoding of pulumiSchema into pulumiSchemaSpec.
+	pulumiSchemaSpec func() *pschema.PackageSpec        // lazily decodes pulumiSchema exactly once.
 	memStats         memStatCollector
 	hasTypeErrors    map[resource.URN]struct{}
 	providerOpts     []providerOption
@@ -285,6 +284,9 @@ func newProvider(ctx context.Context, host *provider.HostClient,
 		providerOpts:  opts,
 	}
 	ctx = p.loggingContext(ctx, "")
+	p.pulumiSchemaSpec = sync.OnceValue(func() *pschema.PackageSpec {
+		return decodePulumiSchema(ctx, pulumiSchema)
+	})
 	p.initResourceMaps()
 	return providerserver.NewPanicRecoveringProviderServer(&providerserver.PanicRecoveringProviderServerOptions{
 		Logger:                 host,
@@ -294,23 +296,28 @@ func newProvider(ctx context.Context, host *provider.HostClient,
 	})
 }
 
-// schemaSpec lazily decodes the JSON-encoded Pulumi schema into a PackageSpec. Decoding is deferred
-// until the schema is actually needed (config/input type checking) because for large providers the
-// unmarshal is expensive and would otherwise run unconditionally on every startup. Returns nil if no
-// schema was provided or if it fails to decode.
-func (p *Provider) schemaSpec(ctx context.Context) *pschema.PackageSpec {
-	p.pulumiSchemaOnce.Do(func() {
-		if p.pulumiSchemaSpec != nil || len(p.pulumiSchema) == 0 {
-			return
-		}
-		var schema pschema.PackageSpec
-		if err := json.Unmarshal(p.pulumiSchema, &schema); err != nil {
-			GetLogger(ctx).Debug(fmt.Sprintf("unable to unmarshal pulumi package spec: %s", err.Error()))
-			return
-		}
-		p.pulumiSchemaSpec = &schema
-	})
-	return p.pulumiSchemaSpec
+// decodePulumiSchema decodes the JSON-encoded Pulumi schema into a PackageSpec. Returns nil if no
+// schema was provided or if it fails to decode; callers treat a nil spec as "skip type checking",
+// so a malformed schema degrades type checking instead of failing the provider.
+func decodePulumiSchema(ctx context.Context, pulumiSchema []byte) *pschema.PackageSpec {
+	if len(pulumiSchema) == 0 {
+		return nil
+	}
+	var schema pschema.PackageSpec
+	if err := json.Unmarshal(pulumiSchema, &schema); err != nil {
+		GetLogger(ctx).Debug(fmt.Sprintf("unable to unmarshal pulumi package spec: %s", err.Error()))
+		return nil
+	}
+	return &schema
+}
+
+// schemaSpec returns the decoded Pulumi schema, decoding it on first use. Returns nil if no schema
+// was provided or if it fails to decode.
+func (p *Provider) schemaSpec() *pschema.PackageSpec {
+	if p.pulumiSchemaSpec == nil {
+		return nil
+	}
+	return p.pulumiSchemaSpec()
 }
 
 func newMuxWithProvider(ctx context.Context, host *provider.HostClient,
@@ -614,9 +621,9 @@ func (p *Provider) typeCheckConfig(
 
 	// If we don't have a schema, then we don't attempt to type check the config at
 	// all.
-	schemaSpec := p.schemaSpec(ctx)
+	schemaSpec := p.schemaSpec()
 	if schemaSpec == nil {
-		logger.Debug("p.pulumiSchemaSpec == nil, skipping type checking config")
+		logger.Debug("p.schemaSpec() == nil, skipping type checking config")
 		return nil
 	}
 
@@ -991,7 +998,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	validateShouldError := cmdutil.IsTruthy(os.Getenv("PULUMI_ERROR_TYPE_CHECKER"))
 	schemaMap, schemaInfos := res.TF.Schema(), res.Schema.GetFields()
 	if p.pulumiSchema != nil {
-		schema := p.schemaSpec(ctx)
+		schema := p.schemaSpec()
 		if schema != nil {
 			typeFailures := typechecker.New(*schema, false).ValidateInputs(t, news)
 			if len(typeFailures) > 0 {

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -298,15 +298,14 @@ func newProvider(ctx context.Context, host *provider.HostClient,
 // until the schema is actually needed (config/input type checking) because for large providers the
 // unmarshal is expensive and would otherwise run unconditionally on every startup. Returns nil if no
 // schema was provided or if it fails to decode.
-func (p *Provider) schemaSpec() *pschema.PackageSpec {
+func (p *Provider) schemaSpec(ctx context.Context) *pschema.PackageSpec {
 	p.pulumiSchemaOnce.Do(func() {
-		if len(p.pulumiSchema) == 0 {
+		if p.pulumiSchemaSpec != nil || len(p.pulumiSchema) == 0 {
 			return
 		}
 		var schema pschema.PackageSpec
 		if err := json.Unmarshal(p.pulumiSchema, &schema); err != nil {
-			GetLogger(context.Background()).Debug(
-				fmt.Sprintf("unable to unmarshal pulumi package spec: %s", err.Error()))
+			GetLogger(ctx).Debug(fmt.Sprintf("unable to unmarshal pulumi package spec: %s", err.Error()))
 			return
 		}
 		p.pulumiSchemaSpec = &schema
@@ -615,7 +614,7 @@ func (p *Provider) typeCheckConfig(
 
 	// If we don't have a schema, then we don't attempt to type check the config at
 	// all.
-	schemaSpec := p.schemaSpec()
+	schemaSpec := p.schemaSpec(ctx)
 	if schemaSpec == nil {
 		logger.Debug("p.pulumiSchemaSpec == nil, skipping type checking config")
 		return nil
@@ -992,7 +991,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	validateShouldError := cmdutil.IsTruthy(os.Getenv("PULUMI_ERROR_TYPE_CHECKER"))
 	schemaMap, schemaInfos := res.TF.Schema(), res.Schema.GetFields()
 	if p.pulumiSchema != nil {
-		schema := p.schemaSpec()
+		schema := p.schemaSpec(ctx)
 		if schema != nil {
 			typeFailures := typechecker.New(*schema, false).ValidateInputs(t, news)
 			if len(typeFailures) > 0 {

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -98,6 +99,7 @@ type Provider struct {
 	supportsSecrets  bool                               // true if the engine supports secret property values
 	pulumiSchema     []byte                             // the JSON-encoded Pulumi schema.
 	pulumiSchemaSpec *pschema.PackageSpec
+	pulumiSchemaOnce sync.Once // guards lazy decoding of pulumiSchema into pulumiSchemaSpec.
 	memStats         memStatCollector
 	hasTypeErrors    map[resource.URN]struct{}
 	providerOpts     []providerOption
@@ -284,19 +286,32 @@ func newProvider(ctx context.Context, host *provider.HostClient,
 	}
 	ctx = p.loggingContext(ctx, "")
 	p.initResourceMaps()
-	if pulumiSchema != nil || len(pulumiSchema) != 0 {
-		var schema pschema.PackageSpec
-		if err := json.Unmarshal(pulumiSchema, &schema); err != nil {
-			GetLogger(ctx).Debug(fmt.Sprintf("unable to unmarshal pulumi package spec: %s", err.Error()))
-		}
-		p.pulumiSchemaSpec = &schema
-	}
 	return providerserver.NewPanicRecoveringProviderServer(&providerserver.PanicRecoveringProviderServerOptions{
 		Logger:                 host,
 		ResourceProviderServer: p,
 		ProviderName:           module,
 		ProviderVersion:        version,
 	})
+}
+
+// schemaSpec lazily decodes the JSON-encoded Pulumi schema into a PackageSpec. Decoding is deferred
+// until the schema is actually needed (config/input type checking) because for large providers the
+// unmarshal is expensive and would otherwise run unconditionally on every startup. Returns nil if no
+// schema was provided or if it fails to decode.
+func (p *Provider) schemaSpec() *pschema.PackageSpec {
+	p.pulumiSchemaOnce.Do(func() {
+		if len(p.pulumiSchema) == 0 {
+			return
+		}
+		var schema pschema.PackageSpec
+		if err := json.Unmarshal(p.pulumiSchema, &schema); err != nil {
+			GetLogger(context.Background()).Debug(
+				fmt.Sprintf("unable to unmarshal pulumi package spec: %s", err.Error()))
+			return
+		}
+		p.pulumiSchemaSpec = &schema
+	})
+	return p.pulumiSchemaSpec
 }
 
 func newMuxWithProvider(ctx context.Context, host *provider.HostClient,
@@ -600,12 +615,13 @@ func (p *Provider) typeCheckConfig(
 
 	// If we don't have a schema, then we don't attempt to type check the config at
 	// all.
-	if p.pulumiSchemaSpec == nil {
+	schemaSpec := p.schemaSpec()
+	if schemaSpec == nil {
 		logger.Debug("p.pulumiSchemaSpec == nil, skipping type checking config")
 		return nil
 	}
 
-	typeFailures := typechecker.New(*p.pulumiSchemaSpec, true).ValidateConfig(news)
+	typeFailures := typechecker.New(*schemaSpec, true).ValidateConfig(news)
 	if validateShouldError {
 		return p.convertTypeFailures(urn, typeFailures)
 	}
@@ -976,7 +992,7 @@ func (p *Provider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (*pul
 	validateShouldError := cmdutil.IsTruthy(os.Getenv("PULUMI_ERROR_TYPE_CHECKER"))
 	schemaMap, schemaInfos := res.TF.Schema(), res.Schema.GetFields()
 	if p.pulumiSchema != nil {
-		schema := p.pulumiSchemaSpec
+		schema := p.schemaSpec()
 		if schema != nil {
 			typeFailures := typechecker.New(*schema, false).ValidateInputs(t, news)
 			if len(typeFailures) > 0 {

--- a/pkg/tfbridge/provider_test.go
+++ b/pkg/tfbridge/provider_test.go
@@ -1468,7 +1468,7 @@ func TestCheckWarnings(t *testing.T) {
 		module:           "testprov",
 		config:           shimv2.NewSchemaMap(p.Schema),
 		pulumiSchema:     []byte("hello"), // we only check whether this is nil in type checking
-		pulumiSchemaSpec: pulumiSchemaSpec,
+		pulumiSchemaSpec: func() *pschema.PackageSpec { return pulumiSchemaSpec },
 		hasTypeErrors:    make(map[resource.URN]struct{}),
 		resources: map[tokens.Type]Resource{
 			"ExampleResource": {

--- a/pkg/tfshim/sdk-v2/provider2.go
+++ b/pkg/tfshim/sdk-v2/provider2.go
@@ -437,14 +437,13 @@ func (p v2Provider) NewDestroyDiff(
 }
 
 func (p *v2Provider) Importer(t string) shim.ImportFunc {
-	res := p.tf.ResourcesMap[t]
-	ty := res.CoreConfigSchema().ImpliedType()
 	return shim.ImportFunc(func(tt, id string, _ interface{}) ([]shim.InstanceState, error) {
 		// Note: why are we dropping meta (3rd parameter)? Apparently this refers to
 		// provider-level meta and calling ImportResourceState can already locate it in the
 		// provider object, so it is redundant.
 		ctx := context.TODO() // We should probably preserve Context here from the caller.
 		contract.Assertf(tt == t, "Expected Import to be called with %q, got %q", t, tt)
+		ty := p.tf.ResourcesMap[t].CoreConfigSchema().ImpliedType()
 		states, err := p.server.ImportResourceState(ctx, t, ty, id)
 		if err != nil {
 			return nil, nil


### PR DESCRIPTION
Currently providers using tfbridge can take a long time to start up. For example `pulumi-aws` takes 1.7 seconds to start up.

There are two expensive operations that can easily be deferred until they are needed.  Namely decoding the pulumi schema, and loading the resources map when creating the importer.

Both of these can be deferred until later, so e.g. just retrieving the schema, which we do in `pulumi do <resource> --help` doesn't need to wait for these expensive operations to finish.  These changes combined reduce the startup time of the `pulumi-aws` by ~1 second, which given `pulumi do <package> --help>` takes 2.5 seconds right now is significant.