### PR TITLE
fix(pf): send a compatible Terraform version

### DIFF
--- a/dynamic/provider_test.go
+++ b/dynamic/provider_test.go
@@ -790,6 +790,9 @@ func TestSDKv1Provider(t *testing.T) {
 
 	server := parameterizedTestServer(t, sdkv1ProviderPath)
 
+	_, err := server.Configure(t.Context(), &pulumirpc.ConfigureRequest{})
+	require.NoError(t, err)
+
 	const typ = "sdkv1:index/res:Res"
 	urn := string(resource.NewURN(
 		"test", "test", "", typ, "res",

--- a/dynamic/test/sdkv1provider/main.go
+++ b/dynamic/test/sdkv1provider/main.go
@@ -1,16 +1,16 @@
 package main
 
 import (
+	"fmt"
+
+	goversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func Provider() *schema.Provider {
-	return &schema.Provider{
-		ConfigureFunc: func(*schema.ResourceData) (any, error) {
-			return nil, nil
-		},
+	p := &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
 			"test_res": {
 				Schema: map[string]*schema.Schema{
@@ -26,6 +26,19 @@ func Provider() *schema.Provider {
 			},
 		},
 	}
+	p.ConfigureFunc = func(*schema.ResourceData) (any, error) {
+		terraformVersion, err := goversion.NewVersion(p.TerraformVersion)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Terraform version %q: %w", p.TerraformVersion, err)
+		}
+		minimumVersion := goversion.Must(goversion.NewVersion("1.0.0"))
+		if terraformVersion.LessThan(minimumVersion) {
+			return nil, fmt.Errorf("terraform version %s is below minimum version %s",
+				terraformVersion, minimumVersion)
+		}
+		return nil, nil
+	}
+	return p
 }
 
 func main() {

--- a/dynamic/testdata/TestConfigInDestroy/logs.json
+++ b/dynamic/testdata/TestConfigInDestroy/logs.json
@@ -26,7 +26,7 @@
   {
     "name": "github.com/hashicorp/terraform-plugin-mux/tf5to6server.v5tov6Server.ConfigureProvider",
     "call": "/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.16.0/tf5to6server/tf5to6server.go:60",
-    "request": "terraform_version:\"pulumi-terraform-bridge\" config:{msgpack:\"\\x86\\xa6app_id\\xa6pulumi\\xa8endpoint\\xd9(https://phpipam.space.voided.network/api\\xa8insecure\\xc0\\xb2nest_custom_fields\\xc0\\xa8password\\xbeRrS94KVOZHbQnHEOhl0joqEM8MumxN\\xa8username\\xa6pulumi\"}",
+    "request": "terraform_version:\"1.0.0+pulumi-terraform-bridge\" config:{msgpack:\"\\x86\\xa6app_id\\xa6pulumi\\xa8endpoint\\xd9(https://phpipam.space.voided.network/api\\xa8insecure\\xc0\\xb2nest_custom_fields\\xc0\\xa8password\\xbeRrS94KVOZHbQnHEOhl0joqEM8MumxN\\xa8username\\xa6pulumi\"}",
     "response": "{}"
   },
   {

--- a/dynamic/testdata/TestLogReplayProvider/grpc_log_random.json
+++ b/dynamic/testdata/TestLogReplayProvider/grpc_log_random.json
@@ -20,7 +20,7 @@
   {
     "name": "github.com/hashicorp/terraform-plugin-mux/tf5to6server.v5tov6Server.ConfigureProvider",
     "call": "/Users/guin/go/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.20.0/tf5to6server/tf5to6server.go:71",
-    "request": "terraform_version:\"pulumi-terraform-bridge\"  config:{msgpack:\"\\x80\"}  client_capabilities:{write_only_attributes_allowed:true}",
+    "request": "terraform_version:\"1.0.0+pulumi-terraform-bridge\"  config:{msgpack:\"\\x80\"}  client_capabilities:{write_only_attributes_allowed:true}",
     "response": "{}"
   },
   {
@@ -56,7 +56,7 @@
   {
     "name": "github.com/hashicorp/terraform-plugin-mux/tf5to6server.v5tov6Server.ConfigureProvider",
     "call": "/Users/guin/go/pkg/mod/github.com/hashicorp/terraform-plugin-mux@v0.20.0/tf5to6server/tf5to6server.go:71",
-    "request": "terraform_version:\"pulumi-terraform-bridge\"  config:{msgpack:\"\\x80\"}  client_capabilities:{write_only_attributes_allowed:true}",
+    "request": "terraform_version:\"1.0.0+pulumi-terraform-bridge\"  config:{msgpack:\"\\x80\"}  client_capabilities:{write_only_attributes_allowed:true}",
     "response": "{}"
   },
   {

--- a/pkg/pf/tests/provider_configure_test.go
+++ b/pkg/pf/tests/provider_configure_test.go
@@ -15,11 +15,13 @@
 package tfbridgetests
 
 import (
+	"context"
 	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/pulumi/providertest/replay"
@@ -27,6 +29,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
 
+	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/providerbuilder"
 	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/testprovider"
 	tfpf "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge"
@@ -215,6 +218,36 @@ func TestPFConfigure(t *testing.T) {
 			},
 		))
 	})
+}
+
+func TestConfigureSendsCompatibleTerraformVersion(t *testing.T) {
+	t.Parallel()
+
+	var terraformVersion string
+	testProvider := pb.NewProvider(pb.NewProviderArgs{
+		ConfigureFunc: func(
+			_ context.Context,
+			req provider.ConfigureRequest,
+			_ *provider.ConfigureResponse,
+		) {
+			terraformVersion = req.TerraformVersion
+		},
+	})
+	server, err := newProviderServer(t, testProvider.ToProviderInfo())
+	require.NoError(t, err)
+
+	replay.Replay(t, server, `
+	{
+	  "method": "/pulumirpc.ResourceProvider/Configure",
+	  "request": {},
+	  "response": {
+	    "supportsPreview": true,
+	    "acceptResources": true,
+	    "supportsAutonamingConfiguration": true
+	  }
+	}`)
+
+	require.Equal(t, "1.0.0+pulumi-terraform-bridge", terraformVersion)
 }
 
 func TestConfigureNameOverrides(t *testing.T) {

--- a/pkg/pf/tfbridge/provider_configure.go
+++ b/pkg/pf/tfbridge/provider_configure.go
@@ -27,6 +27,14 @@ import (
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 )
 
+// terraformVersionToImpersonate is the stable Terraform-compatible version reported to providers.
+// TerraformVersion is intended for logging, analytics, and User-Agent purposes, but some providers
+// parse it as semantic versioning or use it for compatibility checks. Version 1.0.0 is a conservative
+// floor for the protocol versions the bridge uses, while the build metadata identifies the actual
+// caller without affecting version precedence. Keep this independent of Pulumi, bridge, and upstream
+// provider versions. Only increase the base version after auditing the associated Terraform behavior.
+const terraformVersionToImpersonate = "1.0.0+pulumi-terraform-bridge"
+
 // This function iterates over the diagnostics and replaces the names of tf config properties
 // with their corresponding Pulumi names.
 func replaceConfigInDiagnostics(
@@ -86,7 +94,7 @@ func (p *provider) ConfigureWithContext(ctx context.Context, inputs resource.Pro
 
 	req := &tfprotov6.ConfigureProviderRequest{
 		Config:           config,
-		TerraformVersion: "pulumi-terraform-bridge",
+		TerraformVersion: terraformVersionToImpersonate,
 	}
 
 	resp, err := p.tfServer.ConfigureProvider(ctx, req)


### PR DESCRIPTION
## Summary

- send providers the stable SemVer value `1.0.0+pulumi-terraform-bridge` during PF configuration
- preserve the bridge identity as SemVer build metadata without affecting version precedence
- cover the shared PF request and the dynamic protocol-v5 forwarding path
- update dynamic replay fixtures for the new configure request

## Rationale

`TerraformVersion` is intended for logging, analytics, and User-Agent purposes, but some providers parse it as SemVer or use it for compatibility checks. The previous `pulumi-terraform-bridge` value can therefore crash providers such as Rootly during configuration.

The `1.0.0` base is a conservative compatibility floor for the protocol versions the bridge uses. The `+pulumi-terraform-bridge` metadata retains the original caller identity and is ignored for SemVer precedence comparisons.

Fixes #3514.

## Testing

- `make test RUN_TEST_CMD='./pkg/pf/tests'`
- `make test RUN_TEST_CMD='./dynamic -run "^(TestSDKv1Provider|TestLogReplayProvider|TestLogReplayProviderWithProgram|TestConfigInDestroy)$"'`
- `make lint`
