### PR TITLE
Generate Pulumi schema for provider-defined functions

### DIFF
--- a/pkg/internal/functions/functions.go
+++ b/pkg/internal/functions/functions.go
@@ -26,7 +26,6 @@ package functions
 
 import (
 	"fmt"
-	"sort"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
@@ -67,16 +66,6 @@ func ArgumentNames(fn shim.Function) []string {
 		assign(v.Name, len(fn.Parameters))
 	}
 	return names
-}
-
-// SortedAttributeNames returns the attribute names of t in a stable order.
-func SortedAttributeNames(t tftypes.Object) []string {
-	attrs := make([]string, 0, len(t.AttributeTypes))
-	for attr := range t.AttributeTypes {
-		attrs = append(attrs, attr)
-	}
-	sort.Strings(attrs)
-	return attrs
 }
 
 // SchemaFromType synthesizes a shim schema mirroring the given type constraint, so that

--- a/pkg/internal/functions/functions.go
+++ b/pkg/internal/functions/functions.go
@@ -14,20 +14,26 @@
 
 // Package functions holds logic shared between build-time schema generation and the
 // runtime bridge for Terraform provider-defined functions: the naming of positional
-// arguments and object attributes, and the conversion between Pulumi property values and
-// Terraform values for the tftypes type constraints that describe function signatures.
+// arguments and the synthesis of shim schemas from the tftypes type constraints that
+// describe function signatures.
+//
+// Function signatures carry no Terraform schema, but the bridge's naming
+// ([tfbridge.TerraformToPulumiNameV2]) and value conversion ([pkg/convert]) machinery is
+// schema-driven. Synthesizing a shim schema from the type constraints lets functions
+// reuse both, so property naming and value conversion behave exactly like the rest of
+// the bridge.
 package functions
 
 import (
 	"fmt"
-	"math/big"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 )
 
 // ArgumentNames assigns a distinct Pulumi property name to each positional parameter of
@@ -63,18 +69,6 @@ func ArgumentNames(fn shim.Function) []string {
 	return names
 }
 
