### PR TITLE
Expose provider-defined functions through muxed and dynamic providers

### DIFF
--- a/docs/guides/provider-functions.md
+++ b/docs/guides/provider-functions.md
@@ -1,0 +1,60 @@
+# Provider-defined functions
+
+Terraform providers built with the Plugin Framework (protocol 6.5+, Terraform 1.8+) can
+define [provider functions](https://developer.hashicorp.com/terraform/plugin/framework/functions/concepts):
+pure, offline computations called in Terraform as `provider::<name>::<function>(...)`.
+The bridge maps each provider function to a Pulumi invoke.
+
+SDKv2-based providers cannot define functions; muxed providers expose functions from
+their Plugin Framework half only.
+
+## Projection
+
+Functions live in a Terraform namespace separate from resources and data sources and are
+registered without the provider prefix (for example `parse_arn`, not `aws_parse_arn`).
+On the Pulumi side:
+
+- Every token strategy (`SingleModule`, `KnownModules`, `MappedModules`,
+  `InferredModules`) maps functions into the top-level (index) module, camelCasing the
+  Terraform name with no `get` prefix: `parse_arn` becomes
+  `pkg:index/parseArn:parseArn`.
+- Ordered Terraform parameters project as positional arguments via the schema's
+  `multiArgumentInputs`. Terraform parameter names are documentation-only, so empty or
+  duplicate names resolve deterministically (`arg1`, `value`, `value2`, ...).
+- A trailing variadic parameter projects to a final, optional list-typed argument.
+- The Terraform return type projects via `returnType`, directly (non-object) for scalar
+  returns.
+- A parameter that sets `AllowNullValue` projects as optional, unless a later parameter
+  is required (target languages cannot express a required positional argument after an
+  optional one).
+- Tuple-typed parameters or returns are not supported and fail schema generation.
+
+## Mapping
+
+Functions have their own section in `ProviderInfo`, keyed by the unprefixed Terraform
+name:
+
+```go
+Functions: map[string]*tfbridge.FunctionInfo{
+    "parse_arn": {Tok: "aws:index/parseArn:parseArn"},
+},
+```
+
+`MustComputeTokens` fills missing entries automatically. Missing and extra mappings are
+validated with the same semantics as resources and data sources
+(`PULUMI_SKIP_MISSING_MAPPING_ERROR`, `PULUMI_SKIP_EXTRA_MAPPING_ERROR`,
+`ProviderInfo.IgnoreMappings`). A function token that collides with a data source invoke
+token fails schema generation: both share the `functions` section of the Pulumi schema.
+
+## Runtime
+
+Invoking the generated function routes through the Terraform `CallFunction` RPC.
+Functions are pure by the Terraform contract, so the call does not require provider
+configuration. Function errors surface as Pulumi errors naming the function; errors
+scoped to an argument name the offending Pulumi argument.
+
+## Docs
+
+Upstream documentation is discovered under `website/docs/functions/` (legacy) and
+`docs/functions/`, falling back to the `Summary` and `Description` the provider ships in
+its schema.

--- a/docs/guides/provider-functions.md
+++ b/docs/guides/provider-functions.md
@@ -40,6 +40,12 @@ Functions: map[string]*tfbridge.FunctionInfo{
 },
 ```
 
+The `functions` section of the marshaled mapping (`GetMapping`) also records whether the
+function's final Terraform parameter is variadic. The Pulumi schema cannot carry this: a
+variadic parameter projects as a trailing, optional array argument, indistinguishable
+from a genuine trailing list parameter, yet the two take different Terraform call syntax
+(spread arguments vs. a list value).
+
 `MustComputeTokens` fills missing entries automatically. Missing and extra mappings are
 validated with the same semantics as resources and data sources
 (`PULUMI_SKIP_MISSING_MAPPING_ERROR`, `PULUMI_SKIP_EXTRA_MAPPING_ERROR`,

--- a/dynamic/info.go
+++ b/dynamic/info.go
@@ -135,6 +135,12 @@ func providerInfo(ctx context.Context, p run.Provider, value parameterize.Value)
 				ignoreMappings = append(ignoreMappings, key)
 			}
 		}
+		// Also check provider-defined functions
+		for key := range provider.Functions() {
+			if shouldIgnore(key) {
+				ignoreMappings = append(ignoreMappings, key)
+			}
+		}
 
 		prov.IgnoreMappings = ignoreMappings
 	}

--- a/dynamic/provider_test.go
+++ b/dynamic/provider_test.go
@@ -249,6 +249,37 @@ func TestDynamicConfigure(t *testing.T) {
 }`)))(t)
 }
 
