### PR TITLE
docs(agent): narrow bridge spec guidance

### DIFF
--- a/.agents/skills/create-bridge-spec/SKILL.md
+++ b/.agents/skills/create-bridge-spec/SKILL.md
@@ -5,130 +5,91 @@ description: Use when creating, reviewing, or revising a design/spec for a non-t
 
 # Create Bridge Spec
 
-Use this skill to turn ambiguous bridge work into a compact, repo-grounded spec
-or implementation plan. The bridge crosses many boundaries; the job is to make
-the relevant boundaries explicit without creating a checklist of every possible
-bridge subsystem.
+Use this skill to find the bridge boundary that owns the reported behavior and
+preserve only the decisions a durable spec needs. It is a routing aid, not a
+required planning framework or a checklist of bridge subsystems.
 
-## Core Move
+Read [`AGENTS.md`](../../../AGENTS.md) and the
+[architecture overview](../../../docs/architecture/overview.md), following only
+the guides relevant to the reported behavior. Trace code facts from the
+repository instead of asking the user to supply them.
 
-Before drafting the spec, establish four things:
+## Ground The Change
 
-1. **Behavior**: what user-visible or provider-author-visible behavior is being
-   changed.
-2. **Path**: which real code path proves that behavior today.
-3. **Ownership**: which layer owns each capability involved.
+Before drafting a spec—or deciding that one is needed—establish:
+
+1. **Behavior**: the concrete provider-author or Pulumi-user behavior changing.
+2. **Path**: the mode, lifecycle transition, and current code path that exhibit
+   it.
+3. **Ownership**: the layer that owns each capability involved.
 4. **Proof**: the smallest executable check that would make the change done.
 
-If any of those are unclear, investigate the repo before writing conclusions.
+Investigate any uncertainty that would materially change ownership, support
+scope, or design. Name the assumption, plausible alternative, and quickest repo
+or downstream probe that distinguishes them. Do not turn clear boundaries into
+an assumption-analysis ritual.
 
-## Boundary Map
+## Keep The Change Narrow
 
-Classify only the boundaries that matter for the task:
-
-- **Build-time generation**: `pkg/tfgen`, `pkg/convert`, `pkg/tf2pulumi`,
-  provider schema generation, docs conversion, metadata generation.
-- **Runtime SDKv2**: `pkg/tfbridge`, `pkg/tfshim/sdk-v{1,2}`,
-  `pkg/providerserver`.
-- **Runtime Plugin Framework**: `pkg/pf/tfbridge`, `pkg/pf/internal/*`,
-  `pkg/pf/proto`.
-- **Muxing**: `pkg/x/muxer`, `pkg/pf/internal/muxer`, dispatch metadata,
-  ownership split between subproviders.
-- **Dynamic bridge**: `dynamic/*`, `pkg/pf/proto`, generated dynamic schema
-  compatibility.
-- **Cross-cutting runtime state**: lifecycle RPCs, imports, refresh, state
-  upgrade, raw state, config, defaults, secrets, diagnostics.
-
-Do not assume that one layer owns all related behavior. Schema shape, runtime
-RPC handling, metadata, validation, state translation, and downstream provider
-exposure can have different owners.
-
-## Assumption Checkpoint
-
-When the plan crosses any boundary above, pause and write down:
-
-- The risky assumptions the plan depends on (e.g., who owns a capability,
-  where schema or state comes from, lifecycle ordering).
-- One plausible alternative for each.
-- The quickest repo or downstream probe that can distinguish them.
-
-Keep this short. The point is to prevent hidden assumptions from becoming a
-phase plan.
+- Propose the smallest end-to-end change that fixes the motivating path.
+- Treat adjacent build-time, SDKv2, PF, mux, dynamic, and lifecycle cases as
+  compatibility questions to disposition, not automatic requirements to
+  implement.
+- Preserve existing behavior in adjacent or unsupported paths when stronger
+  shared semantics cannot be established safely.
+- Before adding generic machinery for an uncommon case, check whether it occurs
+  in current bridge paths, tests, downstream providers, or user reports. Record
+  its incidence, safe fallback, and possible follow-up when support is costly.
+- Broaden across SDKv2 and PF, muxing, dynamic bridge, or downstream providers
+  only when the motivating behavior depends on their agreement or an existing
+  compatibility contract requires it. Otherwise document why the behavior is
+  mode-specific.
+- Keep downstream providers as focused proof points, not bridge-owned
+  inventories.
 
 ## Choose The Artifact
 
-Use the smallest artifact that reduces real risk:
+Use the conversation when behavior, path, ownership, and proof are clear. Do not
+create a design document merely because this skill was loaded.
 