-// PropertyName translates a Terraform object attribute name into its Pulumi property
-// name. The translation applies no schema-based inflection (such as pluralization), so
-// it is invertible via [AttributeName].
-func PropertyName(attr string) string {
-	return tfbridge.TerraformToPulumiNameV2(attr, nil, nil)
-}
-
-// AttributeName is the inverse of [PropertyName].
-func AttributeName(property string) string {
-	return tfbridge.PulumiToTerraformName(property, nil, nil)
-}
-
 // SortedAttributeNames returns the attribute names of t in a stable order.
 func SortedAttributeNames(t tftypes.Object) []string {
 	attrs := make([]string, 0, len(t.AttributeTypes))
@@ -85,324 +79,137 @@ func SortedAttributeNames(t tftypes.Object) []string {
 	return attrs
 }
 
-// EncodeValue converts a Pulumi property value into a Terraform value of the given type
-// constraint. Secret and output wrappers must be removed before calling; unknown values
-// are rejected, since function arguments are always known.
-func EncodeValue(t tftypes.Type, pv resource.PropertyValue) (tftypes.Value, error) {
-	switch {
-	case pv.IsComputed() || pv.IsOutput() && !pv.OutputValue().Known:
-		return tftypes.Value{}, fmt.Errorf("unexpected unknown value")
-	case pv.IsSecret():
-		return EncodeValue(t, pv.SecretValue().Element)
-	case pv.IsOutput():
-		return EncodeValue(t, pv.OutputValue().Element)
-	case pv.IsNull():
-		return tftypes.NewValue(t, nil), nil
-	}
-
-	if t.Is(tftypes.DynamicPseudoType) {
-		return encodeDynamic(pv)
-	}
-
-	switch t := t.(type) {
+// SchemaFromType synthesizes a shim schema mirroring the given type constraint, so that
+// schema-driven naming and value conversion apply to provider function signatures.
+func SchemaFromType(t tftypes.Type) (shim.Schema, error) {
+	s := &schema.Schema{Optional: true}
+	switch tt := t.(type) {
 	case tftypes.List:
-		vals, err := encodeElements(t.ElementType, pv)
+		element, err := SchemaFromType(tt.ElementType)
 		if err != nil {
-			return tftypes.Value{}, err
+			return nil, err
 		}
-		return tftypes.NewValue(t, vals), nil
+		s.Type, s.Elem = shim.TypeList, element
 	case tftypes.Set:
-		vals, err := encodeElements(t.ElementType, pv)
+		element, err := SchemaFromType(tt.ElementType)
 		if err != nil {
-			return tftypes.Value{}, err
+			return nil, err
 		}
-		return tftypes.NewValue(t, vals), nil
+		s.Type, s.Elem = shim.TypeSet, element
 	case tftypes.Map:
-		if !pv.IsObject() {
-			return tftypes.Value{}, fmt.Errorf("expected a map, got %v", pv.TypeString())
-		}
-		vals := map[string]tftypes.Value{}
-		for k, v := range pv.ObjectValue() {
-			// Map keys are data, not property names; they are not renamed.
-			ev, err := EncodeValue(t.ElementType, v)
-			if err != nil {
-				return tftypes.Value{}, fmt.Errorf("[%q]: %w", string(k), err)
-			}
-			vals[string(k)] = ev
-		}
-		return tftypes.NewValue(t, vals), nil
-	case tftypes.Object:
-		if !pv.IsObject() {
-			return tftypes.Value{}, fmt.Errorf("expected an object, got %v", pv.TypeString())
-		}
-		obj := pv.ObjectValue()
-		known := map[resource.PropertyKey]bool{}
-		vals := map[string]tftypes.Value{}
-		for attr, attrType := range t.AttributeTypes {
-			key := resource.PropertyKey(PropertyName(attr))
-			known[key] = true
-			v, has := obj[key]
-			if !has {
-				v = resource.NewNullProperty()
-			}
-			ev, err := EncodeValue(attrType, v)
-			if err != nil {
-				return tftypes.Value{}, fmt.Errorf(".%s: %w", key, err)
-			}
-			vals[attr] = ev
-		}
-		for k := range obj {
-			if !known[k] {
-				return tftypes.Value{}, fmt.Errorf("unexpected property %q", string(k))
-			}
-		}
-		return tftypes.NewValue(t, vals), nil
-	case tftypes.Tuple:
-		return tftypes.Value{}, fmt.Errorf("tuple types are not supported")
-	}
-
-	switch {
-	case t.Is(tftypes.String):
-		if !pv.IsString() {
-			return tftypes.Value{}, fmt.Errorf("expected a string, got %v", pv.TypeString())
-		}
-		return tftypes.NewValue(t, pv.StringValue()), nil
-	case t.Is(tftypes.Bool):
-		if !pv.IsBool() {
-			return tftypes.Value{}, fmt.Errorf("expected a boolean, got %v", pv.TypeString())
-		}
-		return tftypes.NewValue(t, pv.BoolValue()), nil
-	case t.Is(tftypes.Number):
-		if !pv.IsNumber() {
-			return tftypes.Value{}, fmt.Errorf("expected a number, got %v", pv.TypeString())
-		}
-		return tftypes.NewValue(t, pv.NumberValue()), nil
-	}
-	return tftypes.Value{}, fmt.Errorf("unsupported type %v", t)
-}
-
-func encodeElements(elementType tftypes.Type, pv resource.PropertyValue) ([]tftypes.Value, error) {
-	if !pv.IsArray() {
-		return nil, fmt.Errorf("expected a list, got %v", pv.TypeString())
-	}
-	arr := pv.ArrayValue()
-	vals := make([]tftypes.Value, len(arr))
-	for i, e := range arr {
-		ev, err := EncodeValue(elementType, e)
+		element, err := SchemaFromType(tt.ElementType)
 		if err != nil {
-			return nil, fmt.Errorf("[%d]: %w", i, err)
+			return nil, err
 		}
-		vals[i] = ev
-	}
-	return vals, nil
-}
-
-// encodeDynamic performs a best-effort conversion for DynamicPseudoType constraints at
-// the data level, inferring a concrete Terraform type from the value. Object property
-// names are passed through unmodified, mirroring the dynamic encoding used elsewhere in
-// the bridge.
-func encodeDynamic(pv resource.PropertyValue) (tftypes.Value, error) {
-	switch {
-	case pv.IsNull():
-		return tftypes.NewValue(tftypes.DynamicPseudoType, nil), nil
-	case pv.IsBool():
-		return tftypes.NewValue(tftypes.Bool, pv.BoolValue()), nil
-	case pv.IsNumber():
-		return tftypes.NewValue(tftypes.Number, pv.NumberValue()), nil
-	case pv.IsString():
-		return tftypes.NewValue(tftypes.String, pv.StringValue()), nil
-	case pv.IsArray():
-		vals := make([]tftypes.Value, 0, len(pv.ArrayValue()))
-		for i, e := range pv.ArrayValue() {
-			ev, err := encodeDynamic(e)
-			if err != nil {
-				return tftypes.Value{}, fmt.Errorf("[%d]: %w", i, err)
-			}
-			vals = append(vals, ev)
-		}
-		// Elements of a Terraform list must share one type; fall back to a tuple for
-		// heterogeneous arrays.
-		if commonType, err := tftypes.TypeFromElements(vals); err == nil {
-			return tftypes.NewValue(tftypes.List{ElementType: commonType}, vals), nil
-		}
-		types := make([]tftypes.Type, len(vals))
-		for i, v := range vals {
-			types[i] = v.Type()
-		}
-		return tftypes.NewValue(tftypes.Tuple{ElementTypes: types}, vals), nil
-	case pv.IsObject():
-		objType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{}}
-		vals := map[string]tftypes.Value{}
-		for k, v := range pv.ObjectValue() {
-			ev, err := encodeDynamic(v)
-			if err != nil {
-				return tftypes.Value{}, fmt.Errorf(".%s: %w", string(k), err)
-			}
-			vals[string(k)] = ev
-			objType.AttributeTypes[string(k)] = ev.Type()
-		}
-		return tftypes.NewValue(objType, vals), nil
-	case pv.IsSecret():
-		return encodeDynamic(pv.SecretValue().Element)
-	case pv.IsOutput() && pv.OutputValue().Known:
-		return encodeDynamic(pv.OutputValue().Element)
-	default:
-		return tftypes.Value{}, fmt.Errorf("cannot encode %v as a dynamic value", pv.TypeString())
-	}
-}
-
-// DecodeValue converts a Terraform value of the given type constraint back into a Pulumi
-// property value. When the constraint is DynamicPseudoType the value decodes by its own
-// concrete type, with object property names passed through unmodified.
-func DecodeValue(t tftypes.Type, v tftypes.Value) (resource.PropertyValue, error) {
-	if !v.IsKnown() {
-		return resource.PropertyValue{}, fmt.Errorf("unexpected unknown value")
-	}
-	if v.IsNull() {
-		return resource.NewPropertyValue(nil), nil
-	}
-
-	if t.Is(tftypes.DynamicPseudoType) {
-		return decodeDynamic(v)
-	}
-
-	switch t := t.(type) {
-	case tftypes.List:
-		return decodeElements(t.ElementType, v)
-	case tftypes.Set:
-		return decodeElements(t.ElementType, v)
-	case tftypes.Map:
-		var elements map[string]tftypes.Value
-		if err := v.As(&elements); err != nil {
-			return resource.PropertyValue{}, err
-		}
-		result := make(resource.PropertyMap, len(elements))
-		for k, e := range elements {
-			ev, err := DecodeValue(t.ElementType, e)
-			if err != nil {
-				return resource.PropertyValue{}, fmt.Errorf("[%q]: %w", k, err)
-			}
-			result[resource.PropertyKey(k)] = ev
-		}
-		return resource.NewObjectProperty(result), nil
+		s.Type, s.Elem = shim.TypeMap, element
 	case tftypes.Object:
-		var attrs map[string]tftypes.Value
-		if err := v.As(&attrs); err != nil {
-			return resource.PropertyValue{}, err
-		}
-		result := make(resource.PropertyMap, len(attrs))
-		for attr, e := range attrs {
-			attrType, ok := t.AttributeTypes[attr]
-			if !ok {
-				return resource.PropertyValue{}, fmt.Errorf("unexpected attribute %q", attr)
-			}
-			ev, err := DecodeValue(attrType, e)
-			if err != nil {
-				return resource.PropertyValue{}, fmt.Errorf(".%s: %w", attr, err)
-			}
-			result[resource.PropertyKey(PropertyName(attr))] = ev
-		}
-		return resource.NewObjectProperty(result), nil
-	case tftypes.Tuple:
-		return resource.PropertyValue{}, fmt.Errorf("tuple types are not supported")
-	}
-
-	switch {
-	case t.Is(tftypes.String):
-		var s string
-		if err := v.As(&s); err != nil {
-			return resource.PropertyValue{}, err
-		}
-		return resource.NewStringProperty(s), nil
-	case t.Is(tftypes.Bool):
-		var b bool
-		if err := v.As(&b); err != nil {
-			return resource.PropertyValue{}, err
-		}
-		return resource.NewBoolProperty(b), nil
-	case t.Is(tftypes.Number):
-		var n big.Float
-		if err := v.As(&n); err != nil {
-			return resource.PropertyValue{}, err
-		}
-		f, _ := n.Float64()
-		return resource.NewNumberProperty(f), nil
-	}
-	return resource.PropertyValue{}, fmt.Errorf("unsupported type %v", t)
-}
-
-func decodeElements(elementType tftypes.Type, v tftypes.Value) (resource.PropertyValue, error) {
-	var elements []tftypes.Value
-	if err := v.As(&elements); err != nil {
-		return resource.PropertyValue{}, err
-	}
-	result := make([]resource.PropertyValue, len(elements))
-	for i, e := range elements {
-		ev, err := DecodeValue(elementType, e)
+		// A single-nested object is a TypeMap with a Resource element; see the
+		// documentation on [shim.Schema.Elem].
+		attrs, err := SchemaMapFromObject(tt)
 		if err != nil {
-			return resource.PropertyValue{}, fmt.Errorf("[%d]: %w", i, err)
+			return nil, err
 		}
-		result[i] = ev
+		s.Type, s.Elem = shim.TypeMap, (&schema.Resource{Schema: attrs}).Shim()
+	case tftypes.Tuple:
+		// No provider function in the wild uses tuples, and Pulumi schema has no
+		// equivalent type.
+		return nil, fmt.Errorf("tuple types are not supported")
+	default:
+		switch {
+		case t.Is(tftypes.String):
+			s.Type = shim.TypeString
+		case t.Is(tftypes.Bool):
+			s.Type = shim.TypeBool
+		case t.Is(tftypes.Number):
+			s.Type = shim.TypeFloat
+		case t.Is(tftypes.DynamicPseudoType):
+			s.Type = shim.TypeDynamic
+		default:
+			return nil, fmt.Errorf("unsupported type %v", t)
+		}
 	}
-	return resource.NewArrayProperty(result), nil
+	return s.Shim(), nil
 }
 
-// decodeDynamic decodes a value by its own concrete type, without renaming object
-// property names.
-func decodeDynamic(v tftypes.Value) (resource.PropertyValue, error) {
-	switch {
-	case !v.IsKnown():
-		return resource.PropertyValue{}, fmt.Errorf("unexpected unknown value")
-	case v.IsNull():
-		return resource.NewPropertyValue(nil), nil
-	case v.Type().Is(tftypes.Bool):
-		var b bool
-		if err := v.As(&b); err != nil {
-			return resource.PropertyValue{}, err
+// SchemaMapFromObject synthesizes a shim schema map for the attributes of an object type
+// constraint. Passing the result to [tfbridge.TerraformToPulumiNameV2] yields the Pulumi
+// property name of each attribute, with the same inflection rules as the rest of the
+// bridge.
+func SchemaMapFromObject(t tftypes.Object) (shim.SchemaMap, error) {
+	m := schema.SchemaMap{}
+	for attr, attrType := range t.AttributeTypes {
+		s, err := SchemaFromType(attrType)
+		if err != nil {
+			return nil, fmt.Errorf("attribute %q: %w", attr, err)
 		}
-		return resource.NewBoolProperty(b), nil
-	case v.Type().Is(tftypes.Number):
-		var n big.Float
-		if err := v.As(&n); err != nil {
-			return resource.PropertyValue{}, err
-		}
-		f, _ := n.Float64()
-		return resource.NewNumberProperty(f), nil
-	case v.Type().Is(tftypes.String):
-		var s string
-		if err := v.As(&s); err != nil {
-			return resource.PropertyValue{}, err
-		}
-		return resource.NewStringProperty(s), nil
-	case v.Type().Is(tftypes.List{}), v.Type().Is(tftypes.Set{}), v.Type().Is(tftypes.Tuple{}):
-		var elements []tftypes.Value
-		if err := v.As(&elements); err != nil {
-			return resource.PropertyValue{}, err
-		}
-		result := make([]resource.PropertyValue, len(elements))
-		for i, e := range elements {
-			ev, err := decodeDynamic(e)
-			if err != nil {
-				return resource.PropertyValue{}, fmt.Errorf("[%d]: %w", i, err)
-			}
-			result[i] = ev
-		}
-		return resource.NewArrayProperty(result), nil
-	case v.Type().Is(tftypes.Map{}), v.Type().Is(tftypes.Object{}):
-		var elements map[string]tftypes.Value
-		if err := v.As(&elements); err != nil {
-			return resource.PropertyValue{}, err
-		}
-		result := make(resource.PropertyMap, len(elements))
-		for k, e := range elements {
-			ev, err := decodeDynamic(e)
-			if err != nil {
-				return resource.PropertyValue{}, fmt.Errorf(".%s: %w", k, err)
-			}
-			result[resource.PropertyKey(k)] = ev
-		}
-		return resource.NewObjectProperty(result), nil
-	default:
-		return resource.PropertyValue{}, fmt.Errorf("unsupported type %v", v.Type())
+		m[attr] = s
 	}
+	return m, nil
+}
+
+// ObjectSchema describes a synthetic object over parts of a function signature, in the
+// form the pkg/convert encoders and decoders consume.
+type ObjectSchema struct {
+	Type        tftypes.Object
+	SchemaMap   shim.SchemaMap
+	SchemaInfos map[string]*info.Schema
+}
+
+// ArgumentsSchema synthesizes an object over the positional arguments of fn, keyed and
+// named by argNames (from [ArgumentNames]). A trailing variadic parameter appears as a
+// list over its element type. Names are pinned exactly, since the schema's
+// multiArgumentInputs list refers to them positionally.
+func ArgumentsSchema(fn shim.Function, argNames []string) (ObjectSchema, error) {
+	attrTypes := map[string]tftypes.Type{}
+	schemaMap := schema.SchemaMap{}
+	schemaInfos := map[string]*info.Schema{}
+	add := func(name string, t tftypes.Type) error {
+		s, err := SchemaFromType(t)
+		if err != nil {
+			return fmt.Errorf("argument %q: %w", name, err)
+		}
+		attrTypes[name] = t
+		schemaMap[name] = s
+		schemaInfos[name] = &info.Schema{Name: name}
+		return nil
+	}
+	for i, p := range fn.Parameters {
+		if err := add(argNames[i], p.Type); err != nil {
+			return ObjectSchema{}, err
+		}
+	}
+	if v := fn.VariadicParameter; v != nil {
+		if err := add(argNames[len(fn.Parameters)], tftypes.List{ElementType: v.Type}); err != nil {
+			return ObjectSchema{}, err
+		}
+	}
+	return ObjectSchema{
+		Type:        tftypes.Object{AttributeTypes: attrTypes},
+		SchemaMap:   schemaMap,
+		SchemaInfos: schemaInfos,
+	}, nil
+}
+
+// ResultSchema synthesizes an object over the return value of fn.
+//
+// An object return decodes directly, with standard attribute naming. Any other return
+// type wraps into a single property named by wrapProperty, matching the single-property
+// map SDKs expect from invokes with a direct (non-object) return type.
+func ResultSchema(fn shim.Function, wrapProperty string) (ObjectSchema, bool, error) {
+	if obj, ok := fn.Return.(tftypes.Object); ok {
+		m, err := SchemaMapFromObject(obj)
+		if err != nil {
+			return ObjectSchema{}, false, err
+		}
+		return ObjectSchema{Type: obj, SchemaMap: m}, true, nil
+	}
+	s, err := SchemaFromType(fn.Return)
+	if err != nil {
+		return ObjectSchema{}, false, err
+	}
+	return ObjectSchema{
+		Type:        tftypes.Object{AttributeTypes: map[string]tftypes.Type{wrapProperty: fn.Return}},
+		SchemaMap:   schema.SchemaMap{wrapProperty: s},
+		SchemaInfos: map[string]*info.Schema{wrapProperty: {Name: wrapProperty}},
+	}, false, nil
 }

--- a/pkg/internal/functions/functions.go
+++ b/pkg/internal/functions/functions.go
@@ -1,0 +1,408 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package functions holds logic shared between build-time schema generation and the
+// runtime bridge for Terraform provider-defined functions: the naming of positional
+// arguments and object attributes, and the conversion between Pulumi property values and
+// Terraform values for the tftypes type constraints that describe function signatures.
+package functions
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+// ArgumentNames assigns a distinct Pulumi property name to each positional parameter of
+// fn, including a trailing variadic parameter. Terraform treats parameter names as
+// documentation-only, so empty and duplicate names are resolved deterministically.
+//
+// The returned names key the Pulumi schema's inputs object and multiArgumentInputs list,
+// and the argument values a provider receives at runtime.
+func ArgumentNames(fn shim.Function) []string {
+	names := make([]string, 0, len(fn.Parameters)+1)
+	seen := make(map[string]bool, len(fn.Parameters)+1)
+	assign := func(raw string, position int) {
+		base := ""
+		if raw != "" {
+			base = tfbridge.TerraformToPulumiNameV2(raw, nil, nil)
+		}
+		if base == "" {
+			base = fmt.Sprintf("arg%d", position+1)
+		}
+		name := base
+		for n := 2; seen[name]; n++ {
+			name = fmt.Sprintf("%s%d", base, n)
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	for i, p := range fn.Parameters {
+		assign(p.Name, i)
+	}
+	if v := fn.VariadicParameter; v != nil {
+		assign(v.Name, len(fn.Parameters))
+	}
+	return names
+}
+
+// PropertyName translates a Terraform object attribute name into its Pulumi property
+// name. The translation applies no schema-based inflection (such as pluralization), so
+// it is invertible via [AttributeName].
+func PropertyName(attr string) string {
+	return tfbridge.TerraformToPulumiNameV2(attr, nil, nil)
+}
+
+// AttributeName is the inverse of [PropertyName].
+func AttributeName(property string) string {
+	return tfbridge.PulumiToTerraformName(property, nil, nil)
+}
+
+// SortedAttributeNames returns the attribute names of t in a stable order.
+func SortedAttributeNames(t tftypes.Object) []string {
+	attrs := make([]string, 0, len(t.AttributeTypes))
+	for attr := range t.AttributeTypes {
+		attrs = append(attrs, attr)
+	}
+	sort.Strings(attrs)
+	return attrs
+}
+
+// EncodeValue converts a Pulumi property value into a Terraform value of the given type
+// constraint. Secret and output wrappers must be removed before calling; unknown values
+// are rejected, since function arguments are always known.
+func EncodeValue(t tftypes.Type, pv resource.PropertyValue) (tftypes.Value, error) {
+	switch {
+	case pv.IsComputed() || pv.IsOutput() && !pv.OutputValue().Known:
+		return tftypes.Value{}, fmt.Errorf("unexpected unknown value")
+	case pv.IsSecret():
+		return EncodeValue(t, pv.SecretValue().Element)
+	case pv.IsOutput():
+		return EncodeValue(t, pv.OutputValue().Element)
+	case pv.IsNull():
+		return tftypes.NewValue(t, nil), nil
+	}
+
+	if t.Is(tftypes.DynamicPseudoType) {
+		return encodeDynamic(pv)
+	}
+
+	switch t := t.(type) {
+	case tftypes.List:
+		vals, err := encodeElements(t.ElementType, pv)
+		if err != nil {
+			return tftypes.Value{}, err
+		}
+		return tftypes.NewValue(t, vals), nil
+	case tftypes.Set:
+		vals, err := encodeElements(t.ElementType, pv)
+		if err != nil {
+			return tftypes.Value{}, err
+		}
+		return tftypes.NewValue(t, vals), nil
+	case tftypes.Map:
+		if !pv.IsObject() {
+			return tftypes.Value{}, fmt.Errorf("expected a map, got %v", pv.TypeString())
+		}
+		vals := map[string]tftypes.Value{}
+		for k, v := range pv.ObjectValue() {
+			// Map keys are data, not property names; they are not renamed.
+			ev, err := EncodeValue(t.ElementType, v)
+			if err != nil {
+				return tftypes.Value{}, fmt.Errorf("[%q]: %w", string(k), err)
+			}
+			vals[string(k)] = ev
+		}
+		return tftypes.NewValue(t, vals), nil
+	case tftypes.Object:
+		if !pv.IsObject() {
+			return tftypes.Value{}, fmt.Errorf("expected an object, got %v", pv.TypeString())
+		}
+		obj := pv.ObjectValue()
+		known := map[resource.PropertyKey]bool{}
+		vals := map[string]tftypes.Value{}
+		for attr, attrType := range t.AttributeTypes {
+			key := resource.PropertyKey(PropertyName(attr))
+			known[key] = true
+			v, has := obj[key]
+			if !has {
+				v = resource.NewNullProperty()
+			}
+			ev, err := EncodeValue(attrType, v)
+			if err != nil {
+				return tftypes.Value{}, fmt.Errorf(".%s: %w", key, err)
+			}
+			vals[attr] = ev
+		}
+		for k := range obj {
+			if !known[k] {
+				return tftypes.Value{}, fmt.Errorf("unexpected property %q", string(k))
+			}
+		}
+		return tftypes.NewValue(t, vals), nil
+	case tftypes.Tuple:
+		return tftypes.Value{}, fmt.Errorf("tuple types are not supported")
+	}
+
+	switch {
+	case t.Is(tftypes.String):
+		if !pv.IsString() {
+			return tftypes.Value{}, fmt.Errorf("expected a string, got %v", pv.TypeString())
+		}
+		return tftypes.NewValue(t, pv.StringValue()), nil
+	case t.Is(tftypes.Bool):
+		if !pv.IsBool() {
+			return tftypes.Value{}, fmt.Errorf("expected a boolean, got %v", pv.TypeString())
+		}
+		return tftypes.NewValue(t, pv.BoolValue()), nil
+	case t.Is(tftypes.Number):
+		if !pv.IsNumber() {
+			return tftypes.Value{}, fmt.Errorf("expected a number, got %v", pv.TypeString())
+		}
+		return tftypes.NewValue(t, pv.NumberValue()), nil
+	}
+	return tftypes.Value{}, fmt.Errorf("unsupported type %v", t)
+}
+
+func encodeElements(elementType tftypes.Type, pv resource.PropertyValue) ([]tftypes.Value, error) {
+	if !pv.IsArray() {
+		return nil, fmt.Errorf("expected a list, got %v", pv.TypeString())
+	}
+	arr := pv.ArrayValue()
+	vals := make([]tftypes.Value, len(arr))
+	for i, e := range arr {
+		ev, err := EncodeValue(elementType, e)
+		if err != nil {
+			return nil, fmt.Errorf("[%d]: %w", i, err)
+		}
+		vals[i] = ev
+	}
+	return vals, nil
+}
+
+// encodeDynamic performs a best-effort conversion for DynamicPseudoType constraints at
+// the data level, inferring a concrete Terraform type from the value. Object property
+// names are passed through unmodified, mirroring the dynamic encoding used elsewhere in
+// the bridge.
+func encodeDynamic(pv resource.PropertyValue) (tftypes.Value, error) {
+	switch {
+	case pv.IsNull():
+		return tftypes.NewValue(tftypes.DynamicPseudoType, nil), nil
+	case pv.IsBool():
+		return tftypes.NewValue(tftypes.Bool, pv.BoolValue()), nil
+	case pv.IsNumber():
+		return tftypes.NewValue(tftypes.Number, pv.NumberValue()), nil
+	case pv.IsString():
+		return tftypes.NewValue(tftypes.String, pv.StringValue()), nil
+	case pv.IsArray():
+		vals := make([]tftypes.Value, 0, len(pv.ArrayValue()))
+		for i, e := range pv.ArrayValue() {
+			ev, err := encodeDynamic(e)
+			if err != nil {
+				return tftypes.Value{}, fmt.Errorf("[%d]: %w", i, err)
+			}
+			vals = append(vals, ev)
+		}
+		// Elements of a Terraform list must share one type; fall back to a tuple for
+		// heterogeneous arrays.
+		if commonType, err := tftypes.TypeFromElements(vals); err == nil {
+			return tftypes.NewValue(tftypes.List{ElementType: commonType}, vals), nil
+		}
+		types := make([]tftypes.Type, len(vals))
+		for i, v := range vals {
+			types[i] = v.Type()
+		}
+		return tftypes.NewValue(tftypes.Tuple{ElementTypes: types}, vals), nil
+	case pv.IsObject():
+		objType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{}}
+		vals := map[string]tftypes.Value{}
+		for k, v := range pv.ObjectValue() {
+			ev, err := encodeDynamic(v)
+			if err != nil {
+				return tftypes.Value{}, fmt.Errorf(".%s: %w", string(k), err)
+			}
+			vals[string(k)] = ev
+			objType.AttributeTypes[string(k)] = ev.Type()
+		}
+		return tftypes.NewValue(objType, vals), nil
+	case pv.IsSecret():
+		return encodeDynamic(pv.SecretValue().Element)
+	case pv.IsOutput() && pv.OutputValue().Known:
+		return encodeDynamic(pv.OutputValue().Element)
+	default:
+		return tftypes.Value{}, fmt.Errorf("cannot encode %v as a dynamic value", pv.TypeString())
+	}
+}
+
+// DecodeValue converts a Terraform value of the given type constraint back into a Pulumi
+// property value. When the constraint is DynamicPseudoType the value decodes by its own
+// concrete type, with object property names passed through unmodified.
+func DecodeValue(t tftypes.Type, v tftypes.Value) (resource.PropertyValue, error) {
+	if !v.IsKnown() {
+		return resource.PropertyValue{}, fmt.Errorf("unexpected unknown value")
+	}
+	if v.IsNull() {
+		return resource.NewPropertyValue(nil), nil
+	}
+
+	if t.Is(tftypes.DynamicPseudoType) {
+		return decodeDynamic(v)
+	}
+
+	switch t := t.(type) {
+	case tftypes.List:
+		return decodeElements(t.ElementType, v)
+	case tftypes.Set:
+		return decodeElements(t.ElementType, v)
+	case tftypes.Map:
+		var elements map[string]tftypes.Value
+		if err := v.As(&elements); err != nil {
+			return resource.PropertyValue{}, err
+		}
+		result := make(resource.PropertyMap, len(elements))
+		for k, e := range elements {
+			ev, err := DecodeValue(t.ElementType, e)
+			if err != nil {
+				return resource.PropertyValue{}, fmt.Errorf("[%q]: %w", k, err)
+			}
+			result[resource.PropertyKey(k)] = ev
+		}
+		return resource.NewObjectProperty(result), nil
+	case tftypes.Object:
+		var attrs map[string]tftypes.Value
+		if err := v.As(&attrs); err != nil {
+			return resource.PropertyValue{}, err
+		}
+		result := make(resource.PropertyMap, len(attrs))
+		for attr, e := range attrs {
+			attrType, ok := t.AttributeTypes[attr]
+			if !ok {
+				return resource.PropertyValue{}, fmt.Errorf("unexpected attribute %q", attr)
+			}
+			ev, err := DecodeValue(attrType, e)
+			if err != nil {
+				return resource.PropertyValue{}, fmt.Errorf(".%s: %w", attr, err)
+			}
+			result[resource.PropertyKey(PropertyName(attr))] = ev
+		}
+		return resource.NewObjectProperty(result), nil
+	case tftypes.Tuple:
+		return resource.PropertyValue{}, fmt.Errorf("tuple types are not supported")
+	}
+
+	switch {
+	case t.Is(tftypes.String):
+		var s string
+		if err := v.As(&s); err != nil {
+			return resource.PropertyValue{}, err
+		}
+		return resource.NewStringProperty(s), nil
+	case t.Is(tftypes.Bool):
+		var b bool
+		if err := v.As(&b); err != nil {
+			return resource.PropertyValue{}, err
+		}
+		return resource.NewBoolProperty(b), nil
+	case t.Is(tftypes.Number):
+		var n big.Float
+		if err := v.As(&n); err != nil {
+			return resource.PropertyValue{}, err
+		}
+		f, _ := n.Float64()
+		return resource.NewNumberProperty(f), nil
+	}
+	return resource.PropertyValue{}, fmt.Errorf("unsupported type %v", t)
+}
+
+func decodeElements(elementType tftypes.Type, v tftypes.Value) (resource.PropertyValue, error) {
+	var elements []tftypes.Value
+	if err := v.As(&elements); err != nil {
+		return resource.PropertyValue{}, err
+	}
+	result := make([]resource.PropertyValue, len(elements))
+	for i, e := range elements {
+		ev, err := DecodeValue(elementType, e)
+		if err != nil {
+			return resource.PropertyValue{}, fmt.Errorf("[%d]: %w", i, err)
+		}
+		result[i] = ev
+	}
+	return resource.NewArrayProperty(result), nil
+}
+
+// decodeDynamic decodes a value by its own concrete type, without renaming object
+// property names.
+func decodeDynamic(v tftypes.Value) (resource.PropertyValue, error) {
+	switch {
+	case !v.IsKnown():
+		return resource.PropertyValue{}, fmt.Errorf("unexpected unknown value")
+	case v.IsNull():
+		return resource.NewPropertyValue(nil), nil
+	case v.Type().Is(tftypes.Bool):
+		var b bool
+		if err := v.As(&b); err != nil {
+			return resource.PropertyValue{}, err
+		}
+		return resource.NewBoolProperty(b), nil
+	case v.Type().Is(tftypes.Number):
+		var n big.Float
+		if err := v.As(&n); err != nil {
+			return resource.PropertyValue{}, err
+		}
+		f, _ := n.Float64()
+		return resource.NewNumberProperty(f), nil
+	case v.Type().Is(tftypes.String):
+		var s string
+		if err := v.As(&s); err != nil {
+			return resource.PropertyValue{}, err
+		}
+		return resource.NewStringProperty(s), nil
+	case v.Type().Is(tftypes.List{}), v.Type().Is(tftypes.Set{}), v.Type().Is(tftypes.Tuple{}):
+		var elements []tftypes.Value
+		if err := v.As(&elements); err != nil {
+			return resource.PropertyValue{}, err
+		}
+		result := make([]resource.PropertyValue, len(elements))
+		for i, e := range elements {
+			ev, err := decodeDynamic(e)
+			if err != nil {
+				return resource.PropertyValue{}, fmt.Errorf("[%d]: %w", i, err)
+			}
+			result[i] = ev
+		}
+		return resource.NewArrayProperty(result), nil
+	case v.Type().Is(tftypes.Map{}), v.Type().Is(tftypes.Object{}):
+		var elements map[string]tftypes.Value
+		if err := v.As(&elements); err != nil {
+			return resource.PropertyValue{}, err
+		}
+		result := make(resource.PropertyMap, len(elements))
+		for k, e := range elements {
+			ev, err := decodeDynamic(e)
+			if err != nil {
+				return resource.PropertyValue{}, fmt.Errorf(".%s: %w", k, err)
+			}
+			result[resource.PropertyKey(k)] = ev
+		}
+		return resource.NewObjectProperty(result), nil
+	default:
+		return resource.PropertyValue{}, fmt.Errorf("unsupported type %v", v.Type())
+	}
+}

--- a/pkg/internal/functions/functions_test.go
+++ b/pkg/internal/functions/functions_test.go
@@ -1,0 +1,247 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+func TestArgumentNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		fn       shim.Function
+		expected []string
+	}{
+		{
+			name: "named parameters",
+			fn: shim.Function{
+				Parameters: []shim.FunctionParameter{
+					{Name: "arn", Type: tftypes.String},
+					{Name: "account_id", Type: tftypes.String},
+				},
+			},
+			expected: []string{"arn", "accountId"},
+		},
+		{
+			name: "empty names",
+			fn: shim.Function{
+				Parameters: []shim.FunctionParameter{
+					{Type: tftypes.String},
+					{Type: tftypes.String},
+				},
+			},
+			expected: []string{"arg1", "arg2"},
+		},
+		{
+			name: "duplicate names",
+			fn: shim.Function{
+				Parameters: []shim.FunctionParameter{
+					{Name: "value", Type: tftypes.String},
+					{Name: "value", Type: tftypes.String},
+					{Name: "value", Type: tftypes.String},
+				},
+			},
+			expected: []string{"value", "value2", "value3"},
+		},
+		{
+			name: "variadic parameter",
+			fn: shim.Function{
+				Parameters: []shim.FunctionParameter{
+					{Name: "separator", Type: tftypes.String},
+				},
+				VariadicParameter: &shim.FunctionParameter{Name: "parts", Type: tftypes.String},
+			},
+			expected: []string{"separator", "parts"},
+		},
+		{
+			name: "unnamed variadic parameter",
+			fn: shim.Function{
+				Parameters: []shim.FunctionParameter{
+					{Name: "separator", Type: tftypes.String},
+				},
+				VariadicParameter: &shim.FunctionParameter{Type: tftypes.String},
+			},
+			expected: []string{"separator", "arg2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, ArgumentNames(tt.fn))
+		})
+	}
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	objType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"account_id": tftypes.String,
+			"port":       tftypes.Number,
+			"tags":       tftypes.Map{ElementType: tftypes.String},
+		},
+		OptionalAttributes: map[string]struct{}{
+			"tags": {},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		typ   tftypes.Type
+		value resource.PropertyValue
+	}{
+		{"string", tftypes.String, resource.NewStringProperty("hello")},
+		{"number", tftypes.Number, resource.NewNumberProperty(42.5)},
+		{"bool", tftypes.Bool, resource.NewBoolProperty(true)},
+		{"null string", tftypes.String, resource.NewNullProperty()},
+		{
+			"list of strings",
+			tftypes.List{ElementType: tftypes.String},
+			resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("a"),
+				resource.NewStringProperty("b"),
+			}),
+		},
+		{
+			"set of numbers",
+			tftypes.Set{ElementType: tftypes.Number},
+			resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewNumberProperty(1),
+				resource.NewNumberProperty(2),
+			}),
+		},
+		{
+			"map of strings",
+			tftypes.Map{ElementType: tftypes.String},
+			resource.NewObjectProperty(resource.PropertyMap{
+				"key_with_underscores": resource.NewStringProperty("v"),
+			}),
+		},
+		{
+			"object with renamed attributes",
+			objType,
+			resource.NewObjectProperty(resource.PropertyMap{
+				"accountId": resource.NewStringProperty("12345"),
+				"port":      resource.NewNumberProperty(443),
+				"tags": resource.NewObjectProperty(resource.PropertyMap{
+					"env": resource.NewStringProperty("prod"),
+				}),
+			}),
+		},
+		{"dynamic string", tftypes.DynamicPseudoType, resource.NewStringProperty("s")},
+		{"dynamic bool", tftypes.DynamicPseudoType, resource.NewBoolProperty(false)},
+		{
+			"dynamic list",
+			tftypes.DynamicPseudoType,
+			resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewNumberProperty(1),
+				resource.NewNumberProperty(2),
+			}),
+		},
+		{
+			"dynamic object",
+			tftypes.DynamicPseudoType,
+			resource.NewObjectProperty(resource.PropertyMap{
+				"snake_key": resource.NewStringProperty("not renamed"),
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			encoded, err := EncodeValue(tt.typ, tt.value)
+			require.NoError(t, err)
+			decoded, err := DecodeValue(tt.typ, encoded)
+			require.NoError(t, err)
+			assert.Equal(t, tt.value, decoded)
+		})
+	}
+}
+
+func TestEncodeObjectFillsMissingAttributes(t *testing.T) {
+	t.Parallel()
+
+	typ := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"required_attr": tftypes.String,
+			"optional_attr": tftypes.String,
+		},
+		OptionalAttributes: map[string]struct{}{"optional_attr": {}},
+	}
+	encoded, err := EncodeValue(typ, resource.NewObjectProperty(resource.PropertyMap{
+		"requiredAttr": resource.NewStringProperty("v"),
+	}))
+	require.NoError(t, err)
+
+	assert.Equal(t, tftypes.NewValue(typ, map[string]tftypes.Value{
+		"required_attr": tftypes.NewValue(tftypes.String, "v"),
+		"optional_attr": tftypes.NewValue(tftypes.String, nil),
+	}), encoded)
+}
+
+func TestEncodeErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("type mismatch", func(t *testing.T) {
+		t.Parallel()
+		_, err := EncodeValue(tftypes.String, resource.NewNumberProperty(1))
+		assert.EqualError(t, err, "expected a string, got number")
+	})
+
+	t.Run("unexpected object property", func(t *testing.T) {
+		t.Parallel()
+		typ := tftypes.Object{AttributeTypes: map[string]tftypes.Type{"a": tftypes.String}}
+		_, err := EncodeValue(typ, resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewStringProperty("v"),
+			"b": resource.NewStringProperty("v"),
+		}))
+		assert.EqualError(t, err, `unexpected property "b"`)
+	})
+
+	t.Run("tuple unsupported", func(t *testing.T) {
+		t.Parallel()
+		typ := tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String}}
+		_, err := EncodeValue(typ, resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("v"),
+		}))
+		assert.EqualError(t, err, "tuple types are not supported")
+	})
+
+	t.Run("unknown value", func(t *testing.T) {
+		t.Parallel()
+		_, err := EncodeValue(tftypes.String, resource.MakeComputed(resource.NewStringProperty("")))
+		assert.EqualError(t, err, "unexpected unknown value")
+	})
+}
+
+func TestEncodeSecretUnwraps(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := EncodeValue(tftypes.String, resource.MakeSecret(resource.NewStringProperty("s3cret")))
+	require.NoError(t, err)
+	assert.Equal(t, tftypes.NewValue(tftypes.String, "s3cret"), encoded)
+}

