### PR TITLE
Route function invokes through the Terraform CallFunction RPC

### DIFF
--- a/pkg/pf/internal/providerbuilder/build_provider.go
+++ b/pkg/pf/internal/providerbuilder/build_provider.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/function"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -38,11 +39,15 @@ type Provider struct {
 	ProviderSchema schema.Schema
 	AllResources   []Resource
 	AllDataSources []DataSource
+	AllFunctions   []func() function.Function
 
 	configureFunc func(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse)
 }
 
-var _ provider.Provider = (*Provider)(nil)
+var (
+	_ provider.Provider              = (*Provider)(nil)
+	_ provider.ProviderWithFunctions = (*Provider)(nil)
+)
 
 func (impl *Provider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
 	resp.TypeName = impl.TypeName
@@ -68,6 +73,10 @@ func (impl *Provider) DataSources(ctx context.Context) []func() datasource.DataS
 		}
 	}
 	return d
+}
+
+func (impl *Provider) Functions(ctx context.Context) []func() function.Function {
+	return impl.AllFunctions
 }
 
 func (impl *Provider) Resources(ctx context.Context) []func() resource.Resource {
@@ -106,6 +115,7 @@ type NewProviderArgs struct {
 	ProviderSchema schema.Schema
 	AllResources   []Resource
 	AllDataSources []DataSource
+	AllFunctions   []func() function.Function
 
 	ConfigureFunc func(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse)
 }
@@ -118,6 +128,7 @@ func NewProvider(params NewProviderArgs) *Provider {
 		ProviderSchema: params.ProviderSchema,
 		AllResources:   params.AllResources,
 		AllDataSources: params.AllDataSources,
+		AllFunctions:   params.AllFunctions,
 
 		configureFunc: params.ConfigureFunc,
 	}

--- a/pkg/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pkg/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -1060,6 +1060,35 @@
                 "type": "object"
             }
         },
