### PR TITLE
Serialize provider-defined function signatures in the provider schema shim

### DIFF
--- a/docs/guides/provider-functions.md
+++ b/docs/guides/provider-functions.md
@@ -40,11 +40,12 @@ Functions: map[string]*tfbridge.FunctionInfo{
 },
 ```
 
-The `functions` section of the marshaled mapping (`GetMapping`) also records whether the
-function's final Terraform parameter is variadic. The Pulumi schema cannot carry this: a
-variadic parameter projects as a trailing, optional array argument, indistinguishable
-from a genuine trailing list parameter, yet the two take different Terraform call syntax
-(spread arguments vs. a list value).
+The provider schema section of the marshaled mapping (`GetMapping`) carries each
+function's Terraform signature, so consumers can recover facts the Pulumi schema cannot
+carry — most importantly variadic-ness: a variadic parameter projects as a trailing,
+optional array argument, indistinguishable from a genuine trailing list parameter, yet
+the two take different Terraform call syntax (spread arguments vs. a list value). After
+unmarshaling the mapping, the signatures are available as `info.P.Functions()`.
 
 `MustComputeTokens` fills missing entries automatically. Missing and extra mappings are
 validated with the same semantics as resources and data sources

--- a/pkg/pf/tests/provider_get_mapping_test.go
+++ b/pkg/pf/tests/provider_get_mapping_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
 	tfbridge0 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
 func TestPFGetMapping(t *testing.T) {
@@ -89,7 +91,8 @@ func TestPFGetMapping(t *testing.T) {
 }
 
 // Provider-defined functions surface in GetMapping data so converters can translate
-// provider::name::fn(...) calls.
+// provider::name::fn(...) calls: the functions section maps Terraform names to Pulumi
+// tokens, and the provider schema section carries the Terraform signatures.
 func TestPFGetMappingFunctions(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -108,10 +111,27 @@ func TestPFGetMappingFunctions(t *testing.T) {
 	require.NoError(t, json.Unmarshal(m.Data, &marshalled))
 
 	assert.Equal(t, map[string]*info.MarshallableFunction{
-		"concat":           {Tok: "testbridge:index/concat:concat", Variadic: true},
+		"concat":           {Tok: "testbridge:index/concat:concat"},
 		"parse_id":         {Tok: "testbridge:index/parseId:parseId"},
 		"nullable_default": {Tok: "testbridge:index/nullableDefault:nullableDefault"},
 	}, marshalled.Functions)
+
+	unmarshalled := marshalled.Unmarshal()
+	require.NotNil(t, unmarshalled.P)
+	assert.Equal(t, shim.Function{
+		Parameters: []shim.FunctionParameter{{
+			Name:        "separator",
+			Type:        tftypes.String,
+			Description: "String placed between each part.",
+		}},
+		VariadicParameter: &shim.FunctionParameter{
+			Name:        "parts",
+			Type:        tftypes.String,
+			Description: "Strings to join.",
+		},
+		Return:  tftypes.String,
+		Summary: "Concatenates strings with a separator.",
+	}, unmarshalled.P.Functions()["concat"])
 }
 
 func TestMuxedGetMapping(t *testing.T) {

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -23,6 +23,7 @@ package info
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -1083,11 +1084,135 @@ func (m *MarshallableElemShim) Unmarshal() interface{} {
 	}
 }
 
+// MarshallableTFType is the JSON-marshallable form of a tftypes.Type. It uses
+// Terraform's type-signature encoding, the same encoding the plugin protocol uses for
+// provider-defined function parameter and return types.
+type MarshallableTFType struct {
+	Type tftypes.Type
+}
+
+// MarshalJSON implements json.Marshaler.
+func (t MarshallableTFType) MarshalJSON() ([]byte, error) {
+	if t.Type == nil {
+		return []byte("null"), nil
+	}
+	//nolint:staticcheck // This method isn't really deprecated, but it is supposed to be private.
+	return t.Type.MarshalJSON()
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (t *MarshallableTFType) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		t.Type = nil
+		return nil
+	}
+	//nolint:staticcheck // This function isn't really deprecated, but it is supposed to be private.
+	parsed, err := tftypes.ParseJSONType(data)
+	if err != nil {
+		return err
+	}
+	t.Type = parsed
+	return nil
+}
+
+// MarshallableFunctionParameterShim is the JSON-marshallable form of a provider-defined
+// function parameter.
+type MarshallableFunctionParameterShim struct {
+	Name           string             `json:"name,omitempty"`
+	Type           MarshallableTFType `json:"type"`
+	AllowNullValue bool               `json:"allowNullValue,omitempty"`
+	Description    string             `json:"description,omitempty"`
+}
+
+// MarshalFunctionParameterShim converts a provider-defined function parameter into a
+// MarshallableFunctionParameterShim.
+func MarshalFunctionParameterShim(p shim.FunctionParameter) MarshallableFunctionParameterShim {
+	return MarshallableFunctionParameterShim{
+		Name:           p.Name,
+		Type:           MarshallableTFType{Type: p.Type},
+		AllowNullValue: p.AllowNullValue,
+		Description:    p.Description,
+	}
+}
+
+// Unmarshal creates a provider-defined function parameter from the given
+// MarshallableFunctionParameterShim.
+func (m MarshallableFunctionParameterShim) Unmarshal() shim.FunctionParameter {
+	return shim.FunctionParameter{
+		Name:           m.Name,
+		Type:           m.Type.Type,
+		AllowNullValue: m.AllowNullValue,
+		Description:    m.Description,
+	}
+}
+
+// MarshallableFunctionShim is the JSON-marshallable form of a provider-defined function
+// signature.
+type MarshallableFunctionShim struct {
+	Parameters         []MarshallableFunctionParameterShim `json:"parameters,omitempty"`
+	VariadicParameter  *MarshallableFunctionParameterShim  `json:"variadicParameter,omitempty"`
+	Return             MarshallableTFType                  `json:"return"`
+	Summary            string                              `json:"summary,omitempty"`
+	Description        string                              `json:"description,omitempty"`
+	DeprecationMessage string                              `json:"deprecationMessage,omitempty"`
+}
+
+// MarshalFunctionShim converts a provider-defined function signature into a
+// MarshallableFunctionShim.
+func MarshalFunctionShim(f shim.Function) MarshallableFunctionShim {
+	var parameters []MarshallableFunctionParameterShim
+	if len(f.Parameters) > 0 {
+		parameters = make([]MarshallableFunctionParameterShim, len(f.Parameters))
+		for i, p := range f.Parameters {
+			parameters[i] = MarshalFunctionParameterShim(p)
+		}
+	}
+	var variadic *MarshallableFunctionParameterShim
+	if f.VariadicParameter != nil {
+		v := MarshalFunctionParameterShim(*f.VariadicParameter)
+		variadic = &v
+	}
+	return MarshallableFunctionShim{
+		Parameters:         parameters,
+		VariadicParameter:  variadic,
+		Return:             MarshallableTFType{Type: f.Return},
+		Summary:            f.Summary,
+		Description:        f.Description,
+		DeprecationMessage: f.DeprecationMessage,
+	}
+}
+
+// Unmarshal creates a provider-defined function signature from the given
+// MarshallableFunctionShim.
+func (m MarshallableFunctionShim) Unmarshal() shim.Function {
+	var parameters []shim.FunctionParameter
+	if len(m.Parameters) > 0 {
+		parameters = make([]shim.FunctionParameter, len(m.Parameters))
+		for i, p := range m.Parameters {
+			parameters[i] = p.Unmarshal()
+		}
+	}
+	var variadic *shim.FunctionParameter
+	if m.VariadicParameter != nil {
+		v := m.VariadicParameter.Unmarshal()
+		variadic = &v
+	}
+	return shim.Function{
+		Parameters:         parameters,
+		VariadicParameter:  variadic,
+		Return:             m.Return.Type,
+		Summary:            m.Summary,
+		Description:        m.Description,
+		DeprecationMessage: m.DeprecationMessage,
+	}
+}
+
 // MarshallableProviderShim is the JSON-marshallable form of a Terraform provider schema.
 type MarshallableProviderShim struct {
 	Schema      map[string]*MarshallableSchemaShim  `json:"schema,omitempty"`
 	Resources   map[string]MarshallableResourceShim `json:"resources,omitempty"`
 	DataSources map[string]MarshallableResourceShim `json:"dataSources,omitempty"`
+	Functions   map[string]MarshallableFunctionShim `json:"functions,omitempty"`
 }
 
 // MarshalProviderShim converts a Terraform provider schema into a MarshallableProviderShim.
@@ -1111,10 +1236,18 @@ func MarshalProviderShim(p shim.Provider) *MarshallableProviderShim {
 		dataSources[k] = MarshalResourceShim(v)
 		return true
 	})
+	var functions map[string]MarshallableFunctionShim
+	if fns := p.Functions(); len(fns) > 0 {
+		functions = make(map[string]MarshallableFunctionShim, len(fns))
+		for k, v := range fns {
+			functions[k] = MarshalFunctionShim(v)
+		}
+	}
 	return &MarshallableProviderShim{
 		Schema:      config,
 		Resources:   resources,
 		DataSources: dataSources,
+		Functions:   functions,
 	}
 }
 
@@ -1136,10 +1269,18 @@ func (m *MarshallableProviderShim) Unmarshal() shim.Provider {
 	for k, v := range m.DataSources {
 		dataSources[k] = v.Unmarshal()
 	}
+	var functions map[string]shim.Function
+	if len(m.Functions) > 0 {
+		functions = make(map[string]shim.Function, len(m.Functions))
+		for k, v := range m.Functions {
+			functions[k] = v.Unmarshal()
+		}
+	}
 	return (&schema.Provider{
 		Schema:         config,
 		ResourcesMap:   resources,
 		DataSourcesMap: dataSources,
+		Functions:      functions,
 	}).Shim()
 }
 
@@ -1325,8 +1466,6 @@ func (m *MarshallableDataSource) Unmarshal() *DataSource {
 // MarshallableFunction is the JSON-marshallable form of a Pulumi FunctionInfo value.
 type MarshallableFunction struct {
 	Tok tokens.ModuleMember `json:"tok"`
-	// Variadic is true when the function's final Terraform parameter is variadic.
-	Variadic bool `json:"variadic,omitempty"`
 }
 
 // MarshalFunction converts a Pulumi FunctionInfo value into a MarshallableFunction value.
@@ -1335,9 +1474,6 @@ func MarshalFunction(f *Function) *MarshallableFunction {
 }
 
 // Unmarshal creates a mostly-initialized Pulumi FunctionInfo value from the given MarshallableFunction.
-//
-// Variadic is wire-only and is dropped: consumers that need it read the
-// MarshallableFunction form directly.
 func (m *MarshallableFunction) Unmarshal() *Function {
 	return &Function{Tok: m.Tok}
 }
@@ -1371,19 +1507,9 @@ func MarshalProvider(p *Provider) *MarshallableProvider {
 	}
 	var functions map[string]*MarshallableFunction
 	if len(p.Functions) > 0 {
-		var shimFunctions map[string]shim.Function
-		if p.P != nil {
-			shimFunctions = p.P.Functions()
-		}
 		functions = make(map[string]*MarshallableFunction)
 		for k, v := range p.Functions {
-			mf := MarshalFunction(v)
-			// The provider's signature is authoritative for variadic-ness; the info
-			// value is author-provided and does not carry it.
-			if fn, ok := shimFunctions[k]; ok {
-				mf.Variadic = fn.VariadicParameter != nil
-			}
-			functions[k] = mf
+			functions[k] = MarshalFunction(v)
 		}
 	}
 

--- a/pkg/tfbridge/info/marshal_functions_test.go
+++ b/pkg/tfbridge/info/marshal_functions_test.go
@@ -1,0 +1,88 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This test lives in an external test package (unlike info_test.go) because it keeps
+// Provider's methods reflection-reachable, which requires the pkg/tfbridge linkname
+// targets of external_methods.go to be linked into the test binary.
+package info_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge" // linkname targets
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
+	schemashim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
+)
+
+// Provider-defined function signatures round-trip through the JSON wire form, so
+// mapping consumers can recover the full Terraform signature (including variadic-ness)
+// from the provider schema section.
+func TestMarshallableProviderFunctions(t *testing.T) {
+	t.Parallel()
+
+	functions := map[string]shim.Function{
+		"concat": {
+			Parameters: []shim.FunctionParameter{{
+				Name:        "separator",
+				Type:        tftypes.String,
+				Description: "String placed between each part.",
+			}},
+			VariadicParameter: &shim.FunctionParameter{
+				Name:           "parts",
+				Type:           tftypes.String,
+				AllowNullValue: true,
+			},
+			Return:  tftypes.String,
+			Summary: "Concatenates strings with a separator.",
+		},
+		"parse_id": {
+			Parameters: []shim.FunctionParameter{
+				{Name: "id", Type: tftypes.String},
+				{Name: "extra", Type: tftypes.DynamicPseudoType},
+				{Name: "tags", Type: tftypes.List{ElementType: tftypes.String}},
+			},
+			Return: tftypes.Object{
+				AttributeTypes: map[string]tftypes.Type{
+					"prefix": tftypes.String,
+					"suffix": tftypes.String,
+				},
+				OptionalAttributes: map[string]struct{}{"suffix": {}},
+			},
+			Description:        "Splits prefix/suffix identifiers.",
+			DeprecationMessage: "use split_id instead",
+		},
+	}
+
+	provider := &info.Provider{
+		Name: "test",
+		P:    (&schemashim.Provider{Functions: functions}).Shim(),
+		Functions: map[string]*info.Function{
+			"concat":   {Tok: "test:index/concat:concat"},
+			"parse_id": {Tok: "test:index/parseId:parseId"},
+		},
+	}
+
+	data, err := json.Marshal(info.MarshalProvider(provider))
+	require.NoError(t, err)
+	var decoded info.MarshallableProvider
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, functions, decoded.Unmarshal().P.Functions())
+}


### PR DESCRIPTION
## Summary

`MarshallableProviderShim` gains a `functions` section carrying each provider-defined function's Terraform signature — parameters, the variadic parameter, return type, and documentation — with `tftypes` values encoded using Terraform's type-signature JSON (the same encoding the plugin protocol uses, via `tftypes.ParseJSONType`, matching the dynamic bridge's existing use). Unmarshaling reconstructs the signatures on the schema-only provider, so mapping consumers read them as `info.P.Functions()`.

This replaces `MarshallableFunction.Variadic` (added on https://github.com/pulumi/pulumi-terraform-bridge/pull/3510, unreleased): that field stowed a single derived signature fact in the author-facing `functions` mapping section, whose `Unmarshal()` dropped it, forcing consumers to read the wire form directly. A function's signature is provider schema of the same kind as resource and data source schemas, so it belongs in the provider schema section — and the next signature fact a consumer needs (parameter types, `AllowNullValue`, docs) requires no new wire field.

All GetMapping surfaces (plain, muxed, dynamic) route through `MarshalProviderInfo`, so they all pick this up.

Consumer migration: pulumi-hcl currently reads `MarshallableFunction.Variadic` from the payload (https://github.com/pulumi-labs/pulumi-hcl/pull/315, also unreleased); after this merges it switches to `info.P.Functions()[name].VariadicParameter != nil` and drops its wire-form side-channel.

## Testing

- `TestMarshallableProviderFunctions`: JSON round-trip of full signatures through `MarshallableProvider`, covering variadic, `AllowNullValue`, object/list/dynamic types, and `OptionalAttributes`.
- `TestPFGetMappingFunctions`: updated to assert the `functions` mapping section is `Tok`-only and the unmarshaled provider shim carries the exact `concat` signature.
- `go test ./pkg/tfbridge/... ./pkg/tfshim/...` (3116 tests), `./pkg/pf/proto/...`, `./pkg/pf/internal/schemashim/...`, muxed function invoke test, and lint are green; the `dynamic` module builds.