--- a/pkg/internal/functions/functions_test.go
+++ b/pkg/internal/functions/functions_test.go
@@ -15,6 +15,7 @@
 package functions
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -22,6 +23,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/convert"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -94,154 +97,133 @@ func TestArgumentNames(t *testing.T) {
 	}
 }
 
-func TestEncodeDecodeRoundTrip(t *testing.T) {
+func TestSchemaFromTypeErrors(t *testing.T) {
 	t.Parallel()
 
-	objType := tftypes.Object{
-		AttributeTypes: map[string]tftypes.Type{
-			"account_id": tftypes.String,
-			"port":       tftypes.Number,
-			"tags":       tftypes.Map{ElementType: tftypes.String},
+	_, err := SchemaFromType(tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String}})
+	assert.EqualError(t, err, "tuple types are not supported")
+
+	_, err = SchemaMapFromObject(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"pair": tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String}},
+	}})
+	assert.EqualError(t, err, `attribute "pair": tuple types are not supported`)
+}
+
+// Object attribute naming follows the standard bridge rules, including pluralization of
+// list-typed attributes.
+func TestObjectAttributeNaming(t *testing.T) {
+	t.Parallel()
+
+	obj := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"account_id": tftypes.String,
+		"rule":       tftypes.List{ElementType: tftypes.String},
+	}}
+	m, err := SchemaMapFromObject(obj)
+	require.NoError(t, err)
+
+	assert.Equal(t, "accountId", tfbridge.TerraformToPulumiNameV2("account_id", m, nil))
+	assert.Equal(t, "rules", tfbridge.TerraformToPulumiNameV2("rule", m, nil))
+}
+
+// The synthetic schemas drive the pkg/convert encoders and decoders; values round-trip
+// with argument names pinned exactly and nested object attributes renamed.
+func TestArgumentsSchemaRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	fn := shim.Function{
+		Parameters: []shim.FunctionParameter{
+			{Name: "value", Type: tftypes.String},
+			{
+				Name: "config",
+				Type: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"account_id": tftypes.String,
+				}},
+			},
 		},
