### PR TITLE
Do not synthesize an "id" output for Plugin Framework data sources

### DIFF
--- a/dynamic/testdata/TestSchemaGeneration/BunnyWay/bunnynet-0.5.1.golden
+++ b/dynamic/testdata/TestSchemaGeneration/BunnyWay/bunnynet-0.5.1.golden
@@ -3839,10 +3839,6 @@
                     "code": {
                         "type": "string"
                     },
-                    "id": {
-                        "type": "string",
-                        "description": "The provider-assigned unique ID for this managed resource."
-                    },
                     "name": {
                         "type": "string"
                     },
@@ -3862,8 +3858,7 @@
                     "name",
                     "supportPlayerTranslation",
                     "supportTranscribing",
-                    "transcribingAccuracy",
-                    "id"
+                    "transcribingAccuracy"
                 ]
             }
         },

--- a/pkg/pf/internal/schemashim/datasource.go
+++ b/pkg/pf/internal/schemashim/datasource.go
@@ -30,7 +30,10 @@ type schemaOnlyDataSource struct {
 	internalinter.Internal
 }
 
-var _ shim.Resource = (*schemaOnlyDataSource)(nil)
+var _ shim.ResourceWithoutImplicitID = (*schemaOnlyDataSource)(nil)
+
+// Plugin Framework data sources have no implicit "id" attribute.
+func (r *schemaOnlyDataSource) NoImplicitID() {}
 
 func (r *schemaOnlyDataSource) SchemaType() valueshim.Type {
 	protoSchema, err := r.tf.ResourceProtoSchema(context.Background())

--- a/pkg/pf/proto/resource.go
+++ b/pkg/pf/proto/resource.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	_ = shim.ResourceMap(resourceMap{})
-	_ = shim.Resource(resource{})
+	_ = shim.ResourceWithoutImplicitID(resource{})
 )
 
 type resourceMap map[string]*tfprotov6.Schema