+        "testbridge:index/concat:concat": {
+            "description": "Concatenates strings with a separator.\n",
+            "inputs": {
+                "properties": {
+                    "parts": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Strings to join.\n"
+                    },
+                    "separator": {
+                        "type": "string",
+                        "description": "String placed between each part.\n"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "separator"
+                ]
+            },
+            "multiArgumentInputs": [
+                "separator",
+                "parts"
+            ],
+            "outputs": {
+                "type": "string"
+            }
+        },
         "testbridge:index/echo:Echo": {
             "inputs": {
                 "description": "A collection of arguments for invoking Echo.\n",
@@ -1096,6 +1125,55 @@
                     "output",
                     "sensitive",
                     "id"
+                ],
+                "type": "object"
+            }
+        },
+        "testbridge:index/nullableDefault:nullableDefault": {
+            "description": "Returns the value, or a default when the value is null.\n",
+            "inputs": {
+                "properties": {
+                    "value": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "multiArgumentInputs": [
+                "value"
+            ],
+            "outputs": {
+                "type": "string"
+            }
+        },
+        "testbridge:index/parseId:parseId": {
+            "description": "Parses a prefix/suffix identifier.\n",
+            "inputs": {
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id"
+                ]
+            },
+            "multiArgumentInputs": [
+                "id"
+            ],
+            "outputs": {
+                "properties": {
+                    "prefix": {
+                        "type": "string"
+                    },
+                    "suffix": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "prefix",
+                    "suffix"
                 ],
                 "type": "object"
             }

--- a/pkg/pf/tests/internal/testprovider/testbridge.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge.go
@@ -30,6 +30,7 @@ import (
 
 	tfpf "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 )
 
 //go:embed cmd/pulumi-resource-testbridge/bridge-metadata.json
@@ -129,7 +130,7 @@ func SyntheticTestBridgeProvider() tfbridge.ProviderInfo {
 			"testbridge_smac_ds": {Tok: "testbridge:index/smac:SMAC"},
 		},
 
-		Functions: map[string]*tfbridge.FunctionInfo{
+		Functions: map[string]*info.Function{
 			"concat":           {Tok: "testbridge:index/concat:concat"},
 			"parse_id":         {Tok: "testbridge:index/parseId:parseId"},
 			"nullable_default": {Tok: "testbridge:index/nullableDefault:nullableDefault"},

--- a/pkg/pf/tests/internal/testprovider/testbridge.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge.go
@@ -129,6 +129,12 @@ func SyntheticTestBridgeProvider() tfbridge.ProviderInfo {
 			"testbridge_smac_ds": {Tok: "testbridge:index/smac:SMAC"},
 		},
 
+		Functions: map[string]*tfbridge.FunctionInfo{
+			"concat":           {Tok: "testbridge:index/concat:concat"},
+			"parse_id":         {Tok: "testbridge:index/parseId:parseId"},
+			"nullable_default": {Tok: "testbridge:index/nullableDefault:nullableDefault"},
+		},
+
 		MetadataInfo: tfbridge.NewProviderMetadata(testBridgeMetadata),
 	}
 

--- a/pkg/pf/tests/internal/testprovider/testbridge_functions.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge_functions.go
@@ -1,0 +1,140 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testprovider
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ provider.ProviderWithFunctions = (*syntheticProvider)(nil)
+
+func (p *syntheticProvider) Functions(context.Context) []func() function.Function {
+	return []func() function.Function{
+		func() function.Function { return concatFunction{} },
+		func() function.Function { return parseIDFunction{} },
+		func() function.Function { return nullableDefaultFunction{} },
+	}
+}
+
+// concatFunction joins a variadic list of strings with a separator.
+type concatFunction struct{}
+
+func (concatFunction) Metadata(_ context.Context, _ function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "concat"
+}
+
+func (concatFunction) Definition(_ context.Context, _ function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Summary: "Concatenates strings with a separator.",
+		Parameters: []function.Parameter{
+			function.StringParameter{Name: "separator", Description: "String placed between each part."},
+		},
+		VariadicParameter: function.StringParameter{Name: "parts", Description: "Strings to join."},
+		Return:            function.StringReturn{},
+	}
+}
+
+func (concatFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var separator string
+	var parts []string
+	resp.Error = req.Arguments.Get(ctx, &separator, &parts)
+	if resp.Error != nil {
+		return
+	}
+	resp.Error = resp.Result.Set(ctx, strings.Join(parts, separator))
+}
+
+// parseIDFunction splits "prefix/suffix" identifiers, returning an object. Malformed
+// input produces an argument-scoped function error.
+type parseIDFunction struct{}
+
+var parseIDReturnAttrTypes = map[string]attr.Type{
+	"prefix": types.StringType,
+	"suffix": types.StringType,
+}
+
+func (parseIDFunction) Metadata(_ context.Context, _ function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "parse_id"
+}
+
+func (parseIDFunction) Definition(_ context.Context, _ function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Summary: "Parses a prefix/suffix identifier.",
+		Parameters: []function.Parameter{
+			function.StringParameter{Name: "id"},
+		},
+		Return: function.ObjectReturn{AttributeTypes: parseIDReturnAttrTypes},
+	}
+}
+
+func (parseIDFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var id string
+	resp.Error = req.Arguments.Get(ctx, &id)
+	if resp.Error != nil {
+		return
+	}
+	prefix, suffix, found := strings.Cut(id, "/")
+	if !found {
+		resp.Error = function.NewArgumentFuncError(0, `expected an id of the form "prefix/suffix"`)
+		return
+	}
+	result, diags := types.ObjectValue(parseIDReturnAttrTypes, map[string]attr.Value{
+		"prefix": types.StringValue(prefix),
+		"suffix": types.StringValue(suffix),
+	})
+	if diags.HasError() {
+		resp.Error = function.FuncErrorFromDiags(ctx, diags)
+		return
+	}
+	resp.Error = resp.Result.Set(ctx, result)
+}
+
+// nullableDefaultFunction accepts a nullable string and substitutes a default for null.
+type nullableDefaultFunction struct{}
+
+func (nullableDefaultFunction) Metadata(_ context.Context, _ function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "nullable_default"
+}
+
+func (nullableDefaultFunction) Definition(
+	_ context.Context, _ function.DefinitionRequest, resp *function.DefinitionResponse,
+) {
+	resp.Definition = function.Definition{
+		Summary: "Returns the value, or a default when the value is null.",
+		Parameters: []function.Parameter{
+			function.StringParameter{Name: "value", AllowNullValue: true},
+		},
+		Return: function.StringReturn{},
+	}
+}
+
+func (nullableDefaultFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var value *string
+	resp.Error = req.Arguments.Get(ctx, &value)
+	if resp.Error != nil {
+		return
+	}
+	result := "default"
+	if value != nil {
+		result = *value
+	}
+	resp.Error = resp.Result.Set(ctx, result)
+}

--- a/pkg/pf/tests/provider_function_invoke_test.go
+++ b/pkg/pf/tests/provider_function_invoke_test.go
@@ -143,6 +143,25 @@ func TestProviderFunctionInvoke(t *testing.T) {
 		}`)
 	})
 
+	t.Run("unknown argument value returns unknown without calling", func(t *testing.T) {
+		testutils.Replay(t, server, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Invoke",
+		  "request": {
+		    "tok": "testbridge:index/concat:concat",
+		    "args": {
+		      "separator": "04da6b54-80e4-46f7-96ec-b56ff0331ba9",
+		      "parts": ["a"]
+		    }
+		  },
+		  "response": {
+		    "return": {
+		      "result": "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
+		    }
+		  }
+		}`)
+	})
+
 	t.Run("missing required argument", func(t *testing.T) {
 		testutils.Replay(t, server, `
 		{

--- a/pkg/pf/tests/provider_function_invoke_test.go
+++ b/pkg/pf/tests/provider_function_invoke_test.go
@@ -1,0 +1,190 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"testing"
+
+	testutils "github.com/pulumi/providertest/replay"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
+)
+
+// Provider-defined functions are invoked like data sources but route through the
+// Terraform CallFunction RPC. Functions are pure: none of these calls configure the
+// provider first.
+func TestProviderFunctionInvoke(t *testing.T) {
+	t.Parallel()
+	server, err := newProviderServer(t, testprovider.SyntheticTestBridgeProvider())
+	require.NoError(t, err)
+
+	t.Run("variadic string result", func(t *testing.T) {
+		testutils.Replay(t, server, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Invoke",
+		  "request": {
+		    "tok": "testbridge:index/concat:concat",
+		    "args": {
+		      "separator": "-",
+		      "parts": ["a", "b", "c"]
+		    }
+		  },
+		  "response": {
+		    "return": {
+		      "result": "a-b-c"
+		    }
+		  }
+		}`)
+	})
+
+	t.Run("variadic with no trailing arguments", func(t *testing.T) {
+		testutils.Replay(t, server, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Invoke",
+		  "request": {
+		    "tok": "testbridge:index/concat:concat",
+		    "args": {
+		      "separator": "-"
+		    }
+		  },
+		  "response": {
+		    "return": {
+		      "result": ""
+		    }
+		  }
+		}`)
+	})
+
+	t.Run("object result", func(t *testing.T) {
+		testutils.Replay(t, server, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Invoke",
+		  "request": {
+		    "tok": "testbridge:index/parseId:parseId",
+		    "args": {
+		      "id": "foo/bar"
+		    }
+		  },
+		  "response": {
+		    "return": {
+		      "prefix": "foo",
+		      "suffix": "bar"
+		    }
+		  }
+		}`)
+	})
+
+	t.Run("argument-scoped function error", func(t *testing.T) {
+		testutils.Replay(t, server, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Invoke",
+		  "request": {
+		    "tok": "testbridge:index/parseId:parseId",
+		    "args": {
+		      "id": "malformed"
+		    }
+		  },
+		  "response": {
+		    "return": {},
+		    "failures": [
+		      {
+		        "property": "id",
+		        "reason": "function \"parse_id\": expected an id of the form \"prefix/suffix\""
+		      }
+		    ]
+		  }
+		}`)
+	})
+
+	t.Run("null allowed and omitted", func(t *testing.T) {
+		testutils.Replay(t, server, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Invoke",
+		  "request": {
+		    "tok": "testbridge:index/nullableDefault:nullableDefault",
+		    "args": {}
+		  },
+		  "response": {
+		    "return": {
+		      "result": "default"
+		    }
+		  }
+		}`)
+	})
+
+	t.Run("null allowed and provided", func(t *testing.T) {
+		testutils.Replay(t, server, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Invoke",
+		  "request": {
+		    "tok": "testbridge:index/nullableDefault:nullableDefault",
+		    "args": {
+		      "value": "explicit"
+		    }
+		  },
+		  "response": {
+		    "return": {
+		      "result": "explicit"
+		    }
+		  }
+		}`)
+	})
+
+	t.Run("missing required argument", func(t *testing.T) {
+		testutils.Replay(t, server, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Invoke",
+		  "request": {
+		    "tok": "testbridge:index/concat:concat",
+		    "args": {
+		      "parts": ["a"]
+		    }
+		  },
+		  "response": {
+		    "return": {},
+		    "failures": [
+		      {
+		        "property": "separator",
+		        "reason": "function \"concat\" requires a non-null value for argument \"separator\""
+		      }
+		    ]
+		  }
+		}`)
+	})
+
+	t.Run("unexpected argument", func(t *testing.T) {
+		testutils.Replay(t, server, `
+		{
+		  "method": "/pulumirpc.ResourceProvider/Invoke",
+		  "request": {
+		    "tok": "testbridge:index/concat:concat",
+		    "args": {
+		      "separator": "-",
+		      "bogus": "x"
+		    }
+		  },
+		  "response": {
+		    "return": {},
+		    "failures": [
+		      {
+		        "property": "bogus",
+		        "reason": "unexpected argument for function \"concat\""
+		      }
+		    ]
+		  }
+		}`)
+	})
+}