-		OptionalAttributes: map[string]struct{}{
-			"tags": {},
-		},
+		VariadicParameter: &shim.FunctionParameter{Name: "parts", Type: tftypes.Number},
+		Return:            tftypes.String,
+	}
+	argNames := ArgumentNames(fn)
+	require.Equal(t, []string{"value", "config", "parts"}, argNames)
+
+	os, err := ArgumentsSchema(fn, argNames)
+	require.NoError(t, err)
+
+	enc, err := convert.NewObjectEncoder(convert.ObjectSchema{
+		SchemaMap:   os.SchemaMap,
+		SchemaInfos: os.SchemaInfos,
+		Object:      &os.Type,
+	})
+	require.NoError(t, err)
+	dec, err := convert.NewObjectDecoder(convert.ObjectSchema{
+		SchemaMap:   os.SchemaMap,
+		SchemaInfos: os.SchemaInfos,
+		Object:      &os.Type,
+	})
+	require.NoError(t, err)
+
+	args := resource.PropertyMap{
+		"value": resource.NewStringProperty("v"),
+		"config": resource.NewObjectProperty(resource.PropertyMap{
+			"accountId": resource.NewStringProperty("12345"),
+		}),
+		"parts": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewNumberProperty(1),
+			resource.NewNumberProperty(2),
+		}),
 	}
 
-	tests := []struct {
-		name  string
-		typ   tftypes.Type
-		value resource.PropertyValue
-	}{
-		{"string", tftypes.String, resource.NewStringProperty("hello")},
-		{"number", tftypes.Number, resource.NewNumberProperty(42.5)},
-		{"bool", tftypes.Bool, resource.NewBoolProperty(true)},
-		{"null string", tftypes.String, resource.NewNullProperty()},
-		{
-			"list of strings",
-			tftypes.List{ElementType: tftypes.String},
-			resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewStringProperty("a"),
-				resource.NewStringProperty("b"),
-			}),
-		},
-		{
-			"set of numbers",
-			tftypes.Set{ElementType: tftypes.Number},
-			resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewNumberProperty(1),
-				resource.NewNumberProperty(2),
-			}),
-		},
-		{
-			"map of strings",
-			tftypes.Map{ElementType: tftypes.String},
-			resource.NewObjectProperty(resource.PropertyMap{
-				"key_with_underscores": resource.NewStringProperty("v"),
-			}),
-		},
-		{
-			"object with renamed attributes",
-			objType,
-			resource.NewObjectProperty(resource.PropertyMap{
-				"accountId": resource.NewStringProperty("12345"),
-				"port":      resource.NewNumberProperty(443),
-				"tags": resource.NewObjectProperty(resource.PropertyMap{
-					"env": resource.NewStringProperty("prod"),
-				}),
-			}),
-		},
-		{"dynamic string", tftypes.DynamicPseudoType, resource.NewStringProperty("s")},
-		{"dynamic bool", tftypes.DynamicPseudoType, resource.NewBoolProperty(false)},
-		{
-			"dynamic list",
-			tftypes.DynamicPseudoType,
-			resource.NewArrayProperty([]resource.PropertyValue{
-				resource.NewNumberProperty(1),
-				resource.NewNumberProperty(2),
-			}),
-		},
-		{
-			"dynamic object",
-			tftypes.DynamicPseudoType,
-			resource.NewObjectProperty(resource.PropertyMap{
-				"snake_key": resource.NewStringProperty("not renamed"),
-			}),
-		},
-	}
+	encoded, err := convert.EncodePropertyMap(enc, args)
+	require.NoError(t, err)
+	decoded, err := convert.DecodePropertyMap(context.Background(), dec, encoded)
+	require.NoError(t, err)
+	assert.Equal(t, args, decoded)
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			encoded, err := EncodeValue(tt.typ, tt.value)
-			require.NoError(t, err)
-			decoded, err := DecodeValue(tt.typ, encoded)
-			require.NoError(t, err)
-			assert.Equal(t, tt.value, decoded)
+func TestResultSchema(t *testing.T) {
+	t.Parallel()
+
+	t.Run("object return decodes directly", func(t *testing.T) {
+		t.Parallel()
+		fn := shim.Function{
+			Return: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+				"account_id": tftypes.String,
+			}},
+		}
+		os, isObject, err := ResultSchema(fn, "result")
+		require.NoError(t, err)
+		assert.True(t, isObject)
+		assert.Equal(t, fn.Return, os.Type)
+	})
+
+	t.Run("scalar return wraps into a single property", func(t *testing.T) {
+		t.Parallel()
+		fn := shim.Function{Return: tftypes.List{ElementType: tftypes.String}}
+		os, isObject, err := ResultSchema(fn, "result")
+		require.NoError(t, err)
+		assert.False(t, isObject)
+
+		dec, err := convert.NewObjectDecoder(convert.ObjectSchema{
+			SchemaMap:   os.SchemaMap,
+			SchemaInfos: os.SchemaInfos,
+			Object:      &os.Type,
 		})
-	}
-}
+		require.NoError(t, err)
 