+// Provider-defined functions are exposed by the dynamic bridge and are callable without
+// configuring the provider first.
+func TestDynamicProviderFunction(t *testing.T) {
+	t.Parallel()
+	skipWindows(t)
+
+	s := grpcTestServer(context.Background(), t)
+
+	assertGRPCCall(s.Parameterize, &pulumirpc.ParameterizeRequest{
+		Parameters: &pulumirpc.ParameterizeRequest_Args{
+			Args: &pulumirpc.ParameterizeRequest_ParametersArgs{
+				Args: []string{pfProviderPath(t)},
+			},
+		},
+	}, noParallel, expect(autogold.Expect(`{
+  "name": "pfprovider",
+  "version": "0.0.0"
+}`)))(t)
+
+	assertGRPCCall(s.Invoke, &pulumirpc.InvokeRequest{
+		Tok: "pfprovider:index/echoUpper:echoUpper",
+		Args: marshal(resource.PropertyMap{
+			"input": resource.NewProperty("hello"),
+		}),
+	}, noParallel, expect(autogold.Expect(`{
+  "return": {
+    "result": "HELLO"
+  }
+}`)))(t)
+}
+
 func TestDynamicCheckConfig(t *testing.T) {
 	t.Parallel()
 	skipWindows(t)

--- a/dynamic/test/pfprovider/example_function.go
+++ b/dynamic/test/pfprovider/example_function.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+)
+
+// echoUpperFunction upper-cases its input. It exercises provider-defined functions end
+// to end through the dynamic bridge.
+type echoUpperFunction struct{}
+
+var _ function.Function = echoUpperFunction{}
+
+func NewEchoUpperFunction() function.Function { return echoUpperFunction{} }
+
+func (echoUpperFunction) Metadata(
+	_ context.Context, _ function.MetadataRequest, resp *function.MetadataResponse,
+) {
+	resp.Name = "echo_upper"
+}
+
+func (echoUpperFunction) Definition(
+	_ context.Context, _ function.DefinitionRequest, resp *function.DefinitionResponse,
+) {
+	resp.Definition = function.Definition{
+		Summary: "Returns the input string upper-cased.",
+		Parameters: []function.Parameter{
+			function.StringParameter{Name: "input"},
+		},
+		Return: function.StringReturn{},
+	}
+}
+
+func (echoUpperFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var input string
+	resp.Error = req.Arguments.Get(ctx, &input)
+	if resp.Error != nil {
+		return
+	}
+	resp.Error = resp.Result.Set(ctx, strings.ToUpper(input))
+}

