### PR TITLE
functions: model a variadic `dynamic` parameter as a dynamic argument

### DIFF
--- a/pkg/internal/functions/functions.go
+++ b/pkg/internal/functions/functions.go
@@ -168,7 +168,15 @@ func ArgumentsSchema(fn shim.Function, argNames []string) (ObjectSchema, error) 
 		}
 	}
 	if v := fn.VariadicParameter; v != nil {
-		if err := add(argNames[len(fn.Parameters)], tftypes.List{ElementType: v.Type}); err != nil {
+		// A variadic `dynamic` parameter collects arguments of differing types,
+		// which a List — requiring one element type — cannot represent. Model it
+		// as a dynamic attribute so the encoder can emit a Tuple and the object
+		// accepts it; a concretely-typed variadic parameter stays a List.
+		argType := tftypes.Type(tftypes.List{ElementType: v.Type})
+		if v.Type.Is(tftypes.DynamicPseudoType) {
+			argType = tftypes.DynamicPseudoType
+		}
+		if err := add(argNames[len(fn.Parameters)], argType); err != nil {
 			return ObjectSchema{}, err
 		}
 	}

--- a/pkg/internal/functions/functions_test.go
+++ b/pkg/internal/functions/functions_test.go
@@ -180,6 +180,52 @@ func TestArgumentsSchemaRoundTrip(t *testing.T) {
 	assert.Equal(t, args, decoded)
 }
 
+// A variadic `dynamic` parameter collects arguments of differing types, so it
+// must be modeled as a dynamic attribute rather than a homogeneous list:
+// encoding heterogeneous arguments into a List panics on the mismatched element
+// types, whereas a dynamic attribute accepts the resulting Tuple.
+func TestArgumentsSchemaVariadicDynamic(t *testing.T) {
+	t.Parallel()
+
+	fn := shim.Function{
+		VariadicParameter: &shim.FunctionParameter{Name: "maps", Type: tftypes.DynamicPseudoType},
+		Return:            tftypes.DynamicPseudoType,
+	}
+	argNames := ArgumentNames(fn)
+	require.Equal(t, []string{"maps"}, argNames)
+
+	os, err := ArgumentsSchema(fn, argNames)
+	require.NoError(t, err)
+	assert.Equal(t, tftypes.DynamicPseudoType, os.Type.AttributeTypes["maps"],
+		"a dynamic variadic argument must be a dynamic attribute, not a list")
+
+	enc, err := convert.NewObjectEncoder(convert.ObjectSchema{
+		SchemaMap:   os.SchemaMap,
+		SchemaInfos: os.SchemaInfos,
+		Object:      &os.Type,
+	})
+	require.NoError(t, err)
+
+	// Two arguments of differing shapes, as in deepmerge's mergo(defaults, {}).
+	args := resource.PropertyMap{
+		"maps": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewObjectProperty(resource.PropertyMap{
+				"a":      resource.NewNumberProperty(1),
+				"nested": resource.NewObjectProperty(resource.PropertyMap{"x": resource.NewStringProperty("y")}),
+			}),
+			resource.NewObjectProperty(resource.PropertyMap{"b": resource.NewStringProperty("two")}),
+		}),
+	}
+
+	encoded, err := convert.EncodePropertyMap(enc, args)
+	require.NoError(t, err)
+
+	var attrs map[string]tftypes.Value
+	require.NoError(t, encoded.As(&attrs))
+	assert.True(t, attrs["maps"].Type().Is(tftypes.Tuple{}),
+		"heterogeneous variadic arguments must encode to a tuple, got %s", attrs["maps"].Type())
+}
+
 func TestResultSchema(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

Invoking a provider-defined function whose **variadic parameter is `dynamic`** with two or more arguments of **different concrete types** panics the provider process:

```
panic: lists must only contain one type of element,
  saw tftypes.Object["a":tftypes.Number, "nested":tftypes.Object["x":tftypes.String]]
  and tftypes.Object["b":tftypes.String]
```

A function's variadic parameter is projected to a synthetic argument in the argument object, always typed `tftypes.List{ElementType: v.Type}` (`pkg/internal/functions/functions.go`). For a variadic `dynamic` parameter, `v.Type` is `DynamicPseudoType`, so the argument object declares that attribute as `List[DynamicPseudoType]`. Terraform passes each variadic argument as an independent positional `dynamic` value, so their types need not match — but encoding a heterogeneous set into a single `tftypes.List` (which requires one element type) panics.

## Fix

Model a variadic `dynamic` parameter as a `DynamicPseudoType` argument rather than a `List` of dynamic. The encoder then emits a `Tuple` for heterogeneous arguments (and a `List` for uniform ones), and the argument object accepts it because a dynamic attribute holds a value of any type. The downstream split in `callFunction` already re-marshals each element as its own `dynamic` value, so nothing else changes. A concretely-typed variadic parameter (e.g. `string...`) is untouched and stays a homogeneous `List`.

## Test

`TestArgumentsSchemaVariadicDynamic` in `pkg/internal/functions/functions_test.go` builds the argument schema for a variadic `dynamic` function and encodes a heterogeneous argument set through `convert.EncodePropertyMap` — the exact object-encoding path that panicked. Without the fix it reproduces the production panic; with it the argument encodes to a `Tuple`. `pkg/internal/functions` and `pkg/convert` are green.

## Validated end to end

Built `pulumi-resource-terraform-provider` from this branch and ran the reproducing program (the `MaterializeInc/materialize-terraform-self-managed` operator module via `pulumi-labs/pulumi-hcl`, whose `helm_release` values call `provider::deepmerge::mergo(local.default_helm_values, var.helm_values)` with `var.helm_values = {}`). The invoke previously panicked; it now completes and the full program previews cleanly. Minimal repro: `provider::deepmerge::mergo({ a = 1, nested = { x = "y" } }, { b = "two" })`.