-func TestEncodeObjectFillsMissingAttributes(t *testing.T) {
-	t.Parallel()
+		value := tftypes.NewValue(os.Type, map[string]tftypes.Value{
+			"result": tftypes.NewValue(fn.Return, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "a"),
+			}),
+		})
+		decoded, err := convert.DecodePropertyMap(context.Background(), dec, value)
+		require.NoError(t, err)
 
-	typ := tftypes.Object{
-		AttributeTypes: map[string]tftypes.Type{
-			"required_attr": tftypes.String,
-			"optional_attr": tftypes.String,
-		},
-		OptionalAttributes: map[string]struct{}{"optional_attr": {}},
-	}
-	encoded, err := EncodeValue(typ, resource.NewObjectProperty(resource.PropertyMap{
-		"requiredAttr": resource.NewStringProperty("v"),
-	}))
-	require.NoError(t, err)
-
-	assert.Equal(t, tftypes.NewValue(typ, map[string]tftypes.Value{
-		"required_attr": tftypes.NewValue(tftypes.String, "v"),
-		"optional_attr": tftypes.NewValue(tftypes.String, nil),
-	}), encoded)
-}
-
-func TestEncodeErrors(t *testing.T) {
-	t.Parallel()
-
-	t.Run("type mismatch", func(t *testing.T) {
-		t.Parallel()
-		_, err := EncodeValue(tftypes.String, resource.NewNumberProperty(1))
-		assert.EqualError(t, err, "expected a string, got number")
+		// The wrapped property name is pinned: a list-typed result must not
+		// pluralize to "results".
+		assert.Equal(t, resource.PropertyMap{
+			"result": resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("a"),
+			}),
+		}, decoded)
 	})
-
-	t.Run("unexpected object property", func(t *testing.T) {
-		t.Parallel()
-		typ := tftypes.Object{AttributeTypes: map[string]tftypes.Type{"a": tftypes.String}}
-		_, err := EncodeValue(typ, resource.NewObjectProperty(resource.PropertyMap{
-			"a": resource.NewStringProperty("v"),
-			"b": resource.NewStringProperty("v"),
-		}))
-		assert.EqualError(t, err, `unexpected property "b"`)
-	})
-
-	t.Run("tuple unsupported", func(t *testing.T) {
-		t.Parallel()
-		typ := tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String}}
-		_, err := EncodeValue(typ, resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("v"),
-		}))
-		assert.EqualError(t, err, "tuple types are not supported")
-	})
-
-	t.Run("unknown value", func(t *testing.T) {
-		t.Parallel()
-		_, err := EncodeValue(tftypes.String, resource.MakeComputed(resource.NewStringProperty("")))
-		assert.EqualError(t, err, "unexpected unknown value")
-	})
-}
-
-func TestEncodeSecretUnwraps(t *testing.T) {
-	t.Parallel()
-
-	encoded, err := EncodeValue(tftypes.String, resource.MakeSecret(resource.NewStringProperty("s3cret")))
-	require.NoError(t, err)
-	assert.Equal(t, tftypes.NewValue(tftypes.String, "s3cret"), encoded)
 }

--- a/pkg/tfgen/docs.go
+++ b/pkg/tfgen/docs.go
@@ -151,6 +151,8 @@ const (
 	ResourceDocs DocKind = "resources"
 	// DataSourceDocs indicates documentation pertaining to data source entities.
 	DataSourceDocs DocKind = "data-sources"
+	// FunctionDocs indicates documentation pertaining to provider-defined functions.
+	FunctionDocs DocKind = "functions"
 	// InstallationDocs indicates documentation pertaining to provider configuration and installation.
 	InstallationDocs DocKind = "installation"
 )
@@ -161,6 +163,8 @@ func (k DocKind) String() string {
 		return "data source"
 	case ResourceDocs:
 		return "resource"
+	case FunctionDocs:
+		return "function"
 	default:
 		return ""
 	}
@@ -197,6 +201,8 @@ func getDocsForResource(g *Generator, source DocsSource, kind DocKind,
 		docFile, err = source.getResource(rawname, docInfo)
 	case DataSourceDocs:
 		docFile, err = source.getDatasource(rawname, docInfo)
+	case FunctionDocs:
+		docFile, err = source.getFunction(rawname, docInfo)
 	default:
 		panic("unknown docs kind")
 	}

--- a/pkg/tfgen/docs_test.go
+++ b/pkg/tfgen/docs_test.go
@@ -2709,6 +2709,10 @@ func (m mockSource) getDatasource(rawname string, info *tfbridge.DocInfo) (*DocF
 	return nil, nil
 }
 
