### PR TITLE
Add a cross-test for provider-defined function parity

### DIFF
--- a/pkg/pf/tests/cross_function_test.go
+++ b/pkg/pf/tests/cross_function_test.go
@@ -1,0 +1,98 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/stretchr/testify/assert"
+
+	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/providerbuilder"
+	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
+)
+
+// A provider-defined function must produce the same value whether Terraform calls it
+// (provider::testbridge::fn(...)) or the bridged Pulumi provider invokes it. Non-object
+// returns arrive under the bridge's "result" wrapper property on the Pulumi side, so
+// scalar cases compare against that wrapping.
+func TestCrossFunctionParity(t *testing.T) {
+	t.Parallel()
+	provider := func() *pb.Provider {
+		return pb.NewProvider(pb.NewProviderArgs{
+			TypeName:     "testbridge",
+			AllFunctions: testprovider.SyntheticTestBridgeFunctions(),
+		})
+	}
+
+	t.Run("variadic string result", func(t *testing.T) {
+		t.Parallel()
+		res := crosstests.Function(t, provider(),
+			`provider::testbridge::concat("-", "a", "b", "c")`,
+			"testbridge:index/concat:concat",
+			resource.PropertyMap{
+				"separator": resource.NewStringProperty("-"),
+				"parts": resource.NewArrayProperty([]resource.PropertyValue{
+					resource.NewStringProperty("a"),
+					resource.NewStringProperty("b"),
+					resource.NewStringProperty("c"),
+				}),
+			})
+		assert.Equal(t, map[string]any{"result": res.TF}, res.Pulumi)
+	})
+
+	t.Run("variadic with no trailing arguments", func(t *testing.T) {
+		t.Parallel()
+		res := crosstests.Function(t, provider(),
+			`provider::testbridge::concat("-")`,
+			"testbridge:index/concat:concat",
+			resource.PropertyMap{
+				"separator": resource.NewStringProperty("-"),
+			})
+		assert.Equal(t, map[string]any{"result": res.TF}, res.Pulumi)
+	})
+
+	t.Run("object result", func(t *testing.T) {
+		t.Parallel()
+		res := crosstests.Function(t, provider(),
+			`provider::testbridge::parse_id("foo/bar")`,
+			"testbridge:index/parseId:parseId",
+			resource.PropertyMap{
+				"id": resource.NewStringProperty("foo/bar"),
+			})
+		assert.Equal(t, res.TF, any(res.Pulumi))
+	})
+
+	t.Run("null argument maps to omitted argument", func(t *testing.T) {
+		t.Parallel()
+		res := crosstests.Function(t, provider(),
+			`provider::testbridge::nullable_default(null)`,
+			"testbridge:index/nullableDefault:nullableDefault",
+			resource.PropertyMap{})
+		assert.Equal(t, map[string]any{"result": res.TF}, res.Pulumi)
+	})
+
+	t.Run("nullable argument provided", func(t *testing.T) {
+		t.Parallel()
+		res := crosstests.Function(t, provider(),
+			`provider::testbridge::nullable_default("explicit")`,
+			"testbridge:index/nullableDefault:nullableDefault",
+			resource.PropertyMap{
+				"value": resource.NewStringProperty("explicit"),
+			})
+		assert.Equal(t, map[string]any{"result": res.TF}, res.Pulumi)
+	})
+}