--- a/dynamic/test/pfprovider/provider.go
+++ b/dynamic/test/pfprovider/provider.go
@@ -103,7 +103,9 @@ func (p *PFProvider) DataSources(ctx context.Context) []func() datasource.DataSo
 }
 
 func (p *PFProvider) Functions(ctx context.Context) []func() function.Function {
-	return []func() function.Function{}
+	return []func() function.Function{
+		NewEchoUpperFunction,
+	}
 }
 
 func New(version string) func() provider.Provider {

--- a/pkg/pf/tests/muxed_function_test.go
+++ b/pkg/pf/tests/muxed_function_test.go
@@ -1,0 +1,116 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/function"
+	sdk2schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	testutils "github.com/pulumi/providertest/replay"
+	"github.com/stretchr/testify/require"
+
+	pfmuxer "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/muxer"
+	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/providerbuilder"
+	pfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
+	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
+	sdkv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
+)
+
+// shoutFunction upper-cases its input; used to exercise provider-defined functions
+// through a muxed (SDKv2 + PF) provider.
+type shoutFunction struct{}
+
+func (shoutFunction) Metadata(_ context.Context, _ function.MetadataRequest, resp *function.MetadataResponse) {
+	resp.Name = "shout"
+}
+
+func (shoutFunction) Definition(_ context.Context, _ function.DefinitionRequest, resp *function.DefinitionResponse) {
+	resp.Definition = function.Definition{
+		Parameters: []function.Parameter{function.StringParameter{Name: "input"}},
+		Return:     function.StringReturn{},
+	}
+}
+
+func (shoutFunction) Run(ctx context.Context, req function.RunRequest, resp *function.RunResponse) {
+	var input string
+	resp.Error = req.Arguments.Get(ctx, &input)
+	if resp.Error != nil {
+		return
+	}
+	resp.Error = resp.Result.Set(ctx, strings.ToUpper(input)+"!")
+}
+
+// A muxed provider dispatches function invokes to its Plugin Framework half; the SDKv2
+// half cannot define functions.
+func TestMuxedProviderFunctionInvoke(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pfProvider := pb.NewProvider(pb.NewProviderArgs{
+		TypeName: "muxedfn",
+		AllFunctions: []func() function.Function{
+			func() function.Function { return shoutFunction{} },
+		},
+	})
+	sdkProvider := &sdk2schema.Provider{
+		ResourcesMap: map[string]*sdk2schema.Resource{
+			"muxedfn_res": {
+				Schema: map[string]*sdk2schema.Schema{
+					"x": {Type: sdk2schema.TypeString, Optional: true},
+				},
+			},
+		},
+	}
+
+	info := tfbridge0.ProviderInfo{
+		Name:         "muxedfn",
+		Version:      "0.0.1",
+		P:            pfbridge.MuxShimWithPF(ctx, sdkv2.NewProvider(sdkProvider), pfProvider),
+		MetadataInfo: tfbridge0.NewProviderMetadata(nil),
+	}
+	info.MustComputeTokens(tokens.SingleModule("muxedfn_", "index", tokens.MakeStandard("muxedfn")))
+	require.Equal(t, map[string]*tfbridge0.FunctionInfo{
+		"shout": {Tok: "muxedfn:index/shout:shout"},
+	}, info.Functions)
+
+	schema := genSDKSchema(t, info)
+	dispatch, err := info.P.(*pfmuxer.ProviderShim).ResolveDispatch(&info)
+	require.NoError(t, err)
+	require.NoError(t, metadata.Set(info.GetMetadata(), "mux", dispatch))
+
+	server, err := pfbridge.MakeMuxedServer(ctx, "muxedfn", info, schema)(nil)
+	require.NoError(t, err)
+
+	testutils.Replay(t, server, `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Invoke",
+	  "request": {
+	    "tok": "muxedfn:index/shout:shout",
+	    "args": {
+	      "input": "hi"
+	    }
+	  },
+	  "response": {
+	    "return": {
+	      "result": "HI!"
+	    }
+	  }
+	}`)
+}

--- a/pkg/pf/tests/muxed_function_test.go
+++ b/pkg/pf/tests/muxed_function_test.go
@@ -28,6 +28,7 @@ import (
 	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/providerbuilder"
 	pfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	sdkv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/unstable/metadata"
@@ -79,23 +80,23 @@ func TestMuxedProviderFunctionInvoke(t *testing.T) {
 		},
 	}
 