+func (m mockSource) getFunction(rawname string, info *tfbridge.DocInfo) (*DocFile, error) {
+	return nil, nil
+}
+
 func (m mockSource) getInstallation(info *tfbridge.DocInfo) (*DocFile, error) {
 	f, ok := m["index.md"]
 	if !ok {

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1316,6 +1316,14 @@ func (g *Generator) gatherPackage() (*pkg, error) {
 		pack.addModuleMap(dsmods)
 	}
 
+	// Gather up all provider-defined functions and merge them in.
+	fnmods, err := g.gatherFunctions()
+	if err != nil {
+		return nil, pkgerrors.Wrapf(err, "problem gathering provider functions")
+	} else if fnmods != nil {
+		pack.addModuleMap(fnmods)
+	}
+
 	// Now go ahead and merge in any overlays into the modules if there are any.
 	olaymods, err := g.gatherOverlays()
 	if err != nil {

--- a/pkg/tfgen/generate_functions.go
+++ b/pkg/tfgen/generate_functions.go
@@ -386,7 +386,7 @@ func (c *functionTypeGen) objectSpec(t tftypes.Object, nameHint string) (pschema
 	if err != nil {
 		return pschema.ObjectTypeSpec{}, err
 	}
-	for _, attr := range functions.SortedAttributeNames(t) {
+	for _, attr := range sortedAttributeNames(t) {
 		name := tfbridge.TerraformToPulumiNameV2(attr, syntheticSchema, nil)
 		if _, conflict := spec.Properties[name]; conflict {
 			return pschema.ObjectTypeSpec{}, fmt.Errorf(
@@ -402,4 +402,14 @@ func (c *functionTypeGen) objectSpec(t tftypes.Object, nameHint string) (pschema
 		}
 	}
 	return spec, nil
+}
+
+// sortedAttributeNames returns the attribute names of t in a stable order.
+func sortedAttributeNames(t tftypes.Object) []string {
+	attrs := make([]string, 0, len(t.AttributeTypes))
+	for attr := range t.AttributeTypes {
+		attrs = append(attrs, attr)
+	}
+	sort.Strings(attrs)
+	return attrs
 }

--- a/pkg/tfgen/generate_functions.go
+++ b/pkg/tfgen/generate_functions.go
@@ -1,0 +1,399 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/functions"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+)
+
+// providerFunc is a Terraform provider-defined function that is exposed as a Pulumi
+// invoke with positional arguments (multiArgumentInputs) and a direct return type.
+type providerFunc struct {
+	mod                tokens.Module
+	name               string
+	tok                tokens.ModuleMember
+	tfName             string
+	fn                 shim.Function
+	info               *tfbridge.FunctionInfo
+	doc                string
+	deprecationMessage string
+}
+
+func (pf *providerFunc) Name() string { return pf.name }
+func (pf *providerFunc) Doc() string  { return pf.doc }
+
+// gatherFunctions returns all modules and the provider-defined functions they contain.
+func (g *Generator) gatherFunctions() (moduleMap, error) {
+	functions := g.provider().Functions()
+	if len(functions) == 0 {
+		return nil, nil
+	}
+	modules := make(moduleMap)
+
+	skipFailBuildOnMissingMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_MISSING_MAPPING_ERROR")) ||
+		cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_PROVIDER_MAP_ERROR"))
+	skipFailBuildOnExtraMapError := cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_EXTRA_MAPPING_ERROR"))
+
+	var functionMappingErrors error
+
+	names := make([]string, 0, len(functions))
+	for name := range functions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var fnerr error
+	seen := make(map[string]bool)
+	for _, name := range names {
+		fninfo := g.info.Functions[name]
+		if fninfo == nil {
+			if sliceContains(g.info.IgnoreMappings, name) {
+				g.debug("TF function %q not found in provider map but ignored", name)
+				continue
+			}
+
+			if !skipFailBuildOnMissingMapError {
+				functionMappingErrors = multierror.Append(functionMappingErrors,
+					fmt.Errorf("TF function %q not mapped to the Pulumi provider", name))
+			} else {
+				g.warn("TF function %q not found in provider map", name)
+			}
+			continue
+		}
+		seen[name] = true
+
+		fun, err := g.gatherFunction(name, functions[name], fninfo)
+		if err != nil {
+			// Keep track of the error, but keep going, so we can expose more at once.
+			fnerr = multierror.Append(fnerr, err)
+		} else {
+			modules.ensureModule(fun.mod).addMember(fun)
+		}
+	}
+	if fnerr != nil {
+		return nil, fnerr
+	}
+
+	// Emit an error if there is a map but some names didn't match.
+	var mapped []string
+	for name := range g.info.Functions {
+		mapped = append(mapped, name)
+	}
+	sort.Strings(mapped)
+	for _, name := range mapped {
+		if !seen[name] {
+			if !skipFailBuildOnExtraMapError {
+				functionMappingErrors = multierror.Append(functionMappingErrors,
+					fmt.Errorf("Pulumi token %q is mapped to TF provider function %q, but no such "+
+						"function found. Remove the mapping and try again",
+						g.info.Functions[name].Tok, name))
+			} else {
+				g.warn("Pulumi token %q is mapped to TF provider function %q, but no such "+
+					"function found. The mapping will be ignored in the generated provider",
+					g.info.Functions[name].Tok, name)
+			}
+		}
+	}
+	if functionMappingErrors != nil {
+		return nil, functionMappingErrors
+	}
+
+	if err := g.checkFunctionTokenCollisions(); err != nil {
+		return nil, err
+	}
+
+	return modules, nil
+}
+
+// checkFunctionTokenCollisions rejects provider functions whose Pulumi token collides
+// with a data source invoke token. Both share the "functions" section of the Pulumi
+// schema, while in Terraform they live in separate namespaces; a collision would let
+// one silently shadow the other.
+func (g *Generator) checkFunctionTokenCollisions() error {
+	dataSourceToks := make(map[string]string, len(g.info.DataSources))
+	for tfName, ds := range g.info.DataSources {
+		dataSourceToks[string(ds.Tok)] = tfName
+	}
+	var errs multierror.Error
+	names := make([]string, 0, len(g.info.Functions))
+	for name := range g.info.Functions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		tok := string(g.info.Functions[name].Tok)
+		if dsName, ok := dataSourceToks[tok]; ok {
+			errs.Errors = append(errs.Errors, fmt.Errorf(
+				"TF function %q and TF data source %q are both mapped to the Pulumi token %q; "+
+					"override one of the mappings to avoid the collision", name, dsName, tok))
+		}
+	}
+	return errs.ErrorOrNil()
+}
+
+// gatherFunction returns the module member for a single provider-defined function.
+func (g *Generator) gatherFunction(rawname string,
+	fn shim.Function, info *tfbridge.FunctionInfo,
+) (*providerFunc, error) {
+	name, moduleName := functionName(rawname, info)
+	mod := tokens.NewModuleToken(g.pkg, moduleName)
+	tok := tokens.NewModuleMemberToken(mod, name)
+
+	// Collect documentation information for this function.
+	var entityDocs entityDocs
+	if !g.noDocsRepo {
+		source := NewGitRepoDocsSource(g)
+		docs, err := getDocsForResource(g, source, FunctionDocs, rawname, info)
+		if err == nil {
+			entityDocs = docs
+		} else if !g.checkNoDocsError(err) {
+			return nil, err
+		}
+	}
+
+	doc := entityDocs.Description
+	if doc == "" {
+		// Fall back to the documentation the provider ships in its schema.
+		doc = fn.Description
+		if fn.Summary != "" {
+			if doc == "" {
+				doc = fn.Summary
+			} else {
+				doc = fn.Summary + "\n\n" + doc
+			}
+		}
+	}
+
+	deprecationMessage := info.DeprecationMessage
+	if deprecationMessage == "" {
+		deprecationMessage = fn.DeprecationMessage
+	}
+
+	return &providerFunc{
+		mod:                mod,
+		name:               name.String(),
+		tok:                tok,
+		tfName:             rawname,
+		fn:                 fn,
+		info:               info,
+		doc:                doc,
+		deprecationMessage: deprecationMessage,
+	}, nil
+}
+
+// functionName translates a Terraform function name into its Pulumi name equivalent,
+// plus a module name.
+func functionName(tfName string, info *tfbridge.FunctionInfo) (tokens.ModuleMemberName, tokens.ModuleName) {
+	if info == nil || info.Tok == "" {
+		// Terraform function names are unprefixed; functions map into the top-level
+		// module by default.
+		name := tfbridge.TerraformToPulumiNameV2(tfName, nil, nil)
+		return tokens.ModuleMemberName(name), tokens.ModuleName(string(indexMod) + "/" + name)
+	}
+	return info.Tok.Name(), info.Tok.Module().Name()
+}
+
+// genProviderFunc generates the Pulumi schema for a provider-defined function.
+//
+// Terraform positional parameters project via multiArgumentInputs and the return type
+// projects via returnType, possibly as a direct non-object return. A trailing variadic
+// parameter projects to a final list-typed argument, since the Pulumi schema has no
+// variadic concept. Auxiliary named object types are added to types.
+func (g *schemaGenerator) genProviderFunc(
+	fun *providerFunc, types map[string]pschema.ComplexTypeSpec,
+) (pschema.FunctionSpec, error) {
+	spec := pschema.FunctionSpec{
+		DeprecationMessage: fun.deprecationMessage,
+	}
+	if fun.doc != "" {
+		spec.Description = g.genDocComment(fun.doc)
+	}
+
+	conv := &functionTypeGen{pkg: g.pkg, tfName: fun.tfName, types: types}
+	fn := fun.fn
+	argNames := functions.ArgumentNames(fn)
+
+	if len(argNames) > 0 {
+		inputs := &pschema.ObjectTypeSpec{
+			Type:       "object",
+			Properties: map[string]pschema.PropertySpec{},
+		}
+		multiArgs := make([]string, 0, len(argNames))
+
+		// A parameter that allows null is only projected as optional if every later
+		// parameter is optional too: target languages cannot express a required
+		// positional argument after an optional one.
+		required := make([]bool, len(fn.Parameters))
+		anyRequiredAfter := false
+		for i := len(fn.Parameters) - 1; i >= 0; i-- {
+			required[i] = !fn.Parameters[i].AllowNullValue || anyRequiredAfter
+			if required[i] {
+				anyRequiredAfter = true
+			}
+		}
+
+		for i, p := range fn.Parameters {
+			name := argNames[i]
+			ts, err := conv.typeSpec(p.Type, fun.name+upperFirst(name))
+			if err != nil {
+				return pschema.FunctionSpec{}, fmt.Errorf("function %q: parameter %q: %w", fun.tfName, name, err)
+			}
+			prop := pschema.PropertySpec{TypeSpec: ts}
+			if p.Description != "" {
+				prop.Description = g.genDocComment(p.Description)
+			}
+			inputs.Properties[name] = prop
+			multiArgs = append(multiArgs, name)
+			if required[i] {
+				inputs.Required = append(inputs.Required, name)
+			}
+		}
+
+		if v := fn.VariadicParameter; v != nil {
+			name := argNames[len(fn.Parameters)]
+			elem, err := conv.typeSpec(v.Type, fun.name+upperFirst(name))
+			if err != nil {
+				return pschema.FunctionSpec{}, fmt.Errorf("function %q: variadic parameter %q: %w",
+					fun.tfName, name, err)
+			}
+			prop := pschema.PropertySpec{TypeSpec: pschema.TypeSpec{Type: "array", Items: &elem}}
+			if v.Description != "" {
+				prop.Description = g.genDocComment(v.Description)
+			}
+			// A variadic parameter accepts zero or more arguments, so it is never
+			// required.
+			inputs.Properties[name] = prop
+			multiArgs = append(multiArgs, name)
+		}
+
+		sort.Strings(inputs.Required)
+		spec.Inputs = inputs
+		spec.MultiArgumentInputs = multiArgs
+	}
+
+	if fn.Return == nil {
+		return pschema.FunctionSpec{}, fmt.Errorf("function %q: missing return type", fun.tfName)
+	}
+	if obj, ok := fn.Return.(tftypes.Object); ok {
+		ret, err := conv.objectSpec(obj, fun.name+"Result")
+		if err != nil {
+			return pschema.FunctionSpec{}, fmt.Errorf("function %q: return: %w", fun.tfName, err)
+		}
+		spec.ReturnType = &pschema.ReturnTypeSpec{ObjectTypeSpec: &ret}
+	} else {
+		ts, err := conv.typeSpec(fn.Return, fun.name+"Result")
+		if err != nil {
+			return pschema.FunctionSpec{}, fmt.Errorf("function %q: return: %w", fun.tfName, err)
+		}
+		spec.ReturnType = &pschema.ReturnTypeSpec{TypeSpec: &ts}
+	}
+
+	return spec, nil
+}
+
+// functionTypeGen converts the tftypes types describing a provider-defined function
+// signature into Pulumi schema types. Anonymous Terraform object types become named
+// auxiliary types, added to the types sink under a deterministic name derived from the
+// function and parameter names.
+type functionTypeGen struct {
+	pkg    tokens.Package
+	tfName string
+	types  map[string]pschema.ComplexTypeSpec
+}
+
+func (c *functionTypeGen) typeSpec(t tftypes.Type, nameHint string) (pschema.TypeSpec, error) {
+	switch t := t.(type) {
+	case tftypes.Object:
+		obj, err := c.objectSpec(t, nameHint)
+		if err != nil {
+			return pschema.TypeSpec{}, err
+		}
+		tok := fmt.Sprintf("%s:%s/%s:%s", c.pkg, indexMod, nameHint, nameHint)
+		if existing, ok := c.types[tok]; ok {
+			return pschema.TypeSpec{}, fmt.Errorf(
+				"generated type token %q is already defined as %v", tok, existing)
+		}
+		c.types[tok] = pschema.ComplexTypeSpec{ObjectTypeSpec: obj}
+		return pschema.TypeSpec{Ref: "#/types/" + tok}, nil
+	case tftypes.List:
+		items, err := c.typeSpec(t.ElementType, nameHint)
+		if err != nil {
+			return pschema.TypeSpec{}, err
+		}
+		return pschema.TypeSpec{Type: "array", Items: &items}, nil
+	case tftypes.Set:
+		items, err := c.typeSpec(t.ElementType, nameHint)
+		if err != nil {
+			return pschema.TypeSpec{}, err
+		}
+		return pschema.TypeSpec{Type: "array", Items: &items}, nil
+	case tftypes.Map:
+		additional, err := c.typeSpec(t.ElementType, nameHint)
+		if err != nil {
+			return pschema.TypeSpec{}, err
+		}
+		return pschema.TypeSpec{Type: "object", AdditionalProperties: &additional}, nil
+	case tftypes.Tuple:
+		// No provider function in the wild uses tuples, and Pulumi schema has no
+		// equivalent type.
+		return pschema.TypeSpec{}, fmt.Errorf("tuple types are not supported")
+	}
+	switch {
+	case t.Is(tftypes.DynamicPseudoType):
+		return pschema.TypeSpec{Ref: "pulumi.json#/Any"}, nil
+	case t.Is(tftypes.String):
+		return pschema.TypeSpec{Type: "string"}, nil
+	case t.Is(tftypes.Bool):
+		return pschema.TypeSpec{Type: "boolean"}, nil
+	case t.Is(tftypes.Number):
+		return pschema.TypeSpec{Type: "number"}, nil
+	}
+	return pschema.TypeSpec{}, fmt.Errorf("unsupported type %v", t)
+}
+
+func (c *functionTypeGen) objectSpec(t tftypes.Object, nameHint string) (pschema.ObjectTypeSpec, error) {
+	spec := pschema.ObjectTypeSpec{
+		Type:       "object",
+		Properties: map[string]pschema.PropertySpec{},
+	}
+	for _, attr := range functions.SortedAttributeNames(t) {
+		name := functions.PropertyName(attr)
+		if _, conflict := spec.Properties[name]; conflict {
+			return pschema.ObjectTypeSpec{}, fmt.Errorf(
+				"attribute %q: property name %q is already taken by another attribute", attr, name)
+		}
+		ts, err := c.typeSpec(t.AttributeTypes[attr], nameHint+upperFirst(name))
+		if err != nil {
+			return pschema.ObjectTypeSpec{}, fmt.Errorf("attribute %q: %w", attr, err)
+		}
+		spec.Properties[name] = pschema.PropertySpec{TypeSpec: ts}
+		if _, optional := t.OptionalAttributes[attr]; !optional {
+			spec.Required = append(spec.Required, name)
+		}
+	}
+	return spec, nil
+}

--- a/pkg/tfgen/generate_functions.go
+++ b/pkg/tfgen/generate_functions.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/functions"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
@@ -38,7 +39,7 @@ type providerFunc struct {
 	tok                tokens.ModuleMember
 	tfName             string
 	fn                 shim.Function
-	info               *tfbridge.FunctionInfo
+	info               *info.Function
 	doc                string
 	deprecationMessage string
 }
@@ -157,9 +158,9 @@ func (g *Generator) checkFunctionTokenCollisions() error {
 
 // gatherFunction returns the module member for a single provider-defined function.
 func (g *Generator) gatherFunction(rawname string,
-	fn shim.Function, info *tfbridge.FunctionInfo,
+	fn shim.Function, fninfo *info.Function,
 ) (*providerFunc, error) {
-	name, moduleName := functionName(rawname, info)
+	name, moduleName := functionName(rawname, fninfo)
 	mod := tokens.NewModuleToken(g.pkg, moduleName)
 	tok := tokens.NewModuleMemberToken(mod, name)
 
@@ -167,7 +168,7 @@ func (g *Generator) gatherFunction(rawname string,
 	var entityDocs entityDocs
 	if !g.noDocsRepo {
 		source := NewGitRepoDocsSource(g)
-		docs, err := getDocsForResource(g, source, FunctionDocs, rawname, info)
+		docs, err := getDocsForResource(g, source, FunctionDocs, rawname, fninfo)
 		if err == nil {
 			entityDocs = docs
 		} else if !g.checkNoDocsError(err) {
@@ -188,7 +189,7 @@ func (g *Generator) gatherFunction(rawname string,
 		}
 	}
 
-	deprecationMessage := info.DeprecationMessage
+	deprecationMessage := fninfo.DeprecationMessage
 	if deprecationMessage == "" {
 		deprecationMessage = fn.DeprecationMessage
 	}
@@ -199,7 +200,7 @@ func (g *Generator) gatherFunction(rawname string,
 		tok:                tok,
 		tfName:             rawname,
 		fn:                 fn,
-		info:               info,
+		info:               fninfo,
 		doc:                doc,
 		deprecationMessage: deprecationMessage,
 	}, nil
@@ -207,14 +208,14 @@ func (g *Generator) gatherFunction(rawname string,
 
 // functionName translates a Terraform function name into its Pulumi name equivalent,
 // plus a module name.
-func functionName(tfName string, info *tfbridge.FunctionInfo) (tokens.ModuleMemberName, tokens.ModuleName) {
-	if info == nil || info.Tok == "" {
+func functionName(tfName string, fninfo *info.Function) (tokens.ModuleMemberName, tokens.ModuleName) {
+	if fninfo == nil || fninfo.Tok == "" {
 		// Terraform function names are unprefixed; functions map into the top-level
 		// module by default.
 		name := tfbridge.TerraformToPulumiNameV2(tfName, nil, nil)
 		return tokens.ModuleMemberName(name), tokens.ModuleName(string(indexMod) + "/" + name)
 	}
-	return info.Tok.Name(), info.Tok.Module().Name()
+	return fninfo.Tok.Name(), fninfo.Tok.Module().Name()
 }
 
 // genProviderFunc generates the Pulumi schema for a provider-defined function.
@@ -380,8 +381,14 @@ func (c *functionTypeGen) objectSpec(t tftypes.Object, nameHint string) (pschema
 		Type:       "object",
 		Properties: map[string]pschema.PropertySpec{},
 	}
+	// Attributes are named with the standard bridge rules, driven by a schema map
+	// synthesized from the object type. The runtime decoder derives the same names.
+	syntheticSchema, err := functions.SchemaMapFromObject(t)
+	if err != nil {
+		return pschema.ObjectTypeSpec{}, err
+	}
 	for _, attr := range functions.SortedAttributeNames(t) {
-		name := functions.PropertyName(attr)
+		name := tfbridge.TerraformToPulumiNameV2(attr, syntheticSchema, nil)
 		if _, conflict := spec.Properties[name]; conflict {
 			return pschema.ObjectTypeSpec{}, fmt.Errorf(
 				"attribute %q: property name %q is already taken by another attribute", attr, name)

--- a/pkg/tfgen/generate_functions.go
+++ b/pkg/tfgen/generate_functions.go
@@ -291,7 +291,6 @@ func (g *schemaGenerator) genProviderFunc(
 			multiArgs = append(multiArgs, name)
 		}
 
-		sort.Strings(inputs.Required)
 		spec.Inputs = inputs
 		spec.MultiArgumentInputs = multiArgs
 	}

--- a/pkg/tfgen/generate_functions_test.go
+++ b/pkg/tfgen/generate_functions_test.go
@@ -154,6 +154,35 @@ func TestGenerateProviderFunctionVariadic(t *testing.T) { //nolint:paralleltest 
 	}, spec.Functions["test:index/join:join"])
 }
 
+func TestGenerateProviderFunctionRequiredOrder(t *testing.T) { //nolint:paralleltest // uses t.Setenv
+	info := tfbridge.ProviderInfo{
+		Name: "test",
+		P: (&shimschema.Provider{
+			Functions: map[string]shim.Function{
+				"lookup": {
+					Parameters: []shim.FunctionParameter{
+						{Name: "zone", Type: tftypes.String},
+						{Name: "address", Type: tftypes.String},
+					},
+					Return: tftypes.String,
+				},
+			},
+		}).Shim(),
+		Functions: map[string]*info.Function{
+			"lookup": {Tok: "test:index/lookup:lookup"},
+		},
+	}
+
+	spec, err := generateFunctionSchema(t, info)
+	require.NoError(t, err)
+
+	fn := spec.Functions["test:index/lookup:lookup"]
+	// Required keeps parameter order, matching multiArgumentInputs, rather than
+	// sorting by Pulumi name.
+	assert.Equal(t, []string{"zone", "address"}, fn.Inputs.Required)
+	assert.Equal(t, []string{"zone", "address"}, fn.MultiArgumentInputs)
+}
+
 func TestGenerateProviderFunctionNamingEdgeCases(t *testing.T) { //nolint:paralleltest // uses t.Setenv
 	info := tfbridge.ProviderInfo{
 		Name: "test",

--- a/pkg/tfgen/generate_functions_test.go
+++ b/pkg/tfgen/generate_functions_test.go
@@ -1,0 +1,333 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfgen
+
+import (
+	"io"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	shimschema "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+)
+
+func generateFunctionSchema(t *testing.T, info tfbridge.ProviderInfo) (pschema.PackageSpec, error) {
+	t.Helper()
+	t.Setenv("PULUMI_SKIP_MISSING_MAPPING_ERROR", "")
+	t.Setenv("PULUMI_SKIP_EXTRA_MAPPING_ERROR", "")
+	nilSink := diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{Color: colors.Never})
+	r, err := GenerateSchemaWithOptions(GenerateSchemaOptions{
+		DiagnosticsSink: nilSink,
+		ProviderInfo:    info,
+	})
+	if err != nil {
+		return pschema.PackageSpec{}, err
+	}
+	return r.PackageSpec, nil
+}
+
+func TestGenerateProviderFunction(t *testing.T) { //nolint:paralleltest // uses t.Setenv
+	info := tfbridge.ProviderInfo{
+		Name: "test",
+		P: (&shimschema.Provider{
+			Functions: map[string]shim.Function{
+				"parse_arn": {
+					Parameters: []shim.FunctionParameter{
+						{Name: "arn", Type: tftypes.String, Description: "The ARN to parse."},
+						{Name: "strict_mode", Type: tftypes.Bool, AllowNullValue: true},
+					},
+					Return: tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"service":    tftypes.String,
+							"account_id": tftypes.String,
+						},
+					},
+					Summary:     "Parses an ARN.",
+					Description: "Splits an ARN into its parts.",
+				},
+			},
+		}).Shim(),
+		Functions: map[string]*tfbridge.FunctionInfo{
+			"parse_arn": {Tok: "test:index/parseArn:parseArn"},
+		},
+	}
+
+	spec, err := generateFunctionSchema(t, info)
+	require.NoError(t, err)
+
+	assert.Equal(t, pschema.FunctionSpec{
+		Description: "Parses an ARN.\n\nSplits an ARN into its parts.\n",
+		Inputs: &pschema.ObjectTypeSpec{
+			Type: "object",
+			Properties: map[string]pschema.PropertySpec{
+				"arn": {
+					TypeSpec:    pschema.TypeSpec{Type: "string"},
+					Description: "The ARN to parse.\n",
+				},
+				"strictMode": {
+					TypeSpec: pschema.TypeSpec{Type: "boolean"},
+				},
+			},
+			Required: []string{"arn"},
+		},
+		MultiArgumentInputs: []string{"arn", "strictMode"},
+		ReturnType: &pschema.ReturnTypeSpec{
+			ObjectTypeSpec: &pschema.ObjectTypeSpec{
+				Type: "object",
+				Properties: map[string]pschema.PropertySpec{
+					"service":   {TypeSpec: pschema.TypeSpec{Type: "string"}},
+					"accountId": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				},
+				Required: []string{"accountId", "service"},
+			},
+		},
+	}, spec.Functions["test:index/parseArn:parseArn"])
+}
+
+func TestGenerateProviderFunctionVariadic(t *testing.T) { //nolint:paralleltest // uses t.Setenv
+	info := tfbridge.ProviderInfo{
+		Name: "test",
+		P: (&shimschema.Provider{
+			Functions: map[string]shim.Function{
+				"join": {
+					Parameters: []shim.FunctionParameter{
+						{Name: "separator", Type: tftypes.String},
+					},
+					VariadicParameter: &shim.FunctionParameter{
+						Name:        "parts",
+						Type:        tftypes.String,
+						Description: "Strings to join.",
+					},
+					Return:             tftypes.String,
+					DeprecationMessage: "use something else",
+				},
+			},
+		}).Shim(),
+		Functions: map[string]*tfbridge.FunctionInfo{
+			"join": {Tok: "test:index/join:join"},
+		},
+	}
+
+	spec, err := generateFunctionSchema(t, info)
+	require.NoError(t, err)
+
+	assert.Equal(t, pschema.FunctionSpec{
+		DeprecationMessage: "use something else",
+		Inputs: &pschema.ObjectTypeSpec{
+			Type: "object",
+			Properties: map[string]pschema.PropertySpec{
+				"separator": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				"parts": {
+					TypeSpec: pschema.TypeSpec{
+						Type:  "array",
+						Items: &pschema.TypeSpec{Type: "string"},
+					},
+					Description: "Strings to join.\n",
+				},
+			},
+			Required: []string{"separator"},
+		},
+		MultiArgumentInputs: []string{"separator", "parts"},
+		ReturnType: &pschema.ReturnTypeSpec{
+			TypeSpec: &pschema.TypeSpec{Type: "string"},
+		},
+	}, spec.Functions["test:index/join:join"])
+}
+
+func TestGenerateProviderFunctionNamingEdgeCases(t *testing.T) { //nolint:paralleltest // uses t.Setenv
+	info := tfbridge.ProviderInfo{
+		Name: "test",
+		P: (&shimschema.Provider{
+			Functions: map[string]shim.Function{
+				"weird": {
+					Parameters: []shim.FunctionParameter{
+						{Type: tftypes.String},
+						{Name: "value", Type: tftypes.String},
+						{Name: "value", Type: tftypes.String},
+					},
+					Return: tftypes.DynamicPseudoType,
+				},
+			},
+		}).Shim(),
+		Functions: map[string]*tfbridge.FunctionInfo{
+			"weird": {Tok: "test:index/weird:weird"},
+		},
+	}
+
+	spec, err := generateFunctionSchema(t, info)
+	require.NoError(t, err)
+
+	fn := spec.Functions["test:index/weird:weird"]
+	assert.Equal(t, []string{"arg1", "value", "value2"}, fn.MultiArgumentInputs)
+	assert.Equal(t, &pschema.ReturnTypeSpec{
+		TypeSpec: &pschema.TypeSpec{Ref: "pulumi.json#/Any"},
+	}, fn.ReturnType)
+}
+
+func TestGenerateProviderFunctionObjectParameter(t *testing.T) { //nolint:paralleltest // uses t.Setenv
+	info := tfbridge.ProviderInfo{
+		Name: "test",
+		P: (&shimschema.Provider{
+			Functions: map[string]shim.Function{
+				"describe": {
+					Parameters: []shim.FunctionParameter{
+						{
+							Name: "config",
+							Type: tftypes.Object{
+								AttributeTypes: map[string]tftypes.Type{
+									"region":  tftypes.String,
+									"verbose": tftypes.Bool,
+								},
+								OptionalAttributes: map[string]struct{}{
+									"verbose": {},
+								},
+							},
+						},
+					},
+					Return: tftypes.String,
+				},
+			},
+		}).Shim(),
+		Functions: map[string]*tfbridge.FunctionInfo{
+			"describe": {Tok: "test:index/describe:describe"},
+		},
+	}
+
+	spec, err := generateFunctionSchema(t, info)
+	require.NoError(t, err)
+
+	fn := spec.Functions["test:index/describe:describe"]
+	assert.Equal(t, pschema.TypeSpec{
+		Ref: "#/types/test:index/describeConfig:describeConfig",
+	}, fn.Inputs.Properties["config"].TypeSpec)
+
+	assert.Equal(t, pschema.ComplexTypeSpec{
+		ObjectTypeSpec: pschema.ObjectTypeSpec{
+			Type: "object",
+			Properties: map[string]pschema.PropertySpec{
+				"region":  {TypeSpec: pschema.TypeSpec{Type: "string"}},
+				"verbose": {TypeSpec: pschema.TypeSpec{Type: "boolean"}},
+			},
+			Required: []string{"region"},
+		},
+	}, spec.Types["test:index/describeConfig:describeConfig"])
+}
+
+func TestGenerateProviderFunctionTupleError(t *testing.T) { //nolint:paralleltest // uses t.Setenv
+	info := tfbridge.ProviderInfo{
+		Name: "test",
+		P: (&shimschema.Provider{
+			Functions: map[string]shim.Function{
+				"tuple_fn": {
+					Parameters: []shim.FunctionParameter{
+						{Name: "pair", Type: tftypes.Tuple{
+							ElementTypes: []tftypes.Type{tftypes.String, tftypes.Number},
+						}},
+					},
+					Return: tftypes.String,
+				},
+			},
+		}).Shim(),
+		Functions: map[string]*tfbridge.FunctionInfo{
+			"tuple_fn": {Tok: "test:index/tupleFn:tupleFn"},
+		},
+	}
+
+	_, err := generateFunctionSchema(t, info)
+	assert.ErrorContains(t, err, "tuple types are not supported")
+	assert.ErrorContains(t, err, `function "tuple_fn"`)
+}
+
+func TestGenerateProviderFunctionDataSourceTokenCollision(t *testing.T) { //nolint:paralleltest // uses t.Setenv
+	info := tfbridge.ProviderInfo{
+		Name: "test",
+		P: (&shimschema.Provider{
+			DataSourcesMap: schemaOnlyDataSource(),
+			Functions: map[string]shim.Function{
+				"foo": {Return: tftypes.String},
+			},
+		}).Shim(),
+		DataSources: map[string]*tfbridge.DataSourceInfo{
+			"test_ds": {Tok: "test:index/foo:foo"},
+		},
+		Functions: map[string]*tfbridge.FunctionInfo{
+			"foo": {Tok: "test:index/foo:foo"},
+		},
+	}
+
+	_, err := generateFunctionSchema(t, info)
+	assert.ErrorContains(t, err,
+		`TF function "foo" and TF data source "test_ds" are both mapped to the Pulumi token "test:index/foo:foo"`)
+}
+
+func TestGenerateProviderFunctionMappingErrors(t *testing.T) { //nolint:paralleltest // uses t.Setenv
+	provider := func() shim.Provider {
+		return (&shimschema.Provider{
+			Functions: map[string]shim.Function{
+				"real_fn": {Return: tftypes.String},
+			},
+		}).Shim()
+	}
+
+	t.Run("missing mapping", func(t *testing.T) {
+		_, err := generateFunctionSchema(t, tfbridge.ProviderInfo{
+			Name: "test",
+			P:    provider(),
+		})
+		assert.ErrorContains(t, err, `TF function "real_fn" not mapped to the Pulumi provider`)
+	})
+
+	t.Run("ignore mapping", func(t *testing.T) {
+		spec, err := generateFunctionSchema(t, tfbridge.ProviderInfo{
+			Name:           "test",
+			P:              provider(),
+			IgnoreMappings: []string{"real_fn"},
+		})
+		require.NoError(t, err)
+		// The spec always carries the synthesized terraformConfig provider method;
+		// no function generated from real_fn may appear.
+		assert.NotContains(t, spec.Functions, "test:index/realFn:realFn")
+	})
+
+	t.Run("extra mapping", func(t *testing.T) {
+		_, err := generateFunctionSchema(t, tfbridge.ProviderInfo{
+			Name: "test",
+			P:    provider(),
+			Functions: map[string]*tfbridge.FunctionInfo{
+				"real_fn": {Tok: "test:index/realFn:realFn"},
+				"gone_fn": {Tok: "test:index/goneFn:goneFn"},
+			},
+		})
+		assert.ErrorContains(t, err,
+			`Pulumi token "test:index/goneFn:goneFn" is mapped to TF provider function "gone_fn", but no such function found`)
+	})
+}
+
+func schemaOnlyDataSource() shimschema.ResourceMap {
+	return shimschema.ResourceMap{
+		"test_ds": (&shimschema.Resource{
+			Schema: shimschema.SchemaMap{
+				"x": (&shimschema.Schema{Type: shim.TypeString, Optional: true}).Shim(),
+			},
+		}).Shim(),
+	}
+}

--- a/pkg/tfgen/generate_functions_test.go
+++ b/pkg/tfgen/generate_functions_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	shimschema "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
 )
@@ -66,7 +67,7 @@ func TestGenerateProviderFunction(t *testing.T) { //nolint:paralleltest // uses 
 				},
 			},
 		}).Shim(),
-		Functions: map[string]*tfbridge.FunctionInfo{
+		Functions: map[string]*info.Function{
 			"parse_arn": {Tok: "test:index/parseArn:parseArn"},
 		},
 	}
@@ -122,7 +123,7 @@ func TestGenerateProviderFunctionVariadic(t *testing.T) { //nolint:paralleltest 
 				},
 			},
 		}).Shim(),
-		Functions: map[string]*tfbridge.FunctionInfo{
+		Functions: map[string]*info.Function{
 			"join": {Tok: "test:index/join:join"},
 		},
 	}
@@ -168,7 +169,7 @@ func TestGenerateProviderFunctionNamingEdgeCases(t *testing.T) { //nolint:parall
 				},
 			},
 		}).Shim(),
-		Functions: map[string]*tfbridge.FunctionInfo{
+		Functions: map[string]*info.Function{
 			"weird": {Tok: "test:index/weird:weird"},
 		},
 	}
@@ -207,7 +208,7 @@ func TestGenerateProviderFunctionObjectParameter(t *testing.T) { //nolint:parall
 				},
 			},
 		}).Shim(),
