### PR TITLE
Add provider-defined functions to the shim, info, and token layers

### DIFF
--- a/pkg/pf/internal/muxer/muxer.go
+++ b/pkg/pf/internal/muxer/muxer.go
@@ -17,6 +17,7 @@ package muxer
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -40,13 +41,19 @@ func SchemaOnlyPluginFrameworkProvider(ctx context.Context, provider provider.Pr
 //
 // If there is overlap between shim and pf, shim will dominate.
 func AugmentShimWithPF(ctx context.Context, shim shim.Provider, pf provider.Provider) *ProviderShim {
-	p, _, _ := augmentShimWithPF(ctx, shim, pf)
+	p, _, _, functions := augmentShimWithPF(ctx, shim, pf)
+	// Unlike resources and data sources, conflicting provider function names cannot be
+	// resolved by letting one provider dominate: Terraform function names are global to
+	// a provider, so a collision is always a configuration error.
+	if len(functions) > 0 {
+		contract.Failf("Provider functions are not disjoint: conflicting names: %s", strings.Join(functions, ", "))
+	}
 	return p
 }
 
 func augmentShimWithPF(
 	ctx context.Context, shim shim.Provider, pf provider.Provider,
-) (*ProviderShim, []string, []string) {
+) (*ProviderShim, []string, []string, []string) {
 	var p ProviderShim
 	if alreadyMerged, ok := shim.(*ProviderShim); ok {
 		p = *alreadyMerged
@@ -54,30 +61,30 @@ func augmentShimWithPF(
 		p = newProviderShim(shim)
 	}
 
-	r, d := p.extend(schemashim.ShimSchemaOnlyProvider(ctx, pf))
-	return &p, r, d
+	r, d, f := p.extend(schemashim.ShimSchemaOnlyProvider(ctx, pf))
+	return &p, r, d, f
 }
 
 // AugmentShimWithDisjointPF augments an existing shim with a PF provider.Provider.
 //
 // This function asserts that there is no overlap between providers.
 func AugmentShimWithDisjointPF(ctx context.Context, shim shim.Provider, pf provider.Provider) *ProviderShim {
-	p, resources, datasources := augmentShimWithPF(ctx, shim, pf)
+	p, resources, datasources, functions := augmentShimWithPF(ctx, shim, pf)
 
-	var rErr, dErr error
-	if len(datasources) > 0 {
-		dErr = fmt.Errorf("DataSourceMap is not disjoint: conflicting keys: %s", strings.Join(datasources, ", "))
-	}
+	var errs []string
 	if len(resources) > 0 {
-		rErr = fmt.Errorf("ResourcesMap is not disjoint: conflicting keys: %s", strings.Join(resources, ", "))
+		errs = append(errs,
+			fmt.Sprintf("ResourcesMap is not disjoint: conflicting keys: %s", strings.Join(resources, ", ")))
 	}
-	switch {
-	case dErr != nil && rErr != nil:
-		contract.Failf("Providers are not disjoint:\n- %s\n- %s", rErr.Error(), dErr.Error())
-	case rErr != nil:
-		contract.Failf("Resources are not disjoint: %s", rErr.Error())
-	case dErr != nil:
-		contract.Failf("Datasources are not disjoint: %s", dErr.Error())
+	if len(datasources) > 0 {
+		errs = append(errs,
+			fmt.Sprintf("DataSourceMap is not disjoint: conflicting keys: %s", strings.Join(datasources, ", ")))
+	}
+	if len(functions) > 0 {
+		errs = append(errs, fmt.Sprintf("Functions are not disjoint: conflicting names: %s", strings.Join(functions, ", ")))
+	}
+	if len(errs) > 0 {
+		contract.Failf("Providers are not disjoint:\n- %s", strings.Join(errs, "\n- "))
 	}
 
 	return p
@@ -143,17 +150,40 @@ func (m *ProviderShim) DataSourceIsPF(token string) bool {
 // Extend the `ProviderShim` with another `shim.Provider`.
 //
 // `provider` will be the `len(m.MuxedProviders)` when mappings are computed.
-func (m *ProviderShim) extend(provider shim.Provider) ([]string, []string) {
+func (m *ProviderShim) extend(provider shim.Provider) ([]string, []string, []string) {
 	res := newUnionMap(m.resources, provider.ResourcesMap())
 	conflictingResources := res.ConflictingKeys()
 	data := newUnionMap(m.dataSources, provider.DataSourcesMap())
 	conflictingDataSources := data.ConflictingKeys()
 	listResources := newUnionMap(m.listResources, listResourcesMap(provider))
+	functions, conflictingFunctions := unionFunctions(m.functions, provider.Functions())
 	m.resources = res
 	m.dataSources = data
 	m.listResources = listResources
+	m.functions = functions
 	m.MuxedProviders = append(m.MuxedProviders, provider)
-	return conflictingResources, conflictingDataSources
+	return conflictingResources, conflictingDataSources, conflictingFunctions
+}
+
+// Union two function maps, preferring baseline on conflict.
+func unionFunctions(baseline, extension map[string]shim.Function) (map[string]shim.Function, []string) {
+	if len(extension) == 0 {
+		return baseline, nil
+	}
+	union := make(map[string]shim.Function, len(baseline)+len(extension))
+	for name, fn := range baseline {
+		union[name] = fn
+	}
+	var conflicts []string
+	for name, fn := range extension {
+		if _, ok := union[name]; ok {
+			conflicts = append(conflicts, name)
+			continue
+		}
+		union[name] = fn
+	}
+	sort.Strings(conflicts)
+	return union, conflicts
 }
 
 func newProviderShim(provider shim.Provider) ProviderShim {
@@ -163,6 +193,7 @@ func newProviderShim(provider shim.Provider) ProviderShim {
 			resources:     provider.ResourcesMap(),
 			dataSources:   provider.DataSourcesMap(),
 			listResources: listResourcesMap(provider),
+			functions:     provider.Functions(),
 		},
 		MuxedProviders: []shim.Provider{provider},
 	}
@@ -183,6 +214,9 @@ func (m *ProviderShim) ResolveDispatch(info *tfbridge.ProviderInfo) (muxer.Dispa
 		func(p shim.Provider) shim.ResourceMap { return p.ResourcesMap() })
 	unbackedDatasources := resolveDispatchMap(m, dispatch.Functions, info.DataSources,
 		func(p shim.Provider) shim.ResourceMap { return p.DataSourcesMap() })
+	// Provider-defined functions share the Pulumi schema's functions section (and the
+	// Invoke RPC) with data sources, so they dispatch through the same table.
+	unbackedFunctions := resolveFunctionDispatch(m, dispatch.Functions, info.Functions)
 	// List ownership is intentionally separate from CRUD ownership. Muxed providers
 	// can expose a Terraform list resource from a PF sidecar for an SDKv2 CRUD resource.
 	unbackedListResources := resolveDispatchMap(m, dispatch.ListResources, info.Resources, listResourcesMap)
@@ -198,6 +232,9 @@ func (m *ProviderShim) ResolveDispatch(info *tfbridge.ProviderInfo) (muxer.Dispa
 	if len(unbackedDatasources) > 0 {
 		errs.Errors = append(errs.Errors, joinErr("DataSources", unbackedDatasources))
 	}
+	if len(unbackedFunctions) > 0 {
+		errs.Errors = append(errs.Errors, joinErr("Functions", unbackedFunctions))
+	}
 	if len(unbackedListResources) > 0 {
 		errs.Errors = append(errs.Errors, joinErr("ListResources", unbackedListResources))
 	}
@@ -205,6 +242,31 @@ func (m *ProviderShim) ResolveDispatch(info *tfbridge.ProviderInfo) (muxer.Dispa
 		return dispatch, &errs
 	}
 	return dispatch, nil
+}
+
+// Resolve provider-defined functions into their originating providers.
+func resolveFunctionDispatch(
+	m *ProviderShim, dispatch map[string]int, info map[string]*tfbridge.FunctionInfo,
+) (unbacked []string) {
+	for tfName, fn := range info {
+		if _, ok := m.Functions()[tfName]; !ok {
+			// This function is not in any sub-provider. The bridge will error
+			// later, so we can safely ignore now.
+			continue
+		}
+		var found bool
+		for i, p := range m.MuxedProviders {
+			if _, ok := p.Functions()[tfName]; ok {
+				dispatch[string(fn.Tok)] = i
+				found = true
+				break
+			}
+		}
+		if !found {
+			unbacked = append(unbacked, tfName)
+		}
+	}
+	return unbacked
 }
 
 // Resolve either resources or datasoruces into their originating providers.
@@ -269,6 +331,7 @@ type simpleSchemaProvider struct {
 	resources     shim.ResourceMap
 	dataSources   shim.ResourceMap
 	listResources shim.ResourceMap
+	functions     map[string]shim.Function
 }
 
 func (p *simpleSchemaProvider) Schema() shim.SchemaMap {
@@ -285,6 +348,10 @@ func (p *simpleSchemaProvider) DataSourcesMap() shim.ResourceMap {
 
 func (p *simpleSchemaProvider) ListResourcesMap() shim.ResourceMap {
 	return p.listResources
+}
+
+func (p *simpleSchemaProvider) Functions() map[string]shim.Function {
+	return p.functions
 }
 
 var _ shim.Provider = (*simpleSchemaProvider)(nil)

--- a/pkg/pf/internal/muxer/muxer.go
+++ b/pkg/pf/internal/muxer/muxer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/schemashim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	shimschema "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/x/muxer"
@@ -41,13 +42,7 @@ func SchemaOnlyPluginFrameworkProvider(ctx context.Context, provider provider.Pr
 //
 // If there is overlap between shim and pf, shim will dominate.
 func AugmentShimWithPF(ctx context.Context, shim shim.Provider, pf provider.Provider) *ProviderShim {
-	p, _, _, functions := augmentShimWithPF(ctx, shim, pf)
-	// Unlike resources and data sources, conflicting provider function names cannot be
-	// resolved by letting one provider dominate: Terraform function names are global to
-	// a provider, so a collision is always a configuration error.
-	if len(functions) > 0 {
-		contract.Failf("Provider functions are not disjoint: conflicting names: %s", strings.Join(functions, ", "))
-	}
+	p, _, _, _ := augmentShimWithPF(ctx, shim, pf)
 	return p
 }
 
@@ -246,9 +241,9 @@ func (m *ProviderShim) ResolveDispatch(info *tfbridge.ProviderInfo) (muxer.Dispa
 
 // Resolve provider-defined functions into their originating providers.
 func resolveFunctionDispatch(
-	m *ProviderShim, dispatch map[string]int, info map[string]*tfbridge.FunctionInfo,
+	m *ProviderShim, dispatch map[string]int, functions map[string]*info.Function,
 ) (unbacked []string) {
-	for tfName, fn := range info {
+	for tfName, fn := range functions {
 		if _, ok := m.Functions()[tfName]; !ok {
 			// This function is not in any sub-provider. The bridge will error
 			// later, so we can safely ignore now.

--- a/pkg/pf/internal/pfutils/functions.go
+++ b/pkg/pf/internal/pfutils/functions.go
@@ -1,0 +1,99 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pfutils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+// GatherFunctions returns the provider-defined functions of prov, keyed by their
+// unprefixed Terraform name. Providers that do not implement
+// [provider.ProviderWithFunctions] have no functions.
+func GatherFunctions(ctx context.Context, prov provider.Provider) (map[string]shim.Function, error) {
+	provWithFunctions, ok := prov.(provider.ProviderWithFunctions)
+	if !ok {
+		return nil, nil
+	}
+
+	functions := map[string]shim.Function{}
+	for _, makeFunction := range provWithFunctions.Functions(ctx) {
+		fn := makeFunction()
+
+		meta := function.MetadataResponse{}
+		fn.Metadata(ctx, function.MetadataRequest{}, &meta)
+
+		def := function.DefinitionResponse{}
+		fn.Definition(ctx, function.DefinitionRequest{}, &def)
+		if err := checkDiagsForErrors(def.Diagnostics); err != nil {
+			return nil, fmt.Errorf("function %s Definition() error: %w", meta.Name, err)
+		}
+
+		shimFn, err := fromFunctionDefinition(ctx, def.Definition)
+		if err != nil {
+			return nil, fmt.Errorf("function %s: %w", meta.Name, err)
+		}
+		functions[meta.Name] = shimFn
+	}
+	return functions, nil
+}
+
+func fromFunctionDefinition(ctx context.Context, def function.Definition) (shim.Function, error) {
+	if def.Return == nil {
+		return shim.Function{}, fmt.Errorf("definition has no return type")
+	}
+
+	parameters := make([]shim.FunctionParameter, len(def.Parameters))
+	for i, p := range def.Parameters {
+		parameters[i] = fromFunctionParameter(ctx, p)
+	}
+	var variadic *shim.FunctionParameter
+	if def.VariadicParameter != nil {
+		v := fromFunctionParameter(ctx, def.VariadicParameter)
+		variadic = &v
+	}
+
+	return shim.Function{
+		Parameters:         parameters,
+		VariadicParameter:  variadic,
+		Return:             def.Return.GetType().TerraformType(ctx),
+		Summary:            def.Summary,
+		Description:        markdownOrPlain(def.MarkdownDescription, def.Description),
+		DeprecationMessage: def.DeprecationMessage,
+	}, nil
+}
+
+func fromFunctionParameter(ctx context.Context, p function.Parameter) shim.FunctionParameter {
+	return shim.FunctionParameter{
+		Name:           p.GetName(),
+		Type:           p.GetType().TerraformType(ctx),
+		AllowNullValue: p.GetAllowNullValue(),
+		Description:    markdownOrPlain(p.GetMarkdownDescription(), p.GetDescription()),
+	}
+}
+
+// markdownOrPlain matches the Plugin Framework protocol encoding, which prefers the
+// Markdown variant of a description when both are set.
+func markdownOrPlain(markdown, plain string) string {
+	if markdown != "" {
+		return markdown
+	}
+	return plain
+}

--- a/pkg/pf/internal/schemashim/provider.go
+++ b/pkg/pf/internal/schemashim/provider.go
@@ -44,6 +44,7 @@ type SchemaOnlyProvider struct {
 	resourceMap     schemaOnlyResourceMap
 	dataSourceMap   schemaOnlyDataSourceMap
 	listResourceMap schemaOnlyListResourceMap
+	functions       map[string]shim.Function
 	internalinter.Internal
 }
 
@@ -113,6 +114,10 @@ func (p *SchemaOnlyProvider) DataSourcesMap() shim.ResourceMap {
 
 func (p *SchemaOnlyProvider) ListResourcesMap() shim.ResourceMap {
 	return p.listResourceMap
+}
+
+func (p *SchemaOnlyProvider) Functions() map[string]shim.Function {
+	return p.functions
 }
 
 func (p *SchemaOnlyProvider) InternalValidate() error {

--- a/pkg/pf/internal/schemashim/schemashim.go
+++ b/pkg/pf/internal/schemashim/schemashim.go
@@ -45,6 +45,10 @@ func ShimSchemaOnlyProvider(ctx context.Context, provider pfprovider.Provider) s
 	if err != nil {
 		panic(err)
 	}
+	functions, err := pfutils.GatherFunctions(ctx, provider)
+	if err != nil {
+		panic(err)
+	}
 	resourceMap := newSchemaOnlyResourceMap(resources)
 	dataSourceMap := newSchemaOnlyDataSourceMap(dataSources)
 	listResourceMap := newSchemaOnlyListResourceMap(listResources)
@@ -54,5 +58,6 @@ func ShimSchemaOnlyProvider(ctx context.Context, provider pfprovider.Provider) s
 		resourceMap:     resourceMap,
 		dataSourceMap:   dataSourceMap,
 		listResourceMap: listResourceMap,
+		functions:       functions,
 	}
 }

--- a/pkg/pf/proto/protov6.go
+++ b/pkg/pf/proto/protov6.go
@@ -125,3 +125,49 @@ func (p Provider) DataSourcesMap() shim.ResourceMap {
 	}
 	return resourceMap(v.DataSourceSchemas)
 }
+
+func (p Provider) Functions() map[string]shim.Function {
+	v, err := p.getSchema()
+	if err != nil {
+		tfbridge.GetLogger(p.ctx).Error(err.Error())
+		return nil
+	}
+	functions := make(map[string]shim.Function, len(v.Functions))
+	for name, fn := range v.Functions {
+		functions[name] = fromProtoFunction(fn)
+	}
+	return functions
+}
+
+func fromProtoFunction(fn *tfprotov6.Function) shim.Function {
+	parameters := make([]shim.FunctionParameter, len(fn.Parameters))
+	for i, p := range fn.Parameters {
+		parameters[i] = fromProtoFunctionParameter(p)
+	}
+	var variadic *shim.FunctionParameter
+	if fn.VariadicParameter != nil {
+		v := fromProtoFunctionParameter(fn.VariadicParameter)
+		variadic = &v
+	}
+	var ret tftypes.Type
+	if fn.Return != nil {
+		ret = fn.Return.Type
+	}
+	return shim.Function{
+		Parameters:         parameters,
+		VariadicParameter:  variadic,
+		Return:             ret,
+		Summary:            fn.Summary,
+		Description:        fn.Description,
+		DeprecationMessage: fn.DeprecationMessage,
+	}
+}
+
+func fromProtoFunctionParameter(p *tfprotov6.FunctionParameter) shim.FunctionParameter {
+	return shim.FunctionParameter{
+		Name:           p.Name,
+		Type:           p.Type,
+		AllowNullValue: p.AllowNullValue,
+		Description:    p.Description,
+	}
+}

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -135,9 +135,6 @@ type PreCheckCallback = info.PreCheckCallback
 // DataSourceInfo can be used to override a data source's standard name mangling and argument/return information.
 type DataSourceInfo = info.DataSource
 
-// FunctionInfo can be used to override the mapping of a Terraform provider-defined function.
-type FunctionInfo = info.Function
-
 // SchemaInfo contains optional name transformations to apply.
 type SchemaInfo = info.Schema
 
@@ -256,14 +253,6 @@ type MarshallableDataSourceInfo = info.MarshallableDataSource
 // MarshalDataSourceInfo converts a Pulumi DataSourceInfo value into a MarshallableDataSourceInfo value.
 func MarshalDataSourceInfo(d *DataSourceInfo) *MarshallableDataSourceInfo {
 	return info.MarshalDataSource(d)
-}
-
-// MarshallableFunctionInfo is the JSON-marshallable form of a Pulumi FunctionInfo value.
-type MarshallableFunctionInfo = info.MarshallableFunction
-
-// MarshalFunctionInfo converts a Pulumi FunctionInfo value into a MarshallableFunctionInfo value.
-func MarshalFunctionInfo(f *FunctionInfo) *MarshallableFunctionInfo {
-	return info.MarshalFunction(f)
 }
 
 // MarshallableProviderInfo is the JSON-marshallable form of a Pulumi ProviderInfo value.

--- a/pkg/tfbridge/info.go
+++ b/pkg/tfbridge/info.go
@@ -135,6 +135,9 @@ type PreCheckCallback = info.PreCheckCallback
 // DataSourceInfo can be used to override a data source's standard name mangling and argument/return information.
 type DataSourceInfo = info.DataSource
 
+// FunctionInfo can be used to override the mapping of a Terraform provider-defined function.
+type FunctionInfo = info.Function
+
 // SchemaInfo contains optional name transformations to apply.
 type SchemaInfo = info.Schema
 
@@ -253,6 +256,14 @@ type MarshallableDataSourceInfo = info.MarshallableDataSource
 // MarshalDataSourceInfo converts a Pulumi DataSourceInfo value into a MarshallableDataSourceInfo value.
 func MarshalDataSourceInfo(d *DataSourceInfo) *MarshallableDataSourceInfo {
 	return info.MarshalDataSource(d)
+}
+
+// MarshallableFunctionInfo is the JSON-marshallable form of a Pulumi FunctionInfo value.
+type MarshallableFunctionInfo = info.MarshallableFunction
+
+// MarshalFunctionInfo converts a Pulumi FunctionInfo value into a MarshallableFunctionInfo value.
+func MarshalFunctionInfo(f *FunctionInfo) *MarshallableFunctionInfo {
+	return info.MarshalFunction(f)
 }
 
 // MarshallableProviderInfo is the JSON-marshallable form of a Pulumi ProviderInfo value.

--- a/pkg/tfbridge/info/external_methods.go
+++ b/pkg/tfbridge/info/external_methods.go
@@ -49,6 +49,7 @@ func (info *Provider) ApplyAutoAliases() error { return applyAutoAliases(info) }
 type Strategy struct {
 	Resource   ResourceStrategy
 	DataSource DataSourceStrategy
+	Function   FunctionStrategy
 }
 
 // A strategy for generating missing resources.
@@ -57,12 +58,18 @@ type ResourceStrategy = ElementStrategy[Resource]
 // A strategy for generating missing datasources.
 type DataSourceStrategy = ElementStrategy[DataSource]
 
+// A strategy for generating missing provider-defined functions.
+type FunctionStrategy = ElementStrategy[Function]
+
 // A generic remapping strategy.
-type ElementStrategy[T Resource | DataSource] func(tfToken string, elem *T) error
+type ElementStrategy[T Resource | DataSource | Function] func(tfToken string, elem *T) error
 
 func (ts Strategy) Ignore(substring string) Strategy {
 	ts.DataSource = ts.DataSource.Ignore(substring)
 	ts.Resource = ts.Resource.Ignore(substring)
+	if ts.Function != nil {
+		ts.Function = ts.Function.Ignore(substring)
+	}
 	return ts
 }
 

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -73,6 +73,7 @@ type Provider struct {
 	ExtraConfig    map[string]*Config                 // a list of Pulumi-only configuration variables.
 	Resources      map[string]*Resource               // a map of TF type or renamed entity name to Pulumi resource info.
 	DataSources    map[string]*DataSource             // a map of TF type or renamed entity name to Pulumi resource info.
+	Functions      map[string]*Function               // a map of unprefixed TF function name to Pulumi function info.
 	ExtraTypes     map[string]pschema.ComplexTypeSpec // a map of Pulumi token to schema type for extra types.
 	ExtraResources map[string]pschema.ResourceSpec    // a map of Pulumi token to schema type for extra resources.
 	ExtraFunctions map[string]pschema.FunctionSpec    // a map of Pulumi token to schema type for extra functions.
@@ -477,6 +478,30 @@ func (info *DataSource) GetDocs() *Doc { return info.Docs }
 
 // ReplaceExamplesSection returns whether to replace the upstream examples with our own source
 func (info *DataSource) ReplaceExamplesSection() bool {
+	return info.Docs != nil && info.Docs.ReplaceExamplesSection
+}
+
+// Function can be used to override the mapping of a Terraform provider-defined function.
+//
+// Provider-defined functions are keyed by their unprefixed Terraform name (e.g.
+// "parse_arn", not "aws_parse_arn") in [Provider.Functions].
+type Function struct {
+	Tok                tokens.ModuleMember // a function token to override the default; "" uses the default.
+	Docs               *Doc                // overrides for finding and mapping TF docs.
+	DeprecationMessage string              // message to use in deprecation warning
+}
+
+// GetTok returns a function token
+func (info *Function) GetTok() tokens.Token { return tokens.Token(info.Tok) }
+
+// GetFields returns nil: provider-defined functions do not have schema field overrides.
+func (info *Function) GetFields() map[string]*Schema { return nil }
+
+// GetDocs returns a function docs override from the Pulumi provider
+func (info *Function) GetDocs() *Doc { return info.Docs }
+
+// ReplaceExamplesSection returns whether to replace the upstream examples with our own source
+func (info *Function) ReplaceExamplesSection() bool {
 	return info.Docs != nil && info.Docs.ReplaceExamplesSection
 }
 
@@ -1293,6 +1318,21 @@ func (m *MarshallableDataSource) Unmarshal() *DataSource {
 	}
 }
 
+// MarshallableFunction is the JSON-marshallable form of a Pulumi FunctionInfo value.
+type MarshallableFunction struct {
+	Tok tokens.ModuleMember `json:"tok"`
+}
+
+// MarshalFunction converts a Pulumi FunctionInfo value into a MarshallableFunction value.
+func MarshalFunction(f *Function) *MarshallableFunction {
+	return &MarshallableFunction{Tok: f.Tok}
+}
+
+// Unmarshal creates a mostly-initialized Pulumi FunctionInfo value from the given MarshallableFunction.
+func (m *MarshallableFunction) Unmarshal() *Function {
+	return &Function{Tok: m.Tok}
+}
+
 // MarshallableProvider is the JSON-marshallable form of a Pulumi ProviderInfo value.
 type MarshallableProvider struct {
 	Provider          *MarshallableProviderShim          `json:"provider"`
@@ -1301,6 +1341,7 @@ type MarshallableProvider struct {
 	Config            map[string]*MarshallableSchema     `json:"config,omitempty"`
 	Resources         map[string]*MarshallableResource   `json:"resources,omitempty"`
 	DataSources       map[string]*MarshallableDataSource `json:"dataSources,omitempty"`
+	Functions         map[string]*MarshallableFunction   `json:"functions,omitempty"`
 	TFProviderVersion string                             `json:"tfProviderVersion,omitempty"`
 	SkipDefaultFixups bool                               `json:"skipDefaultFixups,omitempty"`
 }
@@ -1319,6 +1360,13 @@ func MarshalProvider(p *Provider) *MarshallableProvider {
 	for k, v := range p.DataSources {
 		dataSources[k] = MarshalDataSource(v)
 	}
+	var functions map[string]*MarshallableFunction
+	if len(p.Functions) > 0 {
+		functions = make(map[string]*MarshallableFunction)
+		for k, v := range p.Functions {
+			functions[k] = MarshalFunction(v)
+		}
+	}
 
 	info := MarshallableProvider{
 		Provider:          MarshalProviderShim(p.P),
@@ -1327,6 +1375,7 @@ func MarshalProvider(p *Provider) *MarshallableProvider {
 		Config:            config,
 		Resources:         resources,
 		DataSources:       dataSources,
+		Functions:         functions,
 		TFProviderVersion: p.TFProviderVersion,
 		SkipDefaultFixups: p.SkipDefaultFixups,
 	}
@@ -1348,6 +1397,13 @@ func (m *MarshallableProvider) Unmarshal() *Provider {
 	for k, v := range m.DataSources {
 		dataSources[k] = v.Unmarshal()
 	}
+	var functions map[string]*Function
+	if len(m.Functions) > 0 {
+		functions = make(map[string]*Function)
+		for k, v := range m.Functions {
+			functions[k] = v.Unmarshal()
+		}
+	}
 
 	info := Provider{
 		P:                 m.Provider.Unmarshal(),
@@ -1356,6 +1412,7 @@ func (m *MarshallableProvider) Unmarshal() *Provider {
 		Config:            config,
 		Resources:         resources,
 		DataSources:       dataSources,
+		Functions:         functions,
 		TFProviderVersion: m.TFProviderVersion,
 		SkipDefaultFixups: m.SkipDefaultFixups,
 	}

--- a/pkg/tfbridge/tokens/case_insensitive_dedup.go
+++ b/pkg/tfbridge/tokens/case_insensitive_dedup.go
@@ -20,6 +20,11 @@ import (
 func WithCaseInsensitiveDedup(base Strategy, finalize Make, metadata info.ProviderMetadata) Strategy {
 	var result Strategy
 
+	// Provider-defined function tokens pass through undeduplicated: exact token
+	// collisions are rejected during schema generation, and functions have no
+	// auto-alias history to replay.
+	result.Function = base.Function
+
 	if base.Resource != nil {
 		resourceDeduper := newStandardTokenDeduper(finalize, metadata, deduperKindResource)
 		result.Resource = func(tfToken string, elem *info.Resource) error {

--- a/pkg/tfbridge/tokens/functions.go
+++ b/pkg/tfbridge/tokens/functions.go
@@ -1,0 +1,47 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokens
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+)
+
+// The Pulumi module that provider-defined functions map into.
+//
+// Terraform provider-defined functions are named without the provider prefix and live in
+// a namespace separate from resources and data sources, so module-splitting heuristics
+// based on name prefixes do not apply to them. Every token strategy maps functions into
+// the top-level module.
+const functionModule = "index"
+
+// topLevelFunction maps a provider-defined function into the top-level module.
+//
+// The Terraform name is camelCased and used directly, without a "get" prefix: a
+// Terraform function "parse_arn" becomes "pkg:index/parseArn:parseArn".
+func topLevelFunction(finalize Make) info.FunctionStrategy {
+	return func(tfToken string, fn *info.Function) error {
+		if fn.Tok != "" {
+			return nil
+		}
+		tk, err := finalize(functionModule, camelCase(tfToken))
+		if err != nil {
+			return err
+		}
+		fn.Tok = tokens.ModuleMember(tk)
+		return nil
+	}
+}

--- a/pkg/tfbridge/tokens/inferred_modules.go
+++ b/pkg/tfbridge/tokens/inferred_modules.go
@@ -89,6 +89,7 @@ func InferredModules(
 		DataSource: tokenFromMap(tokenMap, dIsEmpty, finalize, func(tk string, datasource *info.DataSource) {
 			checkedApply(&datasource.Tok, tokens.ModuleMember(tk))
 		}),
+		Function: topLevelFunction(finalize),
 	}, nil
 }
 

--- a/pkg/tfbridge/tokens/known_modules.go
+++ b/pkg/tfbridge/tokens/known_modules.go
@@ -75,6 +75,7 @@ func KnownModules(
 			knownResource(finalize), camelCase),
 		DataSource: knownModules(tfPackagePrefix, defaultModule, modules,
 			knownDataSource(finalize), camelCase),
+		Function: topLevelFunction(finalize),
 	}
 }
 

--- a/pkg/tfbridge/tokens/mapped_modules.go
+++ b/pkg/tfbridge/tokens/mapped_modules.go
@@ -50,5 +50,6 @@ func MappedModules(
 			knownResource(finalize), transform),
 		DataSource: knownModules(tfPackagePrefix, defaultModule, mods,
 			knownDataSource(finalize), transform),
+		Function: topLevelFunction(finalize),
 	}
 }

--- a/pkg/tfbridge/tokens/tokens.go
+++ b/pkg/tfbridge/tokens/tokens.go
@@ -164,12 +164,17 @@ func ComputeTokens(info *info.Provider, opts Strategy) error {
 	if err != nil {
 		errs.Errors = append(errs.Errors, fmt.Errorf("datasources:\n%w", err))
 	}
+	err = computeDefaultFunctions(info, opts.Function, ignored)
+	if err != nil {
+		errs.Errors = append(errs.Errors, fmt.Errorf("functions:\n%w", err))
+	}
 	return errs.ErrorOrNil()
 }
 
 type (
 	ResourceStrategy   = info.ResourceStrategy
 	DataSourceStrategy = info.DataSourceStrategy
+	FunctionStrategy   = info.FunctionStrategy
 )
 
 func ignoredTokens(info *info.Provider) map[string]bool {
@@ -190,7 +195,7 @@ func computeDefaultResources(p *info.Provider, strategy ResourceStrategy, ignore
 	if p.Resources == nil {
 		p.Resources = map[string]*info.Resource{}
 	}
-	return applyComputedTokens(p.P.ResourcesMap(), p.Resources, strategy, ignored)
+	return applyComputedTokens(resourceMapKeys(p.P.ResourcesMap()), p.Resources, strategy, ignored)
 }
 
 func computeDefaultDataSources(p *info.Provider, strategy DataSourceStrategy, ignored map[string]bool) error {
@@ -200,20 +205,43 @@ func computeDefaultDataSources(p *info.Provider, strategy DataSourceStrategy, ig
 	if p.DataSources == nil {
 		p.DataSources = map[string]*info.DataSource{}
 	}
-	return applyComputedTokens(p.P.DataSourcesMap(), p.DataSources, strategy, ignored)
+	return applyComputedTokens(resourceMapKeys(p.P.DataSourcesMap()), p.DataSources, strategy, ignored)
 }
 
-// For each key in the info map not present in the result map, compute a result and store
-// it in the result map.
-func applyComputedTokens[T info.Resource | info.DataSource](
-	infoMap shim.ResourceMap, resultMap map[string]*T, tks info.ElementStrategy[T],
-	ignoredMappings map[string]bool,
-) error {
+func computeDefaultFunctions(p *info.Provider, strategy FunctionStrategy, ignored map[string]bool) error {
+	if strategy == nil {
+		return nil
+	}
+	functions := p.P.Functions()
+	if len(functions) == 0 {
+		return nil
+	}
+	if p.Functions == nil {
+		p.Functions = map[string]*info.Function{}
+	}
+	keys := make([]string, 0, len(functions))
+	for k := range functions {
+		keys = append(keys, k)
+	}
+	return applyComputedTokens(keys, p.Functions, strategy, ignored)
+}
+
+func resourceMapKeys(infoMap shim.ResourceMap) []string {
 	keys := make([]string, 0, infoMap.Len())
 	infoMap.Range(func(key string, _ shim.Resource) bool {
 		keys = append(keys, key)
 		return true
 	})
+	return keys
+}
+
+// For each key not present in the result map, compute a result and store it in the result
+// map.
+func applyComputedTokens[T info.Resource | info.DataSource | info.Function](
+	keys []string, resultMap map[string]*T, tks info.ElementStrategy[T],
+	ignoredMappings map[string]bool,
+) error {
+	keys = append([]string(nil), keys...)
 	sort.Strings(keys)
 
 	var errs multierror.Error

--- a/pkg/tfbridge/tokens_functions_test.go
+++ b/pkg/tfbridge/tokens_functions_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
@@ -36,7 +37,7 @@ func testFunction() shim.Function {
 
 func TestTokensSingleModuleFunctions(t *testing.T) {
 	t.Parallel()
-	info := tfbridge.ProviderInfo{
+	prov := tfbridge.ProviderInfo{
 		P: (&schema.Provider{
 			Functions: map[string]shim.Function{
 				"parse_arn":     testFunction(),
@@ -45,43 +46,43 @@ func TestTokensSingleModuleFunctions(t *testing.T) {
 		}).Shim(),
 	}
 
-	err := info.ComputeTokens(tokens.SingleModule("foo_", "index", tokens.MakeStandard("foo")))
+	err := prov.ComputeTokens(tokens.SingleModule("foo_", "index", tokens.MakeStandard("foo")))
 	require.NoError(t, err)
 
 	// Functions are unprefixed in Terraform and always map into the top-level module,
 	// with no "get" prefix.
-	assert.Equal(t, map[string]*tfbridge.FunctionInfo{
+	assert.Equal(t, map[string]*info.Function{
 		"parse_arn":     {Tok: "foo:index/parseArn:parseArn"},
 		"trim_prefixes": {Tok: "foo:index/trimPrefixes:trimPrefixes"},
-	}, info.Functions)
+	}, prov.Functions)
 }
 
 func TestTokensFunctionsRespectExistingMappings(t *testing.T) {
 	t.Parallel()
-	info := tfbridge.ProviderInfo{
+	prov := tfbridge.ProviderInfo{
 		P: (&schema.Provider{
 			Functions: map[string]shim.Function{
 				"parse_arn": testFunction(),
 				"other_fn":  testFunction(),
 			},
 		}).Shim(),
-		Functions: map[string]*tfbridge.FunctionInfo{
+		Functions: map[string]*info.Function{
 			"parse_arn": {Tok: "foo:custom/parseMyArn:parseMyArn"},
 		},
 	}
 
-	err := info.ComputeTokens(tokens.SingleModule("foo_", "index", tokens.MakeStandard("foo")))
+	err := prov.ComputeTokens(tokens.SingleModule("foo_", "index", tokens.MakeStandard("foo")))
 	require.NoError(t, err)
 
-	assert.Equal(t, map[string]*tfbridge.FunctionInfo{
+	assert.Equal(t, map[string]*info.Function{
 		"parse_arn": {Tok: "foo:custom/parseMyArn:parseMyArn"},
 		"other_fn":  {Tok: "foo:index/otherFn:otherFn"},
-	}, info.Functions)
+	}, prov.Functions)
 }
 
 func TestTokensFunctionsRespectIgnoreMappings(t *testing.T) {
 	t.Parallel()
-	info := tfbridge.ProviderInfo{
+	prov := tfbridge.ProviderInfo{
 		P: (&schema.Provider{
 			Functions: map[string]shim.Function{
 				"parse_arn": testFunction(),
@@ -91,17 +92,17 @@ func TestTokensFunctionsRespectIgnoreMappings(t *testing.T) {
 		IgnoreMappings: []string{"ignored"},
 	}
 
-	err := info.ComputeTokens(tokens.SingleModule("foo_", "index", tokens.MakeStandard("foo")))
+	err := prov.ComputeTokens(tokens.SingleModule("foo_", "index", tokens.MakeStandard("foo")))
 	require.NoError(t, err)
 
-	assert.Equal(t, map[string]*tfbridge.FunctionInfo{
+	assert.Equal(t, map[string]*info.Function{
 		"parse_arn": {Tok: "foo:index/parseArn:parseArn"},
-	}, info.Functions)
+	}, prov.Functions)
 }
 
 func TestTokensMappedModulesFunctions(t *testing.T) {
 	t.Parallel()
-	info := tfbridge.ProviderInfo{
+	prov := tfbridge.ProviderInfo{
 		P: (&schema.Provider{
 			Functions: map[string]shim.Function{
 				"parse_arn": testFunction(),
@@ -109,13 +110,13 @@ func TestTokensMappedModulesFunctions(t *testing.T) {
 		}).Shim(),
 	}
 
-	err := info.ComputeTokens(tokens.MappedModules("foo_", "idx", map[string]string{
+	err := prov.ComputeTokens(tokens.MappedModules("foo_", "idx", map[string]string{
 		"mod": "module",
 	}, tokens.MakeStandard("foo")))
 	require.NoError(t, err)
 
 	// Module mappings do not apply to functions; they stay in the top-level module.
-	assert.Equal(t, map[string]*tfbridge.FunctionInfo{
+	assert.Equal(t, map[string]*info.Function{
 		"parse_arn": {Tok: "foo:index/parseArn:parseArn"},
-	}, info.Functions)
+	}, prov.Functions)
 }

--- a/pkg/tfbridge/tokens_functions_test.go
+++ b/pkg/tfbridge/tokens_functions_test.go
@@ -1,0 +1,121 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+)
+
+func testFunction() shim.Function {
+	return shim.Function{
+		Parameters: []shim.FunctionParameter{{Name: "input", Type: tftypes.String}},
+		Return:     tftypes.String,
+	}
+}
+
+func TestTokensSingleModuleFunctions(t *testing.T) {
+	t.Parallel()
+	info := tfbridge.ProviderInfo{
+		P: (&schema.Provider{
+			Functions: map[string]shim.Function{
+				"parse_arn":     testFunction(),
+				"trim_prefixes": testFunction(),
+			},
+		}).Shim(),
+	}
+
+	err := info.ComputeTokens(tokens.SingleModule("foo_", "index", tokens.MakeStandard("foo")))
+	require.NoError(t, err)
+
+	// Functions are unprefixed in Terraform and always map into the top-level module,
+	// with no "get" prefix.
+	assert.Equal(t, map[string]*tfbridge.FunctionInfo{
+		"parse_arn":     {Tok: "foo:index/parseArn:parseArn"},
+		"trim_prefixes": {Tok: "foo:index/trimPrefixes:trimPrefixes"},
+	}, info.Functions)
+}
+
+func TestTokensFunctionsRespectExistingMappings(t *testing.T) {
+	t.Parallel()
+	info := tfbridge.ProviderInfo{
+		P: (&schema.Provider{
+			Functions: map[string]shim.Function{
+				"parse_arn": testFunction(),
+				"other_fn":  testFunction(),
+			},
+		}).Shim(),
+		Functions: map[string]*tfbridge.FunctionInfo{
+			"parse_arn": {Tok: "foo:custom/parseMyArn:parseMyArn"},
+		},
+	}
+
+	err := info.ComputeTokens(tokens.SingleModule("foo_", "index", tokens.MakeStandard("foo")))
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]*tfbridge.FunctionInfo{
+		"parse_arn": {Tok: "foo:custom/parseMyArn:parseMyArn"},
+		"other_fn":  {Tok: "foo:index/otherFn:otherFn"},
+	}, info.Functions)
+}
+
+func TestTokensFunctionsRespectIgnoreMappings(t *testing.T) {
+	t.Parallel()
+	info := tfbridge.ProviderInfo{
+		P: (&schema.Provider{
+			Functions: map[string]shim.Function{
+				"parse_arn": testFunction(),
+				"ignored":   testFunction(),
+			},
+		}).Shim(),
+		IgnoreMappings: []string{"ignored"},
+	}
+
+	err := info.ComputeTokens(tokens.SingleModule("foo_", "index", tokens.MakeStandard("foo")))
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]*tfbridge.FunctionInfo{
+		"parse_arn": {Tok: "foo:index/parseArn:parseArn"},
+	}, info.Functions)
+}
+
+func TestTokensMappedModulesFunctions(t *testing.T) {
+	t.Parallel()
+	info := tfbridge.ProviderInfo{
+		P: (&schema.Provider{
+			Functions: map[string]shim.Function{
+				"parse_arn": testFunction(),
+			},
+		}).Shim(),
+	}
+
+	err := info.ComputeTokens(tokens.MappedModules("foo_", "idx", map[string]string{
+		"mod": "module",
+	}, tokens.MakeStandard("foo")))
+	require.NoError(t, err)
+
+	// Module mappings do not apply to functions; they stay in the top-level module.
+	assert.Equal(t, map[string]*tfbridge.FunctionInfo{
+		"parse_arn": {Tok: "foo:index/parseArn:parseArn"},
+	}, info.Functions)
+}

--- a/pkg/tfshim/function.go
+++ b/pkg/tfshim/function.go
@@ -1,0 +1,65 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shim
+
+import (
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Function describes a provider-defined function.
+//
+// Provider-defined functions are a Terraform Plugin Framework feature (protocol 6.5+,
+// Terraform 1.8+). They are pure, offline computations: no side effects and no access to
+// provider configuration. In Terraform they live in a namespace separate from resources
+// and data sources; names are registered without the provider prefix (e.g. "parse_arn",
+// not "aws_parse_arn") and called as provider::<local-name>::<function-name>(...).
+//
+// See https://developer.hashicorp.com/terraform/plugin/framework/functions/concepts.
+type Function struct {
+	// Parameters describes the ordered, positional parameters of the function.
+	Parameters []FunctionParameter
+
+	// VariadicParameter, if non-nil, describes a final parameter that accepts zero or
+	// more trailing arguments of its type.
+	VariadicParameter *FunctionParameter
+
+	// Return is the type of the function result.
+	Return tftypes.Type
+
+	// Summary is a short, single-line description of the function.
+	Summary string
+
+	// Description is a longer description of the function, possibly in Markdown.
+	Description string
+
+	// DeprecationMessage is non-empty if the function is deprecated.
+	DeprecationMessage string
+}
+
+// FunctionParameter describes a single parameter of a provider-defined function.
+type FunctionParameter struct {
+	// Name is the parameter name. Terraform treats parameter names as
+	// documentation-only: they may be empty or duplicate other parameter names.
+	Name string
+
+	// Type is the type constraint of the parameter.
+	Type tftypes.Type
+
+	// AllowNullValue is true if the parameter accepts a null argument.
+	AllowNullValue bool
+
+	// Description is a description of the parameter, possibly in Markdown.
+	Description string
+}

--- a/pkg/tfshim/schema/provider.go
+++ b/pkg/tfshim/schema/provider.go
@@ -12,6 +12,7 @@ type Provider struct {
 	Schema         shim.SchemaMap
 	ResourcesMap   shim.ResourceMap
 	DataSourcesMap shim.ResourceMap
+	Functions      map[string]shim.Function
 	internalinter.Internal
 }
 
@@ -48,6 +49,10 @@ func (s ProviderShim) ResourcesMap() shim.ResourceMap {
 
 func (s ProviderShim) DataSourcesMap() shim.ResourceMap {
 	return s.V.DataSourcesMap
+}
+
+func (s ProviderShim) Functions() map[string]shim.Function {
+	return s.V.Functions
 }
 
 func (s ProviderShim) InternalValidate() error {

--- a/pkg/tfshim/sdk-v1/provider.go
+++ b/pkg/tfshim/sdk-v1/provider.go
@@ -74,6 +74,11 @@ func (p v1Provider) DataSourcesMap() shim.ResourceMap {
 	return v1ResourceMap(p.tf.DataSourcesMap)
 }
 
+func (p v1Provider) Functions() map[string]shim.Function {
+	// SDK based providers cannot define provider functions.
+	return nil
+}
+
 func (p v1Provider) InternalValidate() error {
 	return p.tf.InternalValidate()
 }

--- a/pkg/tfshim/sdk-v2/provider.go
+++ b/pkg/tfshim/sdk-v2/provider.go
@@ -82,6 +82,11 @@ func (p v2Provider) DataSourcesMap() shim.ResourceMap {
 	return v2ResourceMap(p.tf.DataSourcesMap)
 }
 
+func (p v2Provider) Functions() map[string]shim.Function {
+	// SDK based providers cannot define provider functions.
+	return nil
+}
+
 func (p v2Provider) InternalValidate() error {
 	return p.tf.InternalValidate()
 }

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -302,6 +302,13 @@ type Provider interface {
 	ResourcesMap() ResourceMap
 	DataSourcesMap() ResourceMap
 
+	// Functions returns the provider-defined functions, keyed by their unprefixed
+	// Terraform name.
+	//
+	// Only Plugin Framework based providers can define functions; SDK based providers
+	// always return an empty map.
+	Functions() map[string]Function
+
 	InternalValidate() error
 	Validate(ctx context.Context, c ResourceConfig) ([]diagnostics.ValidationWarning, []error)
 	ValidateResource(ctx context.Context, t string, c ResourceConfig) ([]diagnostics.ValidationWarning, []error)

--- a/pkg/tfshim/util/filter.go
+++ b/pkg/tfshim/util/filter.go
@@ -62,6 +62,10 @@ func (p *FilteringProvider) DataSourcesMap() shim.ResourceMap {
 	return &filteringMap{p.Provider.DataSourcesMap(), p.DataSourceFilter}
 }
 
+func (p *FilteringProvider) Functions() map[string]shim.Function {
+	return p.Provider.Functions()
+}
+
 func (p *FilteringProvider) InternalValidate() error {
 	return p.Provider.InternalValidate()
 }

--- a/pkg/tfshim/util/util.go
+++ b/pkg/tfshim/util/util.go
@@ -29,9 +29,10 @@ type UnimplementedProvider struct {
 	internalinter.Internal
 }
 
-func (UnimplementedProvider) Schema() shim.SchemaMap           { panic("unimplemented") }
-func (UnimplementedProvider) ResourcesMap() shim.ResourceMap   { panic("unimplemented") }
-func (UnimplementedProvider) DataSourcesMap() shim.ResourceMap { panic("unimplemented") }
+func (UnimplementedProvider) Schema() shim.SchemaMap              { panic("unimplemented") }
+func (UnimplementedProvider) ResourcesMap() shim.ResourceMap      { panic("unimplemented") }
+func (UnimplementedProvider) DataSourcesMap() shim.ResourceMap    { panic("unimplemented") }
+func (UnimplementedProvider) Functions() map[string]shim.Function { panic("unimplemented") }
 
 func (UnimplementedProvider) InternalValidate() error { panic("unimplemented") }
 


### PR DESCRIPTION
## Summary

Terraform providers built with the Plugin Framework can define provider functions: pure computations called as `provider::<name>::<fn>(...)` in Terraform. This change adds the plumbing needed to represent them in the bridge, ahead of schema generation (#3508) and runtime support (#3509).

- `pkg/tfshim`: new `shim.Function` and `shim.FunctionParameter` types describe a function signature with tftypes type constraints, including a trailing variadic parameter and `AllowNullValue`. The `shim.Provider` interface gains a `Functions()` accessor, keyed by the unprefixed Terraform function name. SDK-based providers return nil; the schema-only, filtering, and unimplemented providers are updated accordingly.
- `pkg/pf`: the Plugin Framework shim gathers functions from providers that implement `provider.ProviderWithFunctions` (new `pfutils.GatherFunctions`), and the proto shim projects `GetProviderSchemaResponse.Functions` for the dynamic bridge. The internal muxer shim layers functions across sub-providers like resources and data sources: the base shim dominates on overlap, and only `AugmentShimWithDisjointPF` asserts disjointness. Mapped function tokens dispatch to the sub-provider that defines them.
- `pkg/tfbridge/info`: `ProviderInfo` gains a `Functions` section, keyed by the unprefixed Terraform name, with a minimal `info.Function{Tok, Docs, DeprecationMessage}`. Functions marshal into the GetMapping payload so converters can translate provider function calls.
- `pkg/tfbridge/tokens`: every token strategy maps functions into the top-level (index) module, camelCasing the Terraform name with no `get` prefix. `ComputeTokens` fills missing mappings, honoring `IgnoreMappings` and existing entries. `WithCaseInsensitiveDedup` passes function strategies through.

Part of #1955.

## Testing

- New token strategy tests cover default mapping, existing-mapping overrides, `IgnoreMappings`, and module-mapping strategies (functions stay top-level).
- `go build ./...`, `go vet ./...`, and the `pkg/tfbridge`, `pkg/tfshim`, `pkg/pf/internal/muxer`, `pkg/pf/internal/schemashim`, and `pkg/pf/proto` test suites pass at this commit.