-	info := tfbridge0.ProviderInfo{
+	prov := tfbridge0.ProviderInfo{
 		Name:         "muxedfn",
 		Version:      "0.0.1",
 		P:            pfbridge.MuxShimWithPF(ctx, sdkv2.NewProvider(sdkProvider), pfProvider),
 		MetadataInfo: tfbridge0.NewProviderMetadata(nil),
 	}
-	info.MustComputeTokens(tokens.SingleModule("muxedfn_", "index", tokens.MakeStandard("muxedfn")))
-	require.Equal(t, map[string]*tfbridge0.FunctionInfo{
+	prov.MustComputeTokens(tokens.SingleModule("muxedfn_", "index", tokens.MakeStandard("muxedfn")))
+	require.Equal(t, map[string]*info.Function{
 		"shout": {Tok: "muxedfn:index/shout:shout"},
-	}, info.Functions)
+	}, prov.Functions)
 
-	schema := genSDKSchema(t, info)
-	dispatch, err := info.P.(*pfmuxer.ProviderShim).ResolveDispatch(&info)
+	schema := genSDKSchema(t, prov)
+	dispatch, err := prov.P.(*pfmuxer.ProviderShim).ResolveDispatch(&prov)
 	require.NoError(t, err)
-	require.NoError(t, metadata.Set(info.GetMetadata(), "mux", dispatch))
+	require.NoError(t, metadata.Set(prov.GetMetadata(), "mux", dispatch))
 
-	server, err := pfbridge.MakeMuxedServer(ctx, "muxedfn", info, schema)(nil)
+	server, err := pfbridge.MakeMuxedServer(ctx, "muxedfn", prov, schema)(nil)
 	require.NoError(t, err)
 
 	testutils.Replay(t, server, `

--- a/pkg/pf/tests/provider_get_mapping_test.go
+++ b/pkg/pf/tests/provider_get_mapping_test.go
@@ -108,7 +108,7 @@ func TestPFGetMappingFunctions(t *testing.T) {
 	require.NoError(t, json.Unmarshal(m.Data, &marshalled))
 
 	assert.Equal(t, map[string]*info.MarshallableFunction{
-		"concat":           {Tok: "testbridge:index/concat:concat"},
+		"concat":           {Tok: "testbridge:index/concat:concat", Variadic: true},
 		"parse_id":         {Tok: "testbridge:index/parseId:parseId"},
 		"nullable_default": {Tok: "testbridge:index/nullableDefault:nullableDefault"},
 	}, marshalled.Functions)

--- a/pkg/pf/tests/provider_get_mapping_test.go
+++ b/pkg/pf/tests/provider_get_mapping_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
 )
 
 func TestPFGetMapping(t *testing.T) {
@@ -92,11 +93,11 @@ func TestPFGetMapping(t *testing.T) {
 func TestPFGetMappingFunctions(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	info := testprovider.SyntheticTestBridgeProvider()
+	prov := testprovider.SyntheticTestBridgeProvider()
 
-	gen, err := genMetadata(t, info)
+	gen, err := genMetadata(t, prov)
 	require.NoError(t, err)
-	p, err := tfbridge.NewProvider(ctx, info, gen)
+	p, err := tfbridge.NewProvider(ctx, prov, gen)
 	require.NoError(t, err)
 
 	m, err := p.GetMapping(ctx, plugin.GetMappingRequest{Key: "terraform"})
@@ -106,7 +107,7 @@ func TestPFGetMappingFunctions(t *testing.T) {
 	var marshalled tfbridge0.MarshallableProviderInfo
 	require.NoError(t, json.Unmarshal(m.Data, &marshalled))
 
-	assert.Equal(t, map[string]*tfbridge0.MarshallableFunctionInfo{
+	assert.Equal(t, map[string]*info.MarshallableFunction{
 		"concat":           {Tok: "testbridge:index/concat:concat"},
 		"parse_id":         {Tok: "testbridge:index/parseId:parseId"},
 		"nullable_default": {Tok: "testbridge:index/nullableDefault:nullableDefault"},

--- a/pkg/pf/tests/provider_get_mapping_test.go
+++ b/pkg/pf/tests/provider_get_mapping_test.go
@@ -87,6 +87,32 @@ func TestPFGetMapping(t *testing.T) {
 	}
 }
 
+// Provider-defined functions surface in GetMapping data so converters can translate
+// provider::name::fn(...) calls.
+func TestPFGetMappingFunctions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	info := testprovider.SyntheticTestBridgeProvider()
+
+	gen, err := genMetadata(t, info)
+	require.NoError(t, err)
+	p, err := tfbridge.NewProvider(ctx, info, gen)
+	require.NoError(t, err)
+
+	m, err := p.GetMapping(ctx, plugin.GetMappingRequest{Key: "terraform"})
+	require.NoError(t, err)
+	assert.Equal(t, "testbridge", m.Provider)
+
+	var marshalled tfbridge0.MarshallableProviderInfo
+	require.NoError(t, json.Unmarshal(m.Data, &marshalled))
+
+	assert.Equal(t, map[string]*tfbridge0.MarshallableFunctionInfo{
+		"concat":           {Tok: "testbridge:index/concat:concat"},
+		"parse_id":         {Tok: "testbridge:index/parseId:parseId"},
+		"nullable_default": {Tok: "testbridge:index/nullableDefault:nullableDefault"},
+	}, marshalled.Functions)
+}
+
 func TestMuxedGetMapping(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -493,15 +493,6 @@ type Function struct {
 	Tok                tokens.ModuleMember // a function token to override the default; "" uses the default.
 	Docs               *Doc                // overrides for finding and mapping TF docs.
 	DeprecationMessage string              // message to use in deprecation warning
-
-	// Variadic records whether the function's final Terraform parameter is variadic.
-	// The schema projects such a parameter as a trailing array argument, which is
-	// otherwise indistinguishable from a genuine trailing list parameter — but the two
-	// take different Terraform call syntax (spread arguments vs. a list value), so
-	// mapping consumers need the distinction. It is derived from the provider's
-	// function signature when the mapping payload is marshaled and is not meant to be
-	// set by provider authors.
-	Variadic bool
 }
 
 // GetTok returns a function token
@@ -1334,19 +1325,27 @@ func (m *MarshallableDataSource) Unmarshal() *DataSource {
 // MarshallableFunction is the JSON-marshallable form of a Pulumi FunctionInfo value.
 type MarshallableFunction struct {
 	Tok tokens.ModuleMember `json:"tok"`
-	// Variadic is true when the function's final Terraform parameter is variadic. See
-	// [Function.Variadic].
+	// Variadic is true when the function's final Terraform parameter is variadic.
+	// The Pulumi schema projects such a parameter as a trailing array argument,
+	// which is otherwise indistinguishable from a genuine trailing list parameter —
+	// but the two take different Terraform call syntax (spread arguments vs. a list
+	// value), so mapping consumers need the distinction. It is derived from the
+	// provider's function signature when the mapping payload is marshaled and is
+	// deliberately not carried by [Function], which is author-facing.
 	Variadic bool `json:"variadic,omitempty"`
 }
 
 // MarshalFunction converts a Pulumi FunctionInfo value into a MarshallableFunction value.
 func MarshalFunction(f *Function) *MarshallableFunction {
-	return &MarshallableFunction{Tok: f.Tok, Variadic: f.Variadic}
+	return &MarshallableFunction{Tok: f.Tok}
 }
 
 // Unmarshal creates a mostly-initialized Pulumi FunctionInfo value from the given MarshallableFunction.
+//
+// Variadic is wire-only and is dropped: consumers that need it read the
+// MarshallableFunction form directly.
 func (m *MarshallableFunction) Unmarshal() *Function {
-	return &Function{Tok: m.Tok, Variadic: m.Variadic}
+	return &Function{Tok: m.Tok}
 }
 
 // MarshallableProvider is the JSON-marshallable form of a Pulumi ProviderInfo value.

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -1326,12 +1326,6 @@ func (m *MarshallableDataSource) Unmarshal() *DataSource {
 type MarshallableFunction struct {
 	Tok tokens.ModuleMember `json:"tok"`
 	// Variadic is true when the function's final Terraform parameter is variadic.
-	// The Pulumi schema projects such a parameter as a trailing array argument,
-	// which is otherwise indistinguishable from a genuine trailing list parameter —
-	// but the two take different Terraform call syntax (spread arguments vs. a list
-	// value), so mapping consumers need the distinction. It is derived from the
-	// provider's function signature when the mapping payload is marshaled and is
-	// deliberately not carried by [Function], which is author-facing.
 	Variadic bool `json:"variadic,omitempty"`
 }
 

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -493,6 +493,15 @@ type Function struct {
 	Tok                tokens.ModuleMember // a function token to override the default; "" uses the default.
 	Docs               *Doc                // overrides for finding and mapping TF docs.
 	DeprecationMessage string              // message to use in deprecation warning
+
+	// Variadic records whether the function's final Terraform parameter is variadic.
+	// The schema projects such a parameter as a trailing array argument, which is
+	// otherwise indistinguishable from a genuine trailing list parameter — but the two
+	// take different Terraform call syntax (spread arguments vs. a list value), so
+	// mapping consumers need the distinction. It is derived from the provider's
+	// function signature when the mapping payload is marshaled and is not meant to be
+	// set by provider authors.
+	Variadic bool
 }
 
 // GetTok returns a function token
@@ -1325,16 +1334,19 @@ func (m *MarshallableDataSource) Unmarshal() *DataSource {
 // MarshallableFunction is the JSON-marshallable form of a Pulumi FunctionInfo value.
 type MarshallableFunction struct {
 	Tok tokens.ModuleMember `json:"tok"`
+	// Variadic is true when the function's final Terraform parameter is variadic. See
+	// [Function.Variadic].
+	Variadic bool `json:"variadic,omitempty"`
 }
 
 // MarshalFunction converts a Pulumi FunctionInfo value into a MarshallableFunction value.
 func MarshalFunction(f *Function) *MarshallableFunction {
-	return &MarshallableFunction{Tok: f.Tok}
+	return &MarshallableFunction{Tok: f.Tok, Variadic: f.Variadic}
 }
 
 // Unmarshal creates a mostly-initialized Pulumi FunctionInfo value from the given MarshallableFunction.
 func (m *MarshallableFunction) Unmarshal() *Function {
-	return &Function{Tok: m.Tok}
+	return &Function{Tok: m.Tok, Variadic: m.Variadic}
 }
 
 // MarshallableProvider is the JSON-marshallable form of a Pulumi ProviderInfo value.
@@ -1366,9 +1378,19 @@ func MarshalProvider(p *Provider) *MarshallableProvider {
 	}
 	var functions map[string]*MarshallableFunction
 	if len(p.Functions) > 0 {
+		var shimFunctions map[string]shim.Function
+		if p.P != nil {
+			shimFunctions = p.P.Functions()
+		}
 		functions = make(map[string]*MarshallableFunction)
 		for k, v := range p.Functions {
-			functions[k] = MarshalFunction(v)
+			mf := MarshalFunction(v)
+			// The provider's signature is authoritative for variadic-ness; the info
+			// value is author-provided and does not carry it.
+			if fn, ok := shimFunctions[k]; ok {
+				mf.Variadic = fn.VariadicParameter != nil
+			}
+			functions[k] = mf
 		}
 	}
 


### PR DESCRIPTION
## Summary

Completes the provider-defined functions feature across the remaining integration surfaces.

- Muxed providers dispatch function invokes to their Plugin Framework half. A test drives an SDKv2 plus PF provider through schema generation, dispatch resolution, and a function invoke through the muxed server.
- The dynamic bridge exposes functions from dynamically bridged providers end to end: schema discovery through `CallFunction` on an out-of-process provider, exercised against the pfprovider test provider. The include and exclude resource filters also apply to functions.
- GetMapping payloads carry the functions section; a test asserts the mapped tokens for the testbridge provider.
- A new guide documents the projection, mapping, runtime, and docs behavior: `docs/guides/provider-functions.md`.

Closes #1955.

Known follow-ups outside this stack: Terraform-CLI cross-tests for function parity (the cross-test harness has no TF 1.8 `provider::` call support yet; runtime parity is covered via the framework's own providerserver), and `pulumi-converter-terraform` consuming the new `functions` GetMapping section to translate `provider::name::fn(...)` HCL.

## Testing

- `TestMuxedProviderFunctionInvoke` (schema gen → dispatch → invoke through the muxer).
- `TestDynamicProviderFunction` (parameterize → invoke on a real out-of-process provider, unconfigured).
- `TestPFGetMappingFunctions` (functions section in GetMapping data).