### PR TITLE
Update SDK-to-Plugin-Framework migration guides

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -17,4 +17,5 @@
 /docs/guides/sets
 /docs/guides/testing
 /docs/guides/upgrade-sdk-to-mux
+/docs/guides/upgrade-sdk-to-pf
 :::

--- a/docs/guides/new-pf-provider.md
+++ b/docs/guides/new-pf-provider.md
@@ -19,7 +19,7 @@ Follow these steps to bridge a Terraform Provider to Pulumi.
     import (
         _ "embed"
         "github.com/hashicorp/terraform-plugin-framework/provider"
-        pf "github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfbridge"
+        pf "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
         "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
     )
 
@@ -74,7 +74,7 @@ Follow these steps to bridge a Terraform Provider to Pulumi.
         "context"
         _ "embed"
 
-        "github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfbridge"
+        "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
         // import myprovider
     )
 

--- a/docs/guides/upgrade-sdk-to-mux.md
+++ b/docs/guides/upgrade-sdk-to-mux.md
@@ -1,153 +1,157 @@
-# How to Upgrade a provider that has partially migrated to the Plugin Framework
+# Upgrading a Partially Migrated Provider with the PF Muxer
 
-Follow these steps if you have a Pulumi provider that was bridged from a Terraform
-provider built against [Terraform Plugin
-SDK](https://github.com/hashicorp/terraform-plugin-sdk) and you want to upgrade it to a
-version that has migrated some but not all resources/datasources to the [Plugin
-Framework](https://github.com/hashicorp/terraform-plugin-framework?tab=readme).
+Follow these steps when an upstream Terraform provider has migrated some, but not
+all, resources or data sources from Terraform Plugin SDKv2 to
+[Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework).
+The resulting Pulumi provider dispatches each Terraform token to either the SDKv2
+or Framework implementation.
 
-1. Ensure you have access to the
-   `github.com/hashicorp/terraform-plugin-framework/provider.Provider` from the upstream
-   provider.  If the provider is shimmed (or needs to be), you can follow step (1) from
-   ["How to Upgrade a Bridged Provider to Plugin
-   Framework"](./upgrade-sdk-to-pf.md).
+The examples below use SDKv2. Providers still using Terraform Plugin SDKv1 can
+follow the same structure with
+`github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v1` in place of the
+SDKv2 shim.
 
-1. Find the tfgen binary `main` that calls `tfgen.Main` from
-   `github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen` and update it to call
-   `tfgen.MainWithMuxer` from `github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen`.
+1. Obtain both upstream provider implementations:
 
-   Note that the extra version parameter is removed from `tfgen.Main`, so this code:
+   - an SDK provider, normally a
+     `*github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.Provider`; and
+   - a `github.com/hashicorp/terraform-plugin-framework/provider.Provider`.
+
+   If either constructor is in a Go `internal` package, expose it through a small
+   shim module as described in step 1 of the
+   [PF-only migration guide](./upgrade-sdk-to-pf.md). Real providers commonly pass
+   a version or `context.Context` to these constructors, or construct the Framework
+   provider from the SDK provider so both share configuration. Preserve that
+   upstream initialization rather than assuming the constructors are independent.
+
+2. Set up provider metadata.
+
+   Muxed providers require generated bridge metadata for their dispatch table.
+   Bootstrap the file before adding a `go:embed` directive:
+
+   ```sh
+   echo '{}' > provider/cmd/pulumi-resource-myprovider/bridge-metadata.json
+   ```
+
+   Adjust the path if running from the `provider` directory. See
+   [Provider Metadata](./metadata.md) for the complete setup.
+
+3. Update the code that declares `tfbridge.ProviderInfo`, typically
+   `provider/resources.go`, to combine the two implementations:
 
    ```go
-   import "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen"
+   package myprovider
 
-   ...
+   import (
+       "context"
+       _ "embed"
 
-   tfgen.Main("cloudflare", version.Version, tls.Provider())
+       pftfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
+       "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+       shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
+
+       "github.com/pulumi/pulumi-myprovider/provider/pkg/version"
+       "github.com/pulumi/pulumi-myprovider/provider/upstream"
+   )
+
+   //go:embed cmd/pulumi-resource-myprovider/bridge-metadata.json
+   var bridgeMetadata []byte
+
+   func Provider() tfbridge.ProviderInfo {
+       ctx := context.Background()
+       sdkProvider := upstream.SDKProvider()
+       frameworkProvider := upstream.PFProvider()
+
+       p := pftfbridge.MuxShimWithPF(
+           ctx,
+           shimv2.NewProvider(sdkProvider),
+           frameworkProvider,
+       )
+
+       return tfbridge.ProviderInfo{
+           P: p,
+
+           // The mux entrypoints read the version from ProviderInfo rather than
+           // receiving it as a separate argument.
+           Version: version.Version,
+
+           MetadataInfo: tfbridge.NewProviderMetadata(bridgeMetadata),
+
+           // Keep the rest of the provider mapping as before.
+       }
+   }
    ```
 
-   Becomes:
+   Replace `upstream.SDKProvider()` and `upstream.PFProvider()` with the constructors
+   exposed by the upstream provider or its shim. It is also reasonable for
+   `Provider` to accept a `context.Context` and pass it to both constructors.
 
-   ``` go
-   import "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen"
+   Choose the mux helper according to the upstream ownership model:
 
-   ...
+   - `MuxShimWithPF` permits overlapping Terraform tokens. When both providers expose
+     a token, the SDK implementation wins.
+   - `MuxShimWithDisjointgPF` requires disjoint token sets and panics on overlap. Use
+     it when the upstream migration is expected to have exactly one owner for every
+     token; it catches ownership mistakes early. `DisjointgPF` is the current
+     exported spelling.
 
-   tfgen.MainWithMuxer("cloudflare", cloudflare.Provider())
+4. Update the tfgen binary to use `pkg/pf/tfgen.MainWithMuxer`. Remove the separate
+   version argument because it now comes from `ProviderInfo.Version`:
+
+   ```go
+   import pftfgen "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen"
+
+   func main() {
+       pftfgen.MainWithMuxer("myprovider", myprovider.Provider())
+   }
    ```
 
-1. Find the provider binary `main` that calls
-   [`"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge".Main`](https://pkg.go.dev/github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge#Main)
-   and update it to
-   [`"github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfbridge".MainWithMuxer`](https://pkg.go.dev/github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfbridge#MainWithMuxer).
+   This replaces the SDK form:
 
-   Note the signature changes: version parameter is removed, and `Context` is now required, so this
-   code:
+   ```go
+   tfgen.Main("myprovider", version.Version, myprovider.Provider())
+   ```
 
-     ```go
-    import "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+5. Update the provider binary to use
+   `github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge.MainWithMuxer`.
+   It requires a `context.Context`, takes the version from `ProviderInfo`, and
+   receives the generated Pulumi schema directly:
 
-    ...
+   ```go
+   import (
+       "context"
+       _ "embed"
 
-     tfbridge.Main("cloudflare", version.Version, cloudflare.Provider(), pulumiSchema)
-     ```
+       pftfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
+   )
 
-     Becomes:
+   //go:embed schema-embed.json
+   var pulumiSchema []byte
 
-    ```go
-    import "github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfbridge"
+   func main() {
+       pftfbridge.MainWithMuxer(
+           context.Background(),
+           "myprovider",
+           myprovider.Provider(),
+           pulumiSchema,
+       )
+   }
+   ```
 
-    ...
+   `MainWithMuxer` and the corresponding tfgen entrypoint are currently
+   experimental bridge APIs, although they are used by production providers.
 
-    tfbridge.MainWithMuxer(context.Background(), "cloudflare", cloudflare.Provider(), pulumiSchema)
-    ```
+6. Continue with the normal upstream-provider update. Tfgen computes the Pulumi
+   package schema and mux dispatch metadata. Build the provider and SDKs and run
+   tests:
 
-1. Update code declaring
-   [`ProviderInfo`](https://pkg.go.dev/github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge#ProviderInfo)
-   (typically in `provider/resources.go`), changing the embedded
-   `"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge".ProviderInfo.P` to the
-   result of calling
-   [`"github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfbridge".MuxShimWithPF`](https://pkg.go.dev/github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfbridge#MuxShimWithPF).
+   ```sh
+   make tfgen
+   make provider
+   make build_sdks
+   make test
+   ```
 
-   This function combines the original SDK based provider with the new PF based provider, so this code:
-
-    ```go
-    import (
-		"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-		shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
-
-		"github.com/${PROVIDER_ORG}/terraform-provider-${PROVIDER_NAME}"
-	)
-
-    ...
-
-    func Provider() tfbridge.ProviderInfo {
-	    p := shimv2.NewProvider(${PROVIDER_NAME}.SDKProvider())
-
-	    prov := tfbridge.ProviderInfo{
-			P: p,
-	        ...
-	    }
-
-		...
-
-		return prov
-    }
-    ```
-
-    > You should replace
-    > `github.com/${PROVIDER_ORG}/terraform-provider-${PROVIDER_NAME}.SDKProvider()` with
-    > whatever function is necessary to produce the
-    > `*github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.Provider` used by the
-    > upstream provider.
-
-    Becomes:
-
-    ```go
-    import (
-    	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
-       	pfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfbridge"
-       	shimv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
-
-        "github.com/${PROVIDER_ORG}/terraform-provider-${PROVIDER_NAME}"
-    )
-
-    ...
-
-    func Provider() tfbridge.ProviderInfo {
-        p := pfbridge.MuxShimWithPF(context.Background(),
-			shimv2.NewProvider(${PROVIDER_NAME}.SDKProvider()),
-			${PROVIDER_NAME}.PFProvider(),
-	    )
-
-	    prov := tfbridge.ProviderInfo{
-			P: p,
-	        ...
-	    }
-
-        ...
-
-        return prov
-    }
-    ```
-
-    > You should replace
-    > `github.com/${PROVIDER_ORG}/terraform-provider-${PROVIDER_NAME}.PFProvider()` with
-    > whatever function is necessary to produce the
-    > `github.com/hashicorp/terraform-plugin-framework/provider.Provider` used by the
-    > upstream provider.
-
-1. Ensure that `tfbridge.ProviderInfo.MetadataInfo` is set.
-
-   For details on setting this up, see [here](./metadata.md#setup).
-
-1. From this point the update proceeds as a typical upstream provider update. Build and
-   run the tfgen binary to compute the Pulumi Package Schema. It will now also compute a
-   new metadata file `bridge-metadata.json`, build the provider binary, re-generate
-   language-specific SDKs and run tests.
-
-    ```
-    make tfgen
-    make provider
-    make build_sdks
-    ```
+   Review the generated `bridge-metadata.json` and schema changes before committing
+   them. In particular, confirm that resources and data sources moved upstream are
+   dispatched to the Framework side and unchanged tokens remain on the SDK side.

--- a/docs/guides/upgrade-sdk-to-pf.md
+++ b/docs/guides/upgrade-sdk-to-pf.md
@@ -1,110 +1,159 @@
 # Upgrading a Bridged Provider to Plugin Framework
 
-Follow these steps if you have a Pulumi provider that was bridged from a Terraform provider built against
-[Terraform Plugin SDK](https://github.com/hashicorp/terraform-plugin-sdk) and you want to upgrade it to a version that has migrated to the Plugin Framework.
+Follow these steps when an upstream Terraform provider has migrated all of the
+resources and data sources used by the Pulumi provider from Terraform Plugin SDKv2
+to [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework).
+If the upstream provider has migrated only part of its surface, follow the
+[muxed-provider guide](./upgrade-sdk-to-mux.md) instead.
 
-1. Ensure you have access to the [`github.com/hashicorp/terraform-plugin-framework/provider.Provider`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework@v1.16.0/provider#Provider) from
-   the upstream provider.  Make sure the module is now depending on
-   `"github.com/hashicorp/terraform-plugin-framework"` instead of
-   `"github.com/hashicorp/terraform-plugin-sdk/v2"`.  If the provider is shimmed (or needs to be), update the
-   source code accordingly. For example, a `shim.go` that looked like this:
+1. Obtain the upstream
+   [`provider.Provider`](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework/provider#Provider).
 
-    ```go
-    package shim
+   Add `github.com/hashicorp/terraform-plugin-framework` to the module that exposes
+   the upstream provider. Once that module no longer imports SDKv2 directly, `go mod
+   tidy` can remove its direct `github.com/hashicorp/terraform-plugin-sdk/v2`
+   dependency.
 
-    import (
-        "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-        "github.com/hashicorp/terraform-provider-tls/internal/provider"
-    )
+   When the upstream constructor is in a Go `internal` package, a small shim module
+   can expose it. For example, an SDKv2 shim such as:
 
-    func NewProvider() *schema.Provider {
-        p, _ := provider.New()
-        return p
-    }
-    ```
+   ```go
+   package shim
 
-   Becomes:
+   import (
+       "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+       "github.com/hashicorp/terraform-provider-tls/internal/provider"
+   )
 
-    ```go
-    package shim
+   func NewProvider() *schema.Provider {
+       p, _ := provider.New()
+       return p
+   }
+   ```
 
-    import (
-        "github.com/hashicorp/terraform-plugin-framework/provider"
-        p "github.com/hashicorp/terraform-provider-tls/internal/provider"
-    )
+   becomes:
 
-    func NewProvider() provider.Provider {
-        return p.New()
-    }
-    ```
+   ```go
+   package shim
 
-   Make sure the module builds:
+   import (
+       "github.com/hashicorp/terraform-plugin-framework/provider"
+       tlsprovider "github.com/hashicorp/terraform-provider-tls/internal/provider"
+   )
 
-     ```
-     cd provider/shim
-     go mod tidy
-     go build
-     ```
+   func NewProvider() provider.Provider {
+       return tlsprovider.New()
+   }
+   ```
 
-2. Find tfgen binary `main` that calls `tfgen.Main` from `github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen`
-   and update it to call `tfgen.Main` from `github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen`.
+   Providers that already export a Framework constructor do not need a separate
+   shim module. Provider constructors also commonly require a version or a
+   `context.Context`; preserve those arguments when exposing the constructor.
 
-   Note that the extra verson parameter is removed from `tfgen.Main`, so this code:
+   From the repository root, make sure the shim module builds:
 
-    ```go
-    tfgen.Main("tls", version.Version, tls.Provider())
-    ```
+   ```sh
+   (cd provider/shim && go mod tidy && go build ./...)
+   ```
 
-   Becomes:
+2. Set up provider metadata.
 
-    ```
-    tfgen.Main("tls", tls.Provider())
-    ```
+   Plugin Framework providers require generated bridge metadata. Bootstrap the file
+   before adding a `go:embed` directive, otherwise the provider package cannot
+   compile and tfgen cannot run:
 
-3. Find the provider binary `main` that calls `tfbridge.Main` from
-   `github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge` and update it to `Main` from
-   `github.com/pulumi/pulumi-terraform-bridge/v3/pf/tfbridge`. Note the signature changes: version parameter is removed,
-   `Context` is now required, and there is a new `bridge-metadata.json` blob that needs to be embedded:
+   ```sh
+   echo '{}' > provider/cmd/pulumi-resource-myprovider/bridge-metadata.json
+   ```
 
-     ```go
-     ...
+   Adjust the path if running from the `provider` directory. See
+   [Provider Metadata](./metadata.md) for the complete setup.
 
-     func main() {
-         meta := tfbridge.ProviderMetadata{PackageSchema: schema}
-         tfbridge.Main(context.Background(), "myprovider", myprovider.MyProvider(), meta)
-     }
-     ```
+3. Update the code that declares `tfbridge.ProviderInfo`, typically
+   `provider/resources.go`:
 
-4. Update code declaring `tfbridge.ProviderInfo` (typically in `provider/resources.go`):
+   ```go
+   package myprovider
 
-    ```go
+   import (
+       _ "embed"
 
-    //go:embed cmd/pulumi-resource-myprovider/bridge-metadata.json
-    var bridgeMetadata []byte
+       pftfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
+       "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 
-    func Provider() tfbridge.ProviderInfo {
-        info := tfbridge.ProviderInfo{
-            // Replace P (abbreviated for Provider):
-            P: pf.ShimProvider(shim.NewProvider()).
+       "github.com/pulumi/pulumi-myprovider/provider/pkg/version"
+       "github.com/pulumi/pulumi-myprovider/provider/shim"
+   )
 
-            // Make sure Version is set, as it is now required.
-            Version: ...,
+   //go:embed cmd/pulumi-resource-myprovider/bridge-metadata.json
+   var bridgeMetadata []byte
 
-            // This is now required.
-            MetadataInfo: tfbridge.NewProviderMetadata(bridgeMetadata),
+   func Provider() tfbridge.ProviderInfo {
+       return tfbridge.ProviderInfo{
+           // Replace the SDKv2 shim with the Plugin Framework shim.
+           P: pftfbridge.ShimProvider(shim.NewProvider()),
 
-            // Keep the rest of the code as before.
-        }
-        return info
-    }
-    ```
+           // The PF entrypoints read the version from ProviderInfo rather than
+           // receiving it as a separate argument.
+           Version: version.Version,
 
-5. From this point the update proceeds as a typical upstream provider update. Build and run the tfgen binary to compute
-   the Pulumi Package Schema. It will now also compute a new metadata file `bridge-metadata.json`, build the provider
-   binary, re-generate language-specific SDKs and run tests.
+           MetadataInfo: tfbridge.NewProviderMetadata(bridgeMetadata),
 
-    ```
-    make tfgen
-    make provider
-    make build_sdks
-    ```
+           // Keep the rest of the provider mapping as before.
+       }
+   }
+   ```
+
+4. Update the tfgen binary to use `pkg/pf/tfgen`. The PF entrypoint reads the
+   version from `ProviderInfo`, so remove the separate version argument:
+
+   ```go
+   import pftfgen "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfgen"
+
+   func main() {
+       pftfgen.Main("myprovider", myprovider.Provider())
+   }
+   ```
+
+   This replaces the SDKv2 form:
+
+   ```go
+   tfgen.Main("myprovider", version.Version, myprovider.Provider())
+   ```
+
+5. Update the provider binary to use `pkg/pf/tfbridge.Main`. It requires a
+   `context.Context` and `ProviderMetadata` containing the generated Pulumi package
+   schema:
+
+   ```go
+   import (
+       "context"
+       _ "embed"
+
+       pftfbridge "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
+   )
+
+   //go:embed schema-embed.json
+   var pulumiSchema []byte
+
+   func main() {
+       meta := pftfbridge.ProviderMetadata{PackageSchema: pulumiSchema}
+       pftfbridge.Main(context.Background(), "myprovider", myprovider.Provider(), meta)
+   }
+   ```
+
+   `bridge-metadata.json` is supplied through `ProviderInfo.MetadataInfo` from step
+   3. Do not add it to `ProviderMetadata.BridgeMetadata`; that field is deprecated.
+
+6. Continue with the normal upstream-provider update. Generate the schema and bridge
+   metadata, build the provider and SDKs, and run tests:
+
+   ```sh
+   make tfgen
+   make provider
+   make build_sdks
+   make test
+   ```
+
+   Review the generated `bridge-metadata.json` and schema changes before committing
+   them.


### PR DESCRIPTION
## Summary

- refresh the SDKv2-to-Plugin-Framework migration guide
- expand the partial-migration guide using patterns from current muxed providers
- document required provider version and metadata setup
- explain overlapping versus disjoint mux ownership
- fix stale `pkg/pf` import paths and add the PF migration guide to the docs index

## Details

The previous guides described the basic migration shape but had stale runtime
package paths and did not fully represent current provider setups. The revised
guides cover shim modules for upstream `internal` packages, context/version-aware
constructors, metadata bootstrapping, modern runtime `ProviderMetadata`, SDKv1
scope, and both available PF mux helpers.

Bridge-side enforcement of the required `ProviderInfo.Version` is tracked
separately in #3529.

## Validation

- `mise exec python@3.12 -- make -C docs build`
- `git diff --check`