-		Functions: map[string]*tfbridge.FunctionInfo{
+		Functions: map[string]*info.Function{
 			"describe": {Tok: "test:index/describe:describe"},
 		},
 	}
@@ -247,7 +248,7 @@ func TestGenerateProviderFunctionTupleError(t *testing.T) { //nolint:paralleltes
 				},
 			},
 		}).Shim(),
-		Functions: map[string]*tfbridge.FunctionInfo{
+		Functions: map[string]*info.Function{
 			"tuple_fn": {Tok: "test:index/tupleFn:tupleFn"},
 		},
 	}
@@ -269,7 +270,7 @@ func TestGenerateProviderFunctionDataSourceTokenCollision(t *testing.T) { //noli
 		DataSources: map[string]*tfbridge.DataSourceInfo{
 			"test_ds": {Tok: "test:index/foo:foo"},
 		},
-		Functions: map[string]*tfbridge.FunctionInfo{
+		Functions: map[string]*info.Function{
 			"foo": {Tok: "test:index/foo:foo"},
 		},
 	}
@@ -312,7 +313,7 @@ func TestGenerateProviderFunctionMappingErrors(t *testing.T) { //nolint:parallel
 		_, err := generateFunctionSchema(t, tfbridge.ProviderInfo{
 			Name: "test",
 			P:    provider(),
-			Functions: map[string]*tfbridge.FunctionInfo{
+			Functions: map[string]*info.Function{
 				"real_fn": {Tok: "test:index/realFn:realFn"},
 				"gone_fn": {Tok: "test:index/goneFn:goneFn"},
 			},

--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -276,8 +276,8 @@ func genPulumiSchema(
 func (g *schemaGenerator) genPackageSpec(ctx context.Context, pack *pkg) (pschema.PackageSpec, error) {
 	_, span := tfgenTracer.Start(ctx, "genPackageSpec")
 	defer span.End()
-	var typesDur, resourcesDur, functionsDur, gatherNestedDur time.Duration
-	var typesN, resourcesN, functionsN int
+	var typesDur, resourcesDur, functionsDur, providerFunctionsDur, gatherNestedDur time.Duration
+	var typesN, resourcesN, functionsN, providerFunctionsN int
 
 	spec := pschema.PackageSpec{
 		Name:              g.pkg.String(),
@@ -336,6 +336,20 @@ func (g *schemaGenerator) genPackageSpec(ctx context.Context, pack *pkg) (pschem
 				spec.Functions[string(t.info.Tok)] = g.genDatasourceFunc(mod.name, t)
 				functionsDur += time.Since(t0)
 				functionsN++
+			case *providerFunc:
+				t0 := time.Now()
+				tok := string(t.tok)
+				if _, defined := spec.Functions[tok]; defined {
+					return pschema.PackageSpec{}, fmt.Errorf(
+						"provider function %q: token %q is already defined", t.tfName, tok)
+				}
+				fspec, err := g.genProviderFunc(t, spec.Types)
+				if err != nil {
+					return pschema.PackageSpec{}, err
+				}
+				spec.Functions[tok] = fspec
+				providerFunctionsDur += time.Since(t0)
+				providerFunctionsN++
 			case *variable:
 				contract.Assertf(mod.config(), `mod.config()`)
 				config = append(config, t)
@@ -351,6 +365,8 @@ func (g *schemaGenerator) genPackageSpec(ctx context.Context, pack *pkg) (pschem
 		attribute.Int64("gatherNestedTypes.ms", gatherNestedDur.Milliseconds()),
 		attribute.Int("functions.count", functionsN),
 		attribute.Int64("functions.ms", functionsDur.Milliseconds()),
+		attribute.Int("providerFunctions.count", providerFunctionsN),
+		attribute.Int64("providerFunctions.ms", providerFunctionsDur.Milliseconds()),
 		attribute.Int("docComment.count", g.docCommentN),
 		attribute.Int64("docComment.ms", g.docCommentDur.Milliseconds()),
 	)

--- a/pkg/tfgen/source.go
+++ b/pkg/tfgen/source.go
@@ -35,6 +35,9 @@ type DocsSource interface {
 	// Get the bytes for a datasource with TF token rawname.
 	getDatasource(rawname string, info *tfbridge.DocInfo) (*DocFile, error)
 
+	// Get the bytes for a provider-defined function with unprefixed TF name rawname.
+	getFunction(rawname string, info *tfbridge.DocInfo) (*DocFile, error)
+
 	// Get the bytes for the provider installation doc.
 	getInstallation(info *tfbridge.DocInfo) (*DocFile, error)
 }
@@ -74,6 +77,10 @@ func (gh *gitRepoSource) getDatasource(rawname string, info *tfbridge.DocInfo) (
 	return gh.getFile(rawname, info, DataSourceDocs)
 }
 
+func (gh *gitRepoSource) getFunction(rawname string, info *tfbridge.DocInfo) (*DocFile, error) {
+	return gh.getFile(rawname, info, FunctionDocs)
+}
+
 func (gh *gitRepoSource) getInstallation(info *tfbridge.DocInfo) (*DocFile, error) {
 	// The installation docs do not have a rawname.
 	return gh.getFile("", info, InstallationDocs)
@@ -99,7 +106,7 @@ func (gh *gitRepoSource) getFile(
 	switch kind {
 	case InstallationDocs:
 		possibleMarkdownNames = append(possibleMarkdownNames, "index.md", "index.html.markdown")
-	case ResourceDocs, DataSourceDocs:
+	case ResourceDocs, DataSourceDocs, FunctionDocs:
 		possibleMarkdownNames = getMarkdownNames(gh.resourcePrefix, rawname, gh.docRules)
 		if info != nil && info.Source != "" {
 			possibleMarkdownNames = append(possibleMarkdownNames, info.Source)
@@ -269,7 +276,14 @@ func getDocsPath(repo string, kind DocKind) ([]string, error) {
 	// ${repo}/website/docs/r
 	//
 	// This is the legacy way to describe docs.
-	if p := filepath.Join(repo, "website", "docs", string(kind)[:1]); exists(p) {
+	//
+	// Function docs never used single-letter directories: the legacy location is
+	// website/docs/functions.
+	legacyDir := string(kind)[:1]
+	if kind == FunctionDocs {
+		legacyDir = string(kind)
+	}
+	if p := filepath.Join(repo, "website", "docs", legacyDir); exists(p) {
 		paths = append(paths, p)
 	}
 


### PR DESCRIPTION
## Summary

Provider-defined functions reported by the shim (#3507) now appear in the generated Pulumi schema as invokes using the modern `FunctionSpec` shape.

- tfgen gathers provider functions next to data sources, with the same missing and extra mapping validation semantics (`PULUMI_SKIP_MISSING_MAPPING_ERROR`, `PULUMI_SKIP_EXTRA_MAPPING_ERROR`, and `ProviderInfo.IgnoreMappings`). A function whose token collides with a data source invoke token fails schema generation, since both share the schema's `functions` section.
- Ordered Terraform parameters project positionally via `multiArgumentInputs`. Terraform parameter names are documentation-only, so empty and duplicate names resolve deterministically. A trailing variadic parameter projects to a final optional list-typed argument. The Terraform return type projects via `returnType`, directly (non-object) for scalar returns. A parameter that allows null projects as optional unless a later parameter is required.
- Function signatures reuse the bridge's existing schema-driven machinery: the new `pkg/internal/functions` package synthesizes shim schemas from the tftypes type constraints, so object attribute naming goes through `TerraformToPulumiNameV2` (including standard pluralization) and value conversion at runtime (#3509) goes through the `pkg/convert` encoders and decoders. Top-level argument names are pinned exactly, since `multiArgumentInputs` refers to them positionally.
- Objects become named auxiliary types; dynamic maps to `Any`. Tuple types are rejected; a survey of all published Terraform providers (515 functions across 108 providers) found no function using them.
- Function documentation is discovered under `website/docs/functions/` and `docs/functions/`, falling back to the `Summary` and `Description` the provider ships in its schema. `Summary`, `Description`, and `DeprecationMessage` flow into the schema.

Part of #1955.

## Testing

- New schema-generation tests cover positional parameters (incl. `AllowNullValue` optionality rules), variadic functions, empty/duplicate parameter names, object parameters producing auxiliary named types, scalar/object/dynamic returns, the tuple hard error, the data-source token collision error, and missing/extra/ignored mapping validation.
- Unit tests for `pkg/internal/functions` cover argument naming, schema synthesis, naming consistency (incl. pluralization), and round trips through the `pkg/convert` encoders.