--- a/pkg/pf/tests/internal/cross-tests/function.go
+++ b/pkg/pf/tests/internal/cross-tests/function.go
@@ -1,0 +1,101 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crosstests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/logging"
+	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/providerbuilder"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tests/tfcheck"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+)
+
+// FunctionResult holds the value a provider-defined function produced on each side of a
+// [Function] cross-test.
+type FunctionResult struct {
+	// TF is the function's value as Terraform computed it, decoded from JSON.
+	TF any
+
+	// Pulumi is the bridged invoke's return, converted to plain values. Non-object
+	// returns arrive under the bridge's "result" wrapper property.
+	Pulumi map[string]any
+}
+
+// Function calls a provider-defined function through Terraform (an output evaluating
+// hclCall) and through the bridged Pulumi provider (an Invoke of tok with args),
+// returning both results so the caller can assert parity.
+//
+// hclCall and (tok, args) must express the same call: Terraform takes positional
+// arguments while the bridged invoke takes the schema's multiArgumentInputs property
+// names.
+func Function(
+	t *testing.T, prov *pb.Provider, hclCall string, tok string, args resource.PropertyMap,
+) FunctionResult {
+	SkipUnlessLinux(t)
+	ctx := context.Background()
+
+	// Terraform resolves provider::<name>::<fn> through the provider's local name,
+	// which must be declared in required_providers.
+	program := fmt.Sprintf(`
+terraform {
+  required_providers {
+    %[1]s = {
+      source = "hashicorp/%[1]s"
+    }
+  }
+}
+
+output "result" {
+  value = %s
+}
+`, prov.TypeName, hclCall)
+	driver := tfcheck.NewTfDriver(t, t.TempDir(), prov.TypeName, tfcheck.NewTFDriverOpts{
+		V6Provider: prov,
+	})
+	driver.Write(t, program)
+	plan, err := driver.Plan(t)
+	require.NoError(t, err)
+	require.NoError(t, driver.ApplyPlan(t, plan))
+	tfResult := driver.GetOutputJSON(t, "result")
+
+	p := prov.ToProviderInfo()
+	schema, err := tfgen.GenerateSchema(ctx, tfgen.GenerateSchemaOptions{ProviderInfo: p})
+	require.NoError(t, err)
+	p.MetadataInfo = &info.Metadata{Path: "non-empty"}
+	server, err := tfbridge.NewProviderServer(ctx, logging.NewTestingSink(t), p, tfbridge.ProviderMetadata{
+		PackageSchema: schema.ProviderMetadata.PackageSchema,
+	})
+	require.NoError(t, err)
+
+	marshaled, err := plugin.MarshalProperties(args, plugin.MarshalOptions{})
+	require.NoError(t, err)
+	resp, err := server.Invoke(ctx, &pulumirpc.InvokeRequest{Tok: tok, Args: marshaled})
+	require.NoError(t, err)
+	require.Empty(t, resp.Failures)
+	ret, err := plugin.UnmarshalProperties(resp.Return, plugin.MarshalOptions{})
+	require.NoError(t, err)
+
+	return FunctionResult{TF: tfResult, Pulumi: ret.Mappable()}
+}

--- a/pkg/pf/tests/internal/testprovider/testbridge_functions.go
+++ b/pkg/pf/tests/internal/testprovider/testbridge_functions.go
@@ -27,6 +27,12 @@ import (
 var _ provider.ProviderWithFunctions = (*syntheticProvider)(nil)
 
 func (p *syntheticProvider) Functions(context.Context) []func() function.Function {
+	return SyntheticTestBridgeFunctions()
+}
+
+// SyntheticTestBridgeFunctions returns the provider-defined functions of the synthetic
+// testbridge provider, for reuse in tests that build ad-hoc providers.
+func SyntheticTestBridgeFunctions() []func() function.Function {
 	return []func() function.Function{
 		func() function.Function { return concatFunction{} },
 		func() function.Function { return parseIDFunction{} },

--- a/pkg/tests/tfcheck/tfcheck.go
+++ b/pkg/tests/tfcheck/tfcheck.go
@@ -196,6 +196,16 @@ func (d *TFDriver) GetOutput(t pulcheck.T, outputName string) string {
 	return res
 }
 
+// GetOutputJSON returns the value of the named output, decoded from
+// `terraform output -json`, preserving the value's structure and types.
+func (d *TFDriver) GetOutputJSON(t pulcheck.T, outputName string) any {
+	resB, err := d.execTf(t, "output", "-json", outputName)
+	require.NoError(t, err)
+	var v any
+	require.NoError(t, json.Unmarshal(resB, &v))
+	return v
+}
+
 func (d *TFDriver) formatReattachEnvVar() string {
 	name := d.providerName
 	pluginReattachConfig := d.reattachConfig


### PR DESCRIPTION
crosstests.Function evaluates a provider-defined function on both sides
of the bridge — Terraform computes an output from a provider::<name>::<fn>
call against the reattached provider, and the bridged Pulumi provider
serves an Invoke of the same call — and returns both values for parity
assertions.

TestCrossFunctionParity covers the testbridge functions: a variadic call
(with and without trailing arguments), an object return, and a nullable
parameter passed as null versus omitted. tfcheck gains GetOutputJSON so
structured output values survive the readback intact.