--- a/pkg/pf/tfbridge/provider_functions.go
+++ b/pkg/pf/tfbridge/provider_functions.go
@@ -24,8 +24,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/convert"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/functions"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/propertyvalue"
 )
@@ -39,24 +41,31 @@ type functionHandle struct {
 	token           tokens.ModuleMember
 	terraformName   string
 	fn              shim.Function
+	pulumiInfo      *info.Function
 	argNames        []string
-	objectResult    bool
-	pulumiInfo      *tfbridge.FunctionInfo
 	variadicArgName string // empty if the function has no variadic parameter
+
+	argsType tftypes.Object
+	encoder  convert.Encoder
+
+	resultType    tftypes.Object // the object return type, or the wrapper for a direct return
+	objectResult  bool
+	decoder       convert.Decoder
+	resultUnknown resource.PropertyMap // the result shape when arguments are unknown
 }
 
 // functionHandle resolves a Pulumi token to a provider-defined function, reporting false
 // if the token does not map to one.
 func (p *provider) functionHandle(token tokens.ModuleMember) (functionHandle, bool, error) {
 	var tfName string
-	var info *tfbridge.FunctionInfo
+	var pulumiInfo *info.Function
 	for name, v := range p.info.Functions {
 		if v.Tok == token {
-			tfName, info = name, v
+			tfName, pulumiInfo = name, v
 			break
 		}
 	}
-	if info == nil {
+	if pulumiInfo == nil {
 		return functionHandle{}, false, nil
 	}
 
@@ -66,19 +75,59 @@ func (p *provider) functionHandle(token tokens.ModuleMember) (functionHandle, bo
 			"[pf/tfbridge] token %v is mapped to TF function %q, but the provider does not define it", token, tfName)
 	}
 
+	fail := func(err error) (functionHandle, bool, error) {
+		return functionHandle{}, false, fmt.Errorf("[pf/tfbridge] function %q: %w", tfName, err)
+	}
+
 	argNames := functions.ArgumentNames(fn)
+	argsSchema, err := functions.ArgumentsSchema(fn, argNames)
+	if err != nil {
+		return fail(err)
+	}
+	encoder, err := convert.NewObjectEncoder(convert.ObjectSchema{
+		SchemaMap:   argsSchema.SchemaMap,
+		SchemaInfos: argsSchema.SchemaInfos,
+		Object:      &argsSchema.Type,
+	})
+	if err != nil {
+		return fail(err)
+	}
+
+	resultSchema, objectResult, err := functions.ResultSchema(fn, functionResultProperty)
+	if err != nil {
+		return fail(err)
+	}
+	decoder, err := convert.NewObjectDecoder(convert.ObjectSchema{
+		SchemaMap:   resultSchema.SchemaMap,
+		SchemaInfos: resultSchema.SchemaInfos,
+		Object:      &resultSchema.Type,
+	})
+	if err != nil {
+		return fail(err)
+	}
+
+	// Precompute the fully-unknown result shape returned for unknown arguments.
+	resultUnknown := make(resource.PropertyMap, len(resultSchema.Type.AttributeTypes))
+	for attr := range resultSchema.Type.AttributeTypes {
+		name := tfbridge.TerraformToPulumiNameV2(attr, resultSchema.SchemaMap, resultSchema.SchemaInfos)
+		resultUnknown[resource.PropertyKey(name)] = resource.MakeComputed(resource.NewStringProperty(""))
+	}
+
 	h := functionHandle{
 		token:         token,
 		terraformName: tfName,
 		fn:            fn,
+		pulumiInfo:    pulumiInfo,
 		argNames:      argNames,
-		pulumiInfo:    info,
+		argsType:      argsSchema.Type,
+		encoder:       encoder,
+		resultType:    resultSchema.Type,
+		objectResult:  objectResult,
+		decoder:       decoder,
+		resultUnknown: resultUnknown,
 	}
 	if fn.VariadicParameter != nil {
 		h.variadicArgName = argNames[len(fn.Parameters)]
-	}
-	if fn.Return != nil {
-		_, h.objectResult = fn.Return.(tftypes.Object)
 	}
 	return h, true, nil
 }
