### PR TITLE
use latest version of golangci-lint-action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -254,7 +254,7 @@ jobs:
           cache-dependency-path: |
             **/go.sum
       - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           skip-cache: true
           version: v2.5.0


### PR DESCRIPTION
The v8 version of this action uses node@20, which no longer works in GHA.  Use v9 instead, to get CI green again.