### PR TITLE
tfgen: keep provider function required inputs in parameter order

### DIFF
--- a/pkg/tfgen/generate_functions.go
+++ b/pkg/tfgen/generate_functions.go
@@ -291,7 +291,6 @@ func (g *schemaGenerator) genProviderFunc(
 			multiArgs = append(multiArgs, name)
 		}
 
-		sort.Strings(inputs.Required)
 		spec.Inputs = inputs
 		spec.MultiArgumentInputs = multiArgs
 	}

--- a/pkg/tfgen/generate_functions_test.go
+++ b/pkg/tfgen/generate_functions_test.go
@@ -154,6 +154,35 @@ func TestGenerateProviderFunctionVariadic(t *testing.T) { //nolint:paralleltest 
 	}, spec.Functions["test:index/join:join"])
 }
 
+func TestGenerateProviderFunctionRequiredOrder(t *testing.T) { //nolint:paralleltest // uses t.Setenv
+	info := tfbridge.ProviderInfo{
+		Name: "test",
+		P: (&shimschema.Provider{
+			Functions: map[string]shim.Function{
+				"lookup": {
+					Parameters: []shim.FunctionParameter{
+						{Name: "zone", Type: tftypes.String},
+						{Name: "address", Type: tftypes.String},
+					},
+					Return: tftypes.String,
+				},
+			},
+		}).Shim(),
+		Functions: map[string]*info.Function{
+			"lookup": {Tok: "test:index/lookup:lookup"},
+		},
+	}
+
+	spec, err := generateFunctionSchema(t, info)
+	require.NoError(t, err)
+
+	fn := spec.Functions["test:index/lookup:lookup"]
+	// Required keeps parameter order, matching multiArgumentInputs, rather than
+	// sorting by Pulumi name.
+	assert.Equal(t, []string{"zone", "address"}, fn.Inputs.Required)
+	assert.Equal(t, []string{"zone", "address"}, fn.MultiArgumentInputs)
+}
+
 func TestGenerateProviderFunctionNamingEdgeCases(t *testing.T) { //nolint:paralleltest // uses t.Setenv
 	info := tfbridge.ProviderInfo{
 		Name: "test",


### PR DESCRIPTION
## Summary

`genProviderFunc` sorted `inputs.Required` lexicographically. The order was already deterministic — it is built by walking `fn.Parameters` — and every other `Required` array tfgen emits (resources, config, datasources, auxiliary object types) keeps its deterministic iteration order without a re-sort. The sort made provider functions the one outlier and dropped the positional order that `multiArgumentInputs` is built around.

We got here because the outlier was confusing the AI: reviewing #3508, the AI reviewer flagged `objectSpec` for *not* sorting `Required`, citing `genProviderFunc` as the precedent and conflating sorted order with determinism (see https://github.com/pulumi/pulumi-terraform-bridge/pull/3508#discussion_r3512755393). Schemas must be deterministic, but deterministic does not mean sorted; removing the unnecessary sort resolves the inconsistency in the direction the rest of tfgen already follows.

## Testing

New `TestGenerateProviderFunctionRequiredOrder` pins parameter order for `required` where positional and lexicographic order differ; it fails with the sort in place. Existing provider-function tests pass unchanged.