-- **Chat-only plan**: the behavior is narrow, the path is clear, and the
-  validation proof is obvious.
-- **Checked-in spec**: behavior crosses build-time/runtime boundaries, SDKv2/PF
-  parity, mux ownership, dynamic bridge compatibility, lifecycle/state
-  semantics, or multiple plausible designs.
-- **Handoff/status doc**: the work spans sessions and has temporary branch
-  state, staged rollout details, or unresolved blockers that should not clutter
-  the durable spec.
+Create a checked-in spec when the user asks for one or unresolved semantic,
+ownership, lifecycle, or compatibility decisions must survive review or
+handoff. Crossing a repository boundary by itself is not enough. Use a temporary
+handoff/status note instead when only branch state, rollout progress, or blockers
+need to survive another session.
 
-## Spec Shape
+## Keep The Spec Compact
 
-For a checked-in spec, prefer this compact shape:
+Include only sections that preserve a decision or make the implementation
+reviewable:
 
-```markdown
-# <Topic> Bridge Semantics
+- **Summary**: what changes, who observes it, and why it matters.
+- **Current Path**: the relevant build-time or runtime flow grounded in code.
+- **Desired Semantics**: testable behavior and explicit non-goals.
+- **Design**: capability owners, data or schema sources, and rejected shortcuts.
+- **Compatibility Dispositions**: only applicable modes and lifecycle risks,
+  each marked supported now, unaffected, existing fallback, explicitly
+  unsupported/non-goal, or deferred.
+- **Validation**: the smallest proof for each important invariant.
 
-## Summary
-What is changing, who observes it, and why it matters.
+Omit sections that add no information. Keep temporary rollout notes out of the
+durable semantics.
 
-## Current Flow
-Code-grounded walkthrough of the relevant path. Distinguish build-time,
-runtime startup, per-RPC behavior, mux dispatch, dynamic bridge behavior, and
-downstream provider exposure only where relevant.
+## Proof And Guardrails
 
-## Desired Semantics
-Numbered invariants that can be tested or reviewed.
+- Prefer one focused test that proves the user-visible or
+  provider-author-visible regression.
+- Add lower-level, cross-mode, golden, or downstream tests only when they provide
+  distinct proof or useful failure localization. The test locations in
+  `AGENTS.md` are routing options, not a required matrix.
+- Use repository-prescribed `mise` and test commands. Start focused before
+  broadening validation.
+- Do not hand-edit generated SDKs, generated schema artifacts, vendored upstream
+  provider code, or submodule content.
 
-## Design
-Implementation approach, capability owners, metadata/schema sources, and
-shortcuts rejected.
-
-## Compatibility Risks
-Only the risks that apply: SDKv2/PF parity, muxing, aliases, dynamic providers,
-state upgrade, imports, refresh, secrets, defaults, raw state, generated schema,
-diagnostics timing, or downstream provider behavior.
-
-## Validation
-The smallest executable proof for each important invariant, including any
-downstream provider probe needed to prove the real path.
-```
-
-Omit sections that add no information. Split durable semantics from temporary
-rollout notes when combining them would make the spec noisy.
-
-## Validation Guidance
-
-Map each important invariant to a concrete check:
-
-- Build-time schema/metadata: `pkg/tfgen`, `pkg/pf/tfgen`, generated schema
-  tests, or golden files.
-- PF runtime: `pkg/pf/tests`, `pkg/pf/internal/*`, `pkg/pf/tfbridge`.
-- SDKv2 runtime and parity: `pkg/tfbridge`, `pkg/tfshim/sdk-v2`,
-  `pkg/internal/tests/cross-tests`.
-- Mux behavior: mux dispatch tests plus a proof that the normal downstream
-  provider path exercises the intended route.
-- Dynamic bridge: dynamic tests and golden files when schema compatibility can
-  drift.
-
-Prefer focused test commands first. When repo guidance says to use `mise`, use
-`mise exec -- go test ...` or `mise exec -- make ...`.
-
-## Guardrails
-
-- Trace code facts from the repo instead of asking the user to supply them.
-- Keep examples representative, not exhaustive.
-- Treat downstream providers as proof points, not as bridge-owned inventories.
-  A specific provider may prove the path, but the spec should stay
-  provider-agnostic unless the task is provider-specific.
-- Do not hand-edit generated SDKs, generated schema artifacts, vendored
-  upstream provider code, or submodule content.
-- Stop and return to the user when the semantic model is unsettled, the proof
-  path depends on credentials or external state, or the requested scope would
-  require a broader compatibility decision than the user asked for.
+Return to the maintainer with concrete options when the semantic owner or safe
+fallback is unclear, the implementation is becoming substantially broader than
+the reported behavior, a rare case requires disproportionate complexity, a
+broader compatibility decision is needed, or required proof depends on
+credentials or external state unavailable in the current environment. Report
+the evidence gap and concrete validation options.


### PR DESCRIPTION
## Summary

- Focus bridge specs on the motivating behavior and owning boundary.
- Treat adjacent modes and tests as explicit compatibility dispositions rather than a required matrix.
- Distinguish durable specs from conversational plans and temporary handoff notes.
- Preserve escalation guidance for unsupported paths and unavailable external proof.

## Testing

- `git diff --check`
- Verified that the linked repository guidance files exist.