@@ -95,6 +144,12 @@ func (p *provider) callFunction(ctx context.Context, h functionHandle,
 	// does.
 	args = propertyvalue.RemoveSecrets(resource.NewObjectProperty(args)).ObjectValue()
 
+	// Functions are pure, so an unknown argument makes the whole result unknown; there
+	// is nothing to call until the inputs resolve.
+	if args.ContainsUnknowns() {
+		return h.resultUnknown.Copy(), nil, nil
+	}
+
 	known := make(map[resource.PropertyKey]bool, len(h.argNames))
 	for _, name := range h.argNames {
 		known[resource.PropertyKey(name)] = true
@@ -108,57 +163,71 @@ func (p *provider) callFunction(ctx context.Context, h functionHandle,
 			})
 		}
 	}
-	if len(failures) > 0 {
-		return nil, failures, nil
-	}
-
-	arguments := make([]*tfprotov6.DynamicValue, 0, len(fn.Parameters)+1)
-	appendArgument := func(param shim.FunctionParameter, name string, value resource.PropertyValue) error {
+	requireNonNull := func(param shim.FunctionParameter, name string, value resource.PropertyValue) {
 		if value.IsNull() && !param.AllowNullValue {
 			failures = append(failures, plugin.CheckFailure{
 				Property: resource.PropertyKey(name),
 				Reason: fmt.Sprintf("function %q requires a non-null value for argument %q",
 					h.terraformName, name),
 			})
-			return nil
 		}
-		v, err := functions.EncodeValue(param.Type, value)
-		if err != nil {
-			return fmt.Errorf("cannot encode argument %q of function %q: %w", name, h.terraformName, err)
+	}
+	for i, param := range fn.Parameters {
+		requireNonNull(param, h.argNames[i], args[resource.PropertyKey(h.argNames[i])])
+	}
+	var variadicValues []resource.PropertyValue
+	if v := fn.VariadicParameter; v != nil {
+		if value, has := args[resource.PropertyKey(h.variadicArgName)]; has && !value.IsNull() {
+			if !value.IsArray() {
+				return nil, nil, fmt.Errorf("argument %q of function %q must be a list, got %v",
+					h.variadicArgName, h.terraformName, value.TypeString())
+			}
+			variadicValues = value.ArrayValue()
+			for _, e := range variadicValues {
+				requireNonNull(*v, h.variadicArgName, e)
+			}
 		}
-		dv, err := tfprotov6.NewDynamicValue(param.Type, v)
+	}
+	if len(failures) > 0 {
+		return nil, failures, nil
+	}
+
+	// Encode all arguments at once as a synthetic object, then split the object into
+	// the positional call arguments, expanding the trailing variadic list.
+	encoded, err := convert.EncodePropertyMap(h.encoder, args)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot encode the arguments of function %q: %w", h.terraformName, err)
+	}
+	var encodedArgs map[string]tftypes.Value
+	if err := encoded.As(&encodedArgs); err != nil {
+		return nil, nil, fmt.Errorf("cannot encode the arguments of function %q: %w", h.terraformName, err)
+	}
+
+	arguments := make([]*tfprotov6.DynamicValue, 0, len(fn.Parameters)+len(variadicValues))
+	appendArgument := func(t tftypes.Type, name string, value tftypes.Value) error {
+		dv, err := tfprotov6.NewDynamicValue(t, value)
 		if err != nil {
 			return fmt.Errorf("cannot marshal argument %q of function %q: %w", name, h.terraformName, err)
 		}
 		arguments = append(arguments, &dv)
 		return nil
 	}
-
 	for i, param := range fn.Parameters {
-		name := h.argNames[i]
-		if err := appendArgument(param, name, args[resource.PropertyKey(name)]); err != nil {
+		if err := appendArgument(param.Type, h.argNames[i], encodedArgs[h.argNames[i]]); err != nil {
 			return nil, nil, err
 		}
 	}
-	if v := fn.VariadicParameter; v != nil {
-		// The Pulumi projection packs the trailing variadic arguments into a final
-		// list-typed argument; unpack it into individual call arguments.
-		name := h.variadicArgName
-		if value, has := args[resource.PropertyKey(name)]; has && !value.IsNull() {
-			value = propertyvalue.RemoveSecrets(value)
-			if !value.IsArray() {
-				return nil, nil, fmt.Errorf("argument %q of function %q must be a list, got %v",
-					name, h.terraformName, value.TypeString())
-			}
-			for _, e := range value.ArrayValue() {
-				if err := appendArgument(*v, name, e); err != nil {
-					return nil, nil, err
-				}
+	if v := fn.VariadicParameter; v != nil && len(variadicValues) > 0 {
+		var elements []tftypes.Value
+		if err := encodedArgs[h.variadicArgName].As(&elements); err != nil {
+			return nil, nil, fmt.Errorf("cannot encode argument %q of function %q: %w",
+				h.variadicArgName, h.terraformName, err)
+		}
+		for _, e := range elements {
+			if err := appendArgument(v.Type, h.variadicArgName, e); err != nil {
+				return nil, nil, err
 			}
 		}
-	}
-	if len(failures) > 0 {
-		return nil, failures, nil
 	}
 
 	resp, err := p.tfServer.CallFunction(ctx, &tfprotov6.CallFunctionRequest{
@@ -170,11 +239,12 @@ func (p *provider) callFunction(ctx context.Context, h functionHandle,
 	}
 	if respErr := resp.Error; respErr != nil {
 		if respErr.FunctionArgument != nil {
-			name := h.argNameForCallArgument(*respErr.FunctionArgument)
-			return nil, []plugin.CheckFailure{{
-				Property: resource.PropertyKey(name),
-				Reason:   fmt.Sprintf("function %q: %s", h.terraformName, respErr.Text),
-			}}, nil
+			if name := h.argNameForCallArgument(*respErr.FunctionArgument); name != "" {
+				return nil, []plugin.CheckFailure{{
+					Property: resource.PropertyKey(name),
+					Reason:   fmt.Sprintf("function %q: %s", h.terraformName, respErr.Text),
+				}}, nil
+			}
 		}
 		return nil, nil, fmt.Errorf("function %q returned an error: %s", h.terraformName, respErr.Text)
 	}
@@ -186,32 +256,26 @@ func (p *provider) callFunction(ctx context.Context, h functionHandle,
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot unmarshal the result of function %q: %w", h.terraformName, err)
 	}
-	result, err := functions.DecodeValue(fn.Return, resultValue)
+	if !h.objectResult {
+		// Wrap a direct result into the single-property object the decoder expects.
+		resultValue = tftypes.NewValue(h.resultType, map[string]tftypes.Value{
+			functionResultProperty: resultValue,
+		})
+	}
+	result, err := convert.DecodePropertyMap(ctx, h.decoder, resultValue)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot decode the result of function %q: %w", h.terraformName, err)
 	}
-
-	if h.objectResult {
-		if !result.IsObject() {
-			return nil, nil, fmt.Errorf("function %q returned a non-object result", h.terraformName)
-		}
-		return result.ObjectValue(), nil, nil
-	}
-	return resource.PropertyMap{functionResultProperty: result}, nil, nil
+	return result, nil, nil
 }
 
 // argNameForCallArgument maps a zero-based CallFunction argument position back to the
 // Pulumi argument name. Positions past the declared parameters address expanded variadic
-// arguments, which all project to the final list-typed Pulumi argument.
+// arguments, which all project to the final list-typed Pulumi argument; when there is no
+// variadic parameter such a position is out of range and maps to no argument.
 func (h functionHandle) argNameForCallArgument(position int64) string {
 	if position >= 0 && position < int64(len(h.fn.Parameters)) {
 		return h.argNames[position]
 	}
-	if h.variadicArgName != "" {
-		return h.variadicArgName
-	}
-	if len(h.argNames) > 0 {
-		return h.argNames[len(h.argNames)-1]
-	}
-	return ""
+	return h.variadicArgName
 }

--- a/pkg/pf/tfbridge/provider_functions.go
+++ b/pkg/pf/tfbridge/provider_functions.go
@@ -1,0 +1,217 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridge
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/functions"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/propertyvalue"
+)
+
+// The single-property wire form of a non-object function result. SDKs unwrap the sole
+// property of the returned map (e.g. invokeSingle in Node.js), so the key is
+// conventional only.
+const functionResultProperty = "result"
+
+type functionHandle struct {
+	token           tokens.ModuleMember
+	terraformName   string
+	fn              shim.Function
+	argNames        []string
+	objectResult    bool
+	pulumiInfo      *tfbridge.FunctionInfo
+	variadicArgName string // empty if the function has no variadic parameter
+}
+
+// functionHandle resolves a Pulumi token to a provider-defined function, reporting false
+// if the token does not map to one.
+func (p *provider) functionHandle(token tokens.ModuleMember) (functionHandle, bool, error) {
+	var tfName string
+	var info *tfbridge.FunctionInfo
+	for name, v := range p.info.Functions {
+		if v.Tok == token {
+			tfName, info = name, v
+			break
+		}
+	}
+	if info == nil {
+		return functionHandle{}, false, nil
+	}
+
+	fn, ok := p.schemaOnlyProvider.Functions()[tfName]
+	if !ok {
+		return functionHandle{}, false, fmt.Errorf(
+			"[pf/tfbridge] token %v is mapped to TF function %q, but the provider does not define it", token, tfName)
+	}
+
+	argNames := functions.ArgumentNames(fn)
+	h := functionHandle{
+		token:         token,
+		terraformName: tfName,
+		fn:            fn,
+		argNames:      argNames,
+		pulumiInfo:    info,
+	}
+	if fn.VariadicParameter != nil {
+		h.variadicArgName = argNames[len(fn.Parameters)]
+	}
+	if fn.Return != nil {
+		_, h.objectResult = fn.Return.(tftypes.Object)
+	}
+	return h, true, nil
+}
+
+// callFunction implements Pulumi invokes for provider-defined functions by calling the
+// Terraform CallFunction RPC. Functions are pure computations: the call does not require
+// the provider to be configured.
+func (p *provider) callFunction(ctx context.Context, h functionHandle,
+	args resource.PropertyMap,
+) (resource.PropertyMap, []plugin.CheckFailure, error) {
+	fn := h.fn
+
+	// Secrets do not survive the invoke protocol; strip them like the data source path
+	// does.
+	args = propertyvalue.RemoveSecrets(resource.NewObjectProperty(args)).ObjectValue()
+
+	known := make(map[resource.PropertyKey]bool, len(h.argNames))
+	for _, name := range h.argNames {
+		known[resource.PropertyKey(name)] = true
+	}
+	var failures []plugin.CheckFailure
+	for key := range args {
+		if !known[key] {
+			failures = append(failures, plugin.CheckFailure{
+				Property: key,
+				Reason:   fmt.Sprintf("unexpected argument for function %q", h.terraformName),
+			})
+		}
+	}
+	if len(failures) > 0 {
+		return nil, failures, nil
+	}
+
+	arguments := make([]*tfprotov6.DynamicValue, 0, len(fn.Parameters)+1)
+	appendArgument := func(param shim.FunctionParameter, name string, value resource.PropertyValue) error {
+		if value.IsNull() && !param.AllowNullValue {
+			failures = append(failures, plugin.CheckFailure{
+				Property: resource.PropertyKey(name),
+				Reason: fmt.Sprintf("function %q requires a non-null value for argument %q",
+					h.terraformName, name),
+			})
+			return nil
+		}
+		v, err := functions.EncodeValue(param.Type, value)
+		if err != nil {
+			return fmt.Errorf("cannot encode argument %q of function %q: %w", name, h.terraformName, err)
+		}
+		dv, err := tfprotov6.NewDynamicValue(param.Type, v)
+		if err != nil {
+			return fmt.Errorf("cannot marshal argument %q of function %q: %w", name, h.terraformName, err)
+		}
+		arguments = append(arguments, &dv)
+		return nil
+	}
+
+	for i, param := range fn.Parameters {
+		name := h.argNames[i]
+		if err := appendArgument(param, name, args[resource.PropertyKey(name)]); err != nil {
+			return nil, nil, err
+		}
+	}
+	if v := fn.VariadicParameter; v != nil {
+		// The Pulumi projection packs the trailing variadic arguments into a final
+		// list-typed argument; unpack it into individual call arguments.
+		name := h.variadicArgName
+		if value, has := args[resource.PropertyKey(name)]; has && !value.IsNull() {
+			value = propertyvalue.RemoveSecrets(value)
+			if !value.IsArray() {
+				return nil, nil, fmt.Errorf("argument %q of function %q must be a list, got %v",
+					name, h.terraformName, value.TypeString())
+			}
+			for _, e := range value.ArrayValue() {
+				if err := appendArgument(*v, name, e); err != nil {
+					return nil, nil, err
+				}
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return nil, failures, nil
+	}
+
+	resp, err := p.tfServer.CallFunction(ctx, &tfprotov6.CallFunctionRequest{
+		Name:      h.terraformName,
+		Arguments: arguments,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("error calling CallFunction for %q: %w", h.terraformName, err)
+	}
+	if respErr := resp.Error; respErr != nil {
+		if respErr.FunctionArgument != nil {
+			name := h.argNameForCallArgument(*respErr.FunctionArgument)
+			return nil, []plugin.CheckFailure{{
+				Property: resource.PropertyKey(name),
+				Reason:   fmt.Sprintf("function %q: %s", h.terraformName, respErr.Text),
+			}}, nil
+		}
+		return nil, nil, fmt.Errorf("function %q returned an error: %s", h.terraformName, respErr.Text)
+	}
+	if resp.Result == nil {
+		return nil, nil, fmt.Errorf("function %q returned no result", h.terraformName)
+	}
+
+	resultValue, err := resp.Result.Unmarshal(fn.Return)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot unmarshal the result of function %q: %w", h.terraformName, err)
+	}
+	result, err := functions.DecodeValue(fn.Return, resultValue)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot decode the result of function %q: %w", h.terraformName, err)
+	}
+
+	if h.objectResult {
+		if !result.IsObject() {
+			return nil, nil, fmt.Errorf("function %q returned a non-object result", h.terraformName)
+		}
+		return result.ObjectValue(), nil, nil
+	}
+	return resource.PropertyMap{functionResultProperty: result}, nil, nil
+}
+
+// argNameForCallArgument maps a zero-based CallFunction argument position back to the
+// Pulumi argument name. Positions past the declared parameters address expanded variadic
+// arguments, which all project to the final list-typed Pulumi argument.
+func (h functionHandle) argNameForCallArgument(position int64) string {
+	if position >= 0 && position < int64(len(h.fn.Parameters)) {
+		return h.argNames[position]
+	}
+	if h.variadicArgName != "" {
+		return h.variadicArgName
+	}
+	if len(h.argNames) > 0 {
+		return h.argNames[len(h.argNames)-1]
+	}
+	return ""
+}

--- a/pkg/pf/tfbridge/provider_invoke.go
+++ b/pkg/pf/tfbridge/provider_invoke.go
@@ -40,6 +40,14 @@ func (p *provider) InvokeWithContext(
 ) (resource.PropertyMap, []plugin.CheckFailure, error) {
 	ctx = p.initLogging(ctx, p.logSink, "")
 
+	// Provider-defined functions share the invoke surface with data sources but call
+	// the Terraform CallFunction RPC instead of ReadDataSource.
+	if fnHandle, ok, err := p.functionHandle(tok); err != nil {
+		return nil, nil, err
+	} else if ok {
+		return p.callFunction(ctx, fnHandle, args)
+	}
+
 	handle, err := p.datasourceHandle(ctx, tok)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Summary

Calling a generated function invoke on a Plugin Framework based provider now routes through the Terraform `CallFunction` RPC instead of `ReadDataSource`.

- The PF provider resolves function tokens before data source tokens in `Invoke`. Arguments encode through the existing `pkg/convert` encoders, driven by schemas synthesized from the function signature (#3508); the final list-typed Pulumi argument unpacks into individual call arguments for a variadic parameter.
- Unknown (computed) argument values do not error and do not call the function: functions are pure, so an unknown input makes the whole result unknown, and the invoke resolves once inputs are known.
- Functions are pure by the Terraform contract, so the call does not require the provider to be configured.
- Null handling honors `AllowNullValue`: a missing or null argument for a non-nullable parameter returns a check failure naming the argument. Unexpected arguments are rejected the same way.
- A `FunctionError` with an argument position maps back to the Pulumi argument name, including expanded variadic positions, and surfaces as a check failure; positions past the declared parameters of a non-variadic function surface as a function-level error rather than blaming the wrong argument.
- Non-object results return as a single-property map (`result`), matching the wire convention SDKs use to unwrap direct returns (for example, `invokeSingle` in Node.js). Object results return their renamed properties directly.

Part of #1955.

## Testing

The synthetic testbridge provider gains three functions covering variadic parameters, object returns with argument-scoped errors, and nullable parameters; its golden schema is regenerated (reviewable in this diff). gRPC replay tests exercise success, failure, and unknown-input paths, all without configuring the provider. `TestSchemaGenInSync` verifies the regenerated golden.