@@ -70,6 +70,10 @@ type resource struct {
 func newResource(r *tfprotov6.Schema) *resource {
 	return &resource{r, internalinter.Internal{}}
 }
+
+// The wire schema carries every attribute explicitly: SDKv2-based servers surface their
+// implicit "id" in it, and Plugin Framework servers have no implicit "id" at all.
+func (r resource) NoImplicitID() {}
 
 func (r resource) SchemaType() valueshim.Type {
 	ty := r.r.Block.ValueType()

--- a/pkg/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
+++ b/pkg/pf/tests/internal/testprovider/cmd/pulumi-resource-testbridge/schema.json
@@ -1105,10 +1105,6 @@
             "outputs": {
                 "description": "A collection of values returned by Echo.\n",
                 "properties": {
-                    "id": {
-                        "description": "The provider-assigned unique ID for this managed resource.",
-                        "type": "string"
-                    },
                     "input": {
                         "type": "string"
                     },
@@ -1123,8 +1119,7 @@
                 "required": [
                     "input",
                     "output",
-                    "sensitive",
-                    "id"
+                    "sensitive"
                 ],
                 "type": "object"
             }
@@ -1182,17 +1177,12 @@
             "outputs": {
                 "description": "A collection of values returned by SMAC.\n",
                 "properties": {
-                    "id": {
-                        "description": "The provider-assigned unique ID for this managed resource.",
-                        "type": "string"
-                    },
                     "skipMetadataApiCheck": {
                         "type": "string"
                     }
                 },
                 "required": [
-                    "skipMetadataApiCheck",
-                    "id"
+                    "skipMetadataApiCheck"
                 ],
                 "type": "object"
             }
@@ -1211,10 +1201,6 @@
             "outputs": {
                 "description": "A collection of values returned by TestDefaultInfoDataSource.\n",
                 "properties": {
-                    "id": {
-                        "description": "The provider-assigned unique ID for this managed resource.",
-                        "type": "string"
-                    },
                     "input": {
                         "default": "DEFAULT",
                         "type": "string"
@@ -1225,8 +1211,7 @@
                 },
                 "required": [
                     "input",
-                    "output",
-                    "id"
+                    "output"
                 ],
                 "type": "object"
             }

--- a/pkg/pf/tfgen/tfgen_test.go
+++ b/pkg/pf/tfgen/tfgen_test.go
@@ -841,6 +841,52 @@ func TestGenerateSchemaFailsOnPFProviderSchemaImplementation(t *testing.T) {
 	require.ErrorContains(t, err, "missing the CustomType or ElementType field")
 }
 
+// Regression test: the SDKv1/v2 runtime backfills an implicit "id" for data sources, so
+// tfgen synthesizes an "id" output when the TF schema lacks one. The Plugin Framework
+// runtime never returns an undeclared "id", so PF data sources must not advertise it.
+func TestGenerateSchemaOmitsSyntheticIDForPFDataSource(t *testing.T) {
+	t.Parallel()
+
+	res, err := GenerateSchema(context.Background(), GenerateSchemaOptions{
+		ProviderInfo: tfbridge.ProviderInfo{
+			Name:             "testprovider",
+			UpstreamRepoPath: ".", // no invalid mappings warnings
+			P: pftfbridge.ShimProvider(&schemaTestProvider{
+				dataSources: map[string]dschema.Schema{
+					"lookup": {
+						Attributes: map[string]dschema.Attribute{
+							"value": dschema.StringAttribute{Computed: true},
+						},
+					},
+				},
+			}),
+			DataSources: map[string]*tfbridge.DataSourceInfo{
+				"test_lookup": {
+					Tok:  "testprovider:index:getLookup",
+					Docs: &tfbridge.DocInfo{Markdown: []byte{' '}},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var schema puschema.PackageSpec
+	require.NoError(t, json.Unmarshal(res.ProviderMetadata.PackageSchema, &schema))
+
+	fn, ok := schema.Functions["testprovider:index:getLookup"]
+	require.True(t, ok)
+	require.NotNil(t, fn.ReturnType)
+	require.NotNil(t, fn.ReturnType.ObjectTypeSpec)
+	require.Equal(t, puschema.ObjectTypeSpec{
+		Type:        "object",
+		Description: "A collection of values returned by getLookup.\n",
+		Properties: map[string]puschema.PropertySpec{
+			"value": {TypeSpec: puschema.TypeSpec{Type: "string"}},
+		},
+		Required: []string{"value"},
+	}, *fn.ReturnType.ObjectTypeSpec)
+}
+
 func TestGenerateSchemaFailsOnPFDataSourceSchemaImplementation(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -1802,8 +1802,10 @@ func (g *Generator) gatherDataSource(rawname string,
 	}
 
 	// If the data source's schema doesn't expose an id property, make one up since we'd like to expose it for data
-	// sources.
-	if id, has := ds.Schema().GetOk("id"); !has || id.Removed() != "" {
+	// sources. The SDKv1/v2 runtime backfills a value for it. Plugin Framework data sources have no implicit id, so
+	// synthesizing one there would advertise a property the provider can never return.
+	_, noImplicitID := ds.(shim.ResourceWithoutImplicitID)
+	if id, has := ds.Schema().GetOk("id"); !noImplicitID && (!has || id.Removed() != "") {
 		cust := map[string]*tfbridge.SchemaInfo{"id": {}}
 		rawdoc := "The provider-assigned unique ID for this managed resource."
 		idSchema := schema.SchemaMap(map[string]shim.Schema{

--- a/pkg/tfshim/shim.go
+++ b/pkg/tfshim/shim.go
@@ -269,6 +269,16 @@ type Resource interface {
 	internalinter.InternalInterface
 }
 
+// ResourceWithoutImplicitID marks a data source whose runtime never produces a value for
+// an undeclared "id" attribute. The SDKv1/v2 runtimes inject an implicit "id" into every
+// data source result; the Plugin Framework has no such concept. Schema generation
+// consults this interface to avoid advertising an "id" output that the provider can
+// never return.
+type ResourceWithoutImplicitID interface {
+	Resource
+	NoImplicitID()
+}
+
 type ResourceMap interface {
 	Len() int
 	Get(key string) Resource


### PR DESCRIPTION
## Problem

tfgen adds a synthetic `id` result to every data source whose Terraform schema does not declare an `id` attribute (`pkg/tfgen/generate.go`, `gatherDataSource`). This is only correct for SDKv1/v2 providers, where it re-materializes a real property:

- The SDK injects an implicit `Optional+Computed` `id` into the wire schema (`Resource.CoreConfigSchema`), invisible in `Resource.SchemaMap()` which tfgen reads.
- The SDK runtime always returns a non-empty value: `ReadDataApply` backfills `"-"` when the provider never calls `d.SetId()`, and the bridge's SDKv2 `Provider.Invoke` backfills `invoke.ID()`.

The Plugin Framework has no implicit `id` concept: `DataSourceSchemas` returns exactly what the provider declared, and `ReadDataSource` structurally cannot return an undeclared attribute. Bridged PF data sources therefore advertised an `id` result that the provider can never produce, and every generated SDK surfaced it as permanently null/empty.

## Fix

Introduce an opt-out marker interface, `shim.ResourceWithoutImplicitID` (method `NoImplicitID()`), implemented by the PF schema-only shims:

- `schemashim.schemaOnlyDataSource` — compiled-in PF providers (including the PF side of muxed providers; the muxer's `unionMap` passes the underlying `shim.Resource` values through unwrapped).
- `pf/proto.resource` — the dynamic bridge. Dynamically bridged SDKv2 providers are unaffected: their implicit `id` is present in the wire schema, so the existing `GetOk("id")` check already skips synthesis for them.

`gatherDataSource` skips the synthesis when the data source shim implements the marker. SDKv1/v2 schema generation is unchanged.

## Testing

- New regression test `TestGenerateSchemaOmitsSyntheticIDForPFDataSource` (`pkg/pf/tfgen/tfgen_test.go`): a PF data source with a single computed attribute generates a result type without `id`.
- Regenerated goldens as behavioral evidence: the PF testbridge provider's three data sources (`make -C pkg/pf build.testproviders`) and the dynamic bridge's bunnynet golden (`PULUMI_ACCEPT=1`) each lose the phantom `id` property and its `required` entry. The random/tls/muxedrandom goldens are unchanged (those data sources declare `id` upstream), as are all SDKv2-based goldens.
- Full `pkg/pf/tests` suite (352 tests), `pkg/pf/tfgen`, `pkg/pf/proto`, `pkg/pf/internal/schemashim`, `pkg/tfshim`, and the dynamic schema-generation tests pass.

## Real-world demonstration (pre-fix)

Verified against the released dynamic bridge (`terraform-provider` plugin v1.2.0, no credentials required), using `hashicorp/local`'s PF-based `local_command` data source, whose upstream `Schema()` declares no `id`:

```yaml
name: local-command-demo
runtime: yaml
packages:
  local:
    source: terraform-provider
    version: 1.2.0
    parameters: [hashicorp/local]
variables:
  cmdResult:
    fn::invoke:
      function: local:index/getCommand:getCommand
      arguments:
        command: echo
        arguments: ["hello-from-pf-data-source"]
outputs:
  stdout: ${cmdResult.stdout}
  id: ${cmdResult.id}
```

The generated schema for `local:index/getCommand:getCommand` advertises `id` ("The provider-assigned unique ID for this managed resource.") and lists it in the outputs' `required` array, yet `pulumi stack output --json` returns:

```json
{ "stdout": "hello-from-pf-data-source\n" }
```

`id` is absent from the result entirely — a schema-required property that the provider can never produce. The same behavior reproduces with zero arguments via `northwood-labs/corefunc` (`corefunc:index/getRuntimeOs:getRuntimeOs`), where 49 of 99 generated functions carry the phantom `id`.
