### PR TITLE
Support reattaching to running TF providers in the dynamic provider

### DIFF
--- a/dynamic/internal/shim/run/loader.go
+++ b/dynamic/internal/shim/run/loader.go
@@ -79,6 +79,12 @@ func NamedProvider(ctx context.Context, key, version string) (Provider, error) {
 		return nil, fmt.Errorf("invalid provider name: %w", err)
 	}
 
+	if entry, ok, err := reattachEntryFor(p); err != nil {
+		return nil, err
+	} else if ok {
+		return reattachProvider(ctx, p, entry)
+	}
+
 	v, err := getproviders.ParseVersionConstraints(version)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse version constraint %q: %w", version, err)
@@ -191,10 +197,9 @@ func getPluginCache() (string, error) {
 
 type provider struct {
 	tfprotov6.ProviderServer
+	io.Closer
 
 	name, version, url string
-
-	close func() error
 }
 
 func (p provider) Name() string { return p.name }
@@ -202,8 +207,6 @@ func (p provider) Name() string { return p.name }
 func (p provider) Version() string { return p.version }
 
 func (p provider) URL() string { return p.url }
-
-func (p provider) Close() error { return p.close() }
 
 func getProviderServer(
 	ctx context.Context, addr addrs.Provider, version getproviders.VersionConstraints,
@@ -300,38 +303,45 @@ func runProvider(ctx context.Context, meta *providercache.CachedProvider) (Provi
 		return nil, err
 	}
 
-	raw, err := rpcClient.Dispense(tfplugin.ProviderPluginName)
-	if err != nil {
-		return nil, err
-	}
-
-	switch client.NegotiatedVersion() {
-	case 5:
-		p := raw.(*tfplugin.GRPCProvider)
-		p.PluginClient = client
-		p.Addr = meta.Provider
-
-		slog.Info("Found v5 provider.. upgrading to v6")
-
-		v6, err := tf5to6server.UpgradeServer(ctx, func() tfprotov5.ProviderServer {
-			return v5shim.New(tfplugin5.NewProviderClient(rpcClient.(*plugin.GRPCClient).Conn))
-		})
+	if client.NegotiatedVersion() == 5 {
+		raw, err := rpcClient.Dispense(tfplugin.ProviderPluginName)
 		if err != nil {
 			return nil, err
 		}
-		return provider{
-			v6,
-			meta.Provider.Type, meta.Version.String(), meta.Provider.String(),
-			rpcClient.Close,
-		}, nil
+		p := raw.(*tfplugin.GRPCProvider)
+		p.PluginClient = client
+		p.Addr = meta.Provider
+	}
+
+	grpcClient, ok := rpcClient.(*plugin.GRPCClient)
+	if !ok {
+		return nil, fmt.Errorf("expected a gRPC plugin client, got %T", rpcClient)
+	}
+	server, err := protov6ServerFromConn(ctx, grpcClient.Conn, client.NegotiatedVersion())
+	if err != nil {
+		return nil, err
+	}
+	return provider{
+		server,
+		rpcClient,
+		meta.Provider.Type, meta.Version.String(), meta.Provider.String(),
+	}, nil
+}
+
+// protov6ServerFromConn adapts the raw gRPC connection of a running TF
+// provider into a tfprotov6.ProviderServer, upgrading protocol 5 servers.
+func protov6ServerFromConn(
+	ctx context.Context, conn *grpc.ClientConn, protocolVersion int,
+) (tfprotov6.ProviderServer, error) {
+	switch protocolVersion {
+	case 5:
+		slog.Info("Found v5 provider.. upgrading to v6")
+		return tf5to6server.UpgradeServer(ctx, func() tfprotov5.ProviderServer {
+			return v5shim.New(tfplugin5.NewProviderClient(conn))
+		})
 	case 6:
-		p := tfplugin6.NewProviderClient(rpcClient.(*plugin.GRPCClient).Conn)
-		return provider{
-			v6shim.New(p),
-			meta.Provider.Type, meta.Version.String(), meta.Provider.String(),
-			rpcClient.Close,
-		}, nil
+		return v6shim.New(tfplugin6.NewProviderClient(conn)), nil
 	default:
-		panic("unsupported protocol version")
+		return nil, fmt.Errorf("unsupported protocol version %d", protocolVersion)
 	}
 }

--- a/dynamic/internal/shim/run/reattach.go
+++ b/dynamic/internal/shim/run/reattach.go
@@ -1,0 +1,144 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+
+	plugin "github.com/hashicorp/go-plugin"
+	regaddr "github.com/opentofu/registry-address/v2"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/vendored/opentofu/addrs"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/vendored/opentofu/logging"
+	tfplugin "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/vendored/opentofu/plugin"
+)
+
+// envReattachProviders instructs the dynamic provider to connect to an
+// already-running TF provider server instead of downloading and launching the
+// provider binary. Its value uses the same JSON format Terraform and OpenTofu
+// accept in TF_REATTACH_PROVIDERS: a map from provider source address to the
+// reattach information printed by a provider running in debug mode (or served
+// with go-plugin's test mode).
+//
+// Providers matched here report version "0.0.0"; any version constraint
+// requested for them is ignored, since the caller controls the running server.
+const envReattachProviders = "PULUMI_BRIDGE_REATTACH_PROVIDERS"
+
+// reattachProviderVersion is the version reported for reattached providers,
+// which have no registry version.
+const reattachProviderVersion = "0.0.0"
+
+type reattachEntry struct {
+	Protocol        string
+	ProtocolVersion int
+	Pid             int
+	Test            bool
+	Addr            struct {
+		Network string
+		String  string
+	}
+}
+
+// reattachEntryFor returns the reattach entry for addr, if
+// PULUMI_BRIDGE_REATTACH_PROVIDERS is set and contains one. Keys are matched
+// as provider source addresses, so "simple" and "registry.opentofu.org/-/simple"
+// style spellings compare after normalization.
+func reattachEntryFor(addr addrs.Provider) (reattachEntry, bool, error) {
+	raw := os.Getenv(envReattachProviders)
+	if raw == "" {
+		return reattachEntry{}, false, nil
+	}
+
+	var entries map[string]reattachEntry
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		return reattachEntry{}, false, fmt.Errorf("invalid %s: %w", envReattachProviders, err)
+	}
+
+	for key, entry := range entries {
+		keyAddr, err := regaddr.ParseProviderSource(key)
+		if err != nil {
+			return reattachEntry{}, false, fmt.Errorf("invalid %s: provider key %q: %w", envReattachProviders, key, err)
+		}
+		if keyAddr.Equals(addr) {
+			return entry, true, nil
+		}
+	}
+	return reattachEntry{}, false, nil
+}
+
+// reattachProvider connects to the running provider server described by entry
+// instead of launching a provider binary.
+func reattachProvider(ctx context.Context, addr addrs.Provider, entry reattachEntry) (Provider, error) {
+	var netAddr net.Addr
+	switch entry.Addr.Network {
+	case "unix":
+		netAddr = &net.UnixAddr{Name: entry.Addr.String, Net: "unix"}
+	case "tcp":
+		var err error
+		netAddr, err = net.ResolveTCPAddr("tcp", entry.Addr.String)
+		if err != nil {
+			return nil, fmt.Errorf("%s: resolving %q for %s: %w", envReattachProviders, entry.Addr.String, addr, err)
+		}
+	default:
+		return nil, fmt.Errorf("%s: unsupported network %q for %s", envReattachProviders, entry.Addr.Network, addr)
+	}
+
+	if p := plugin.Protocol(entry.Protocol); p != plugin.ProtocolGRPC {
+		return nil, fmt.Errorf("%s: unsupported protocol %q for %s (only %q is supported)",
+			envReattachProviders, entry.Protocol, addr, plugin.ProtocolGRPC)
+	}
+
+	client := plugin.NewClient(&plugin.ClientConfig{
+		HandshakeConfig:  tfplugin.Handshake,
+		Logger:           logging.NewProviderLogger(""),
+		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
+		Reattach: &plugin.ReattachConfig{
+			Protocol:        plugin.ProtocolGRPC,
+			ProtocolVersion: entry.ProtocolVersion,
+			Addr:            netAddr,
+			Pid:             entry.Pid,
+			Test:            entry.Test,
+		},
+	})
+	rpcClient, err := client.Client()
+	if err != nil {
+		client.Kill()
+		return nil, fmt.Errorf("%s: connecting to %s: %w", envReattachProviders, addr, err)
+	}
+	grpcClient, ok := rpcClient.(*plugin.GRPCClient)
+	if !ok {
+		contract.IgnoreClose(rpcClient)
+		return nil, fmt.Errorf("%s: expected a gRPC plugin client for %s, got %T", envReattachProviders, addr, rpcClient)
+	}
+
+	// The handshake-based negotiation in runProvider does not happen when
+	// reattaching, so the protocol version comes from the reattach entry.
+	server, err := protov6ServerFromConn(ctx, grpcClient.Conn, entry.ProtocolVersion)
+	if err != nil {
+		contract.IgnoreClose(grpcClient.Conn)
+		return nil, fmt.Errorf("%s: %s: %w", envReattachProviders, addr, err)
+	}
+
+	return provider{
+		server,
+		grpcClient.Conn,
+		addr.Type, reattachProviderVersion, addr.String(),
+	}, nil
+}

--- a/dynamic/internal/shim/run/reattach.go
+++ b/dynamic/internal/shim/run/reattach.go
@@ -60,6 +60,10 @@ type reattachEntry struct {
 // PULUMI_BRIDGE_REATTACH_PROVIDERS is set and contains one. Keys are matched
 // as provider source addresses, so "simple" and "registry.opentofu.org/-/simple"
 // style spellings compare after normalization.
+//
+// Every key is validated on every call, so a malformed key rejects the env
+// var deterministically — acceptance never depends on which provider is being
+// resolved or on map iteration order.
 func reattachEntryFor(addr addrs.Provider) (reattachEntry, bool, error) {
 	raw := os.Getenv(envReattachProviders)
 	if raw == "" {
@@ -71,16 +75,20 @@ func reattachEntryFor(addr addrs.Provider) (reattachEntry, bool, error) {
 		return reattachEntry{}, false, fmt.Errorf("invalid %s: %w", envReattachProviders, err)
 	}
 
+	var match *reattachEntry
 	for key, entry := range entries {
 		keyAddr, err := regaddr.ParseProviderSource(key)
 		if err != nil {
 			return reattachEntry{}, false, fmt.Errorf("invalid %s: provider key %q: %w", envReattachProviders, key, err)
 		}
 		if keyAddr.Equals(addr) {
-			return entry, true, nil
+			match = &entry
 		}
 	}
-	return reattachEntry{}, false, nil
+	if match == nil {
+		return reattachEntry{}, false, nil
+	}
+	return *match, true, nil
 }
 
 // reattachProvider connects to the running provider server described by entry
@@ -119,7 +127,9 @@ func reattachProvider(ctx context.Context, addr addrs.Provider, entry reattachEn
 	})
 	rpcClient, err := client.Client()
 	if err != nil {
-		client.Kill()
+		// No cleanup: a Reattach-mode client doesn't own the external
+		// process, and client.Kill would shut down (or SIGKILL) the shared
+		// server other clients are attached to.
 		return nil, fmt.Errorf("%s: connecting to %s: %w", envReattachProviders, addr, err)
 	}
 	grpcClient, ok := rpcClient.(*plugin.GRPCClient)

--- a/dynamic/internal/shim/run/reattach_test.go
+++ b/dynamic/internal/shim/run/reattach_test.go
@@ -1,0 +1,120 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type reattachTestProvider struct{}
+
+func (reattachTestProvider) Metadata(
+	_ context.Context, _ pfprovider.MetadataRequest, resp *pfprovider.MetadataResponse,
+) {
+	resp.TypeName = "mini"
+}
+
+func (reattachTestProvider) Schema(context.Context, pfprovider.SchemaRequest, *pfprovider.SchemaResponse) {
+}
+
+func (reattachTestProvider) Configure(context.Context, pfprovider.ConfigureRequest, *pfprovider.ConfigureResponse) {
+}
+
+func (reattachTestProvider) DataSources(context.Context) []func() datasource.DataSource { return nil }
+
+func (reattachTestProvider) Resources(context.Context) []func() resource.Resource { return nil }
+
+// serveReattachProvider serves an in-process protocol 6 provider in go-plugin
+// debug mode and returns the PULUMI_BRIDGE_REATTACH_PROVIDERS value that
+// points key at it.
+func serveReattachProvider(t *testing.T, key string) string {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	reattachCh := make(chan *plugin.ReattachConfig)
+	closeCh := make(chan struct{})
+	go func() {
+		err := tf6server.Serve(
+			"registry.opentofu.org/"+key,
+			providerserver.NewProtocol6(reattachTestProvider{}),
+			tf6server.WithGoPluginLogger(hclog.NewNullLogger()),
+			tf6server.WithDebug(ctx, reattachCh, closeCh),
+			tf6server.WithoutLogStderrOverride(),
+		)
+		assert.NoError(t, err)
+	}()
+	rc := <-reattachCh
+
+	entry := reattachEntry{
+		Protocol:        string(rc.Protocol),
+		ProtocolVersion: rc.ProtocolVersion,
+		Pid:             rc.Pid,
+		Test:            rc.Test,
+	}
+	entry.Addr.Network = rc.Addr.Network()
+	entry.Addr.String = rc.Addr.String()
+	env, err := json.Marshal(map[string]reattachEntry{key: entry})
+	require.NoError(t, err)
+	return string(env)
+}
+
+func TestNamedProviderReattach(t *testing.T) {
+	t.Setenv(envReattachProviders, serveReattachProvider(t, "test/mini"))
+
+	ctx := context.Background()
+	p, err := NamedProvider(ctx, "test/mini", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, p.Close()) })
+
+	assert.Equal(t, "mini", p.Name())
+	assert.Equal(t, reattachProviderVersion, p.Version())
+	assert.Equal(t, "registry.opentofu.org/test/mini", p.URL())
+
+	resp, err := p.GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Provider)
+}
+
+// A fully-qualified request must match a bare env key after address
+// normalization.
+func TestNamedProviderReattachNormalizesAddresses(t *testing.T) {
+	t.Setenv(envReattachProviders, serveReattachProvider(t, "test/mini"))
+
+	p, err := NamedProvider(context.Background(), "registry.opentofu.org/test/mini", "")
+	require.NoError(t, err)
+	require.NoError(t, p.Close())
+}
+
+func TestNamedProviderReattachInvalidEnv(t *testing.T) {
+	t.Setenv(envReattachProviders, "not json")
+
+	_, err := NamedProvider(context.Background(), "test/mini", "")
+	require.ErrorContains(t, err, envReattachProviders)
+}

--- a/dynamic/internal/shim/run/reattach_test.go
+++ b/dynamic/internal/shim/run/reattach_test.go
@@ -25,8 +25,10 @@ import (
 	pfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
+	regaddr "github.com/opentofu/registry-address/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,25 +51,41 @@ func (reattachTestProvider) DataSources(context.Context) []func() datasource.Dat
 
 func (reattachTestProvider) Resources(context.Context) []func() resource.Resource { return nil }
 
-// serveReattachProvider serves an in-process protocol 6 provider in go-plugin
-// debug mode and returns the PULUMI_BRIDGE_REATTACH_PROVIDERS value that
-// points key at it.
-func serveReattachProvider(t *testing.T, key string) string {
+// serveReattachProvider serves an in-process provider in go-plugin debug mode
+// over the given plugin protocol version (5 or 6) and returns its reattach
+// entry.
+func serveReattachProvider(t *testing.T, key string, protocolVersion int) reattachEntry {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
+	name := "registry.opentofu.org/" + key
 	reattachCh := make(chan *plugin.ReattachConfig)
 	closeCh := make(chan struct{})
 	go func() {
-		err := tf6server.Serve(
-			"registry.opentofu.org/"+key,
-			providerserver.NewProtocol6(reattachTestProvider{}),
-			tf6server.WithGoPluginLogger(hclog.NewNullLogger()),
-			tf6server.WithDebug(ctx, reattachCh, closeCh),
-			tf6server.WithoutLogStderrOverride(),
-		)
+		var err error
+		switch protocolVersion {
+		case 5:
+			err = tf5server.Serve(
+				name,
+				providerserver.NewProtocol5(reattachTestProvider{}),
+				tf5server.WithGoPluginLogger(hclog.NewNullLogger()),
+				tf5server.WithDebug(ctx, reattachCh, closeCh),
+				tf5server.WithoutLogStderrOverride(),
+			)
+		case 6:
+			err = tf6server.Serve(
+				name,
+				providerserver.NewProtocol6(reattachTestProvider{}),
+				tf6server.WithGoPluginLogger(hclog.NewNullLogger()),
+				tf6server.WithDebug(ctx, reattachCh, closeCh),
+				tf6server.WithoutLogStderrOverride(),
+			)
+		default:
+			t.Errorf("unsupported protocol version %d", protocolVersion)
+			return
+		}
 		assert.NoError(t, err)
 	}()
 	rc := <-reattachCh
@@ -80,13 +98,19 @@ func serveReattachProvider(t *testing.T, key string) string {
 	}
 	entry.Addr.Network = rc.Addr.Network()
 	entry.Addr.String = rc.Addr.String()
-	env, err := json.Marshal(map[string]reattachEntry{key: entry})
+	return entry
+}
+
+func reattachEnv(t *testing.T, entries map[string]reattachEntry) string {
+	t.Helper()
+	env, err := json.Marshal(entries)
 	require.NoError(t, err)
 	return string(env)
 }
 
 func TestNamedProviderReattach(t *testing.T) {
-	t.Setenv(envReattachProviders, serveReattachProvider(t, "test/mini"))
+	entry := serveReattachProvider(t, "test/mini", 6)
+	t.Setenv(envReattachProviders, reattachEnv(t, map[string]reattachEntry{"test/mini": entry}))
 
 	ctx := context.Background()
 	p, err := NamedProvider(ctx, "test/mini", "")
@@ -102,10 +126,27 @@ func TestNamedProviderReattach(t *testing.T) {
 	require.NotNil(t, resp.Provider)
 }
 
+// A protocol 5 server must be upgraded to protocol 6 over the reattached
+// connection.
+func TestNamedProviderReattachProtocol5(t *testing.T) {
+	entry := serveReattachProvider(t, "test/mini", 5)
+	t.Setenv(envReattachProviders, reattachEnv(t, map[string]reattachEntry{"test/mini": entry}))
+
+	ctx := context.Background()
+	p, err := NamedProvider(ctx, "test/mini", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, p.Close()) })
+
+	resp, err := p.GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Provider)
+}
+
 // A fully-qualified request must match a bare env key after address
 // normalization.
 func TestNamedProviderReattachNormalizesAddresses(t *testing.T) {
-	t.Setenv(envReattachProviders, serveReattachProvider(t, "test/mini"))
+	entry := serveReattachProvider(t, "test/mini", 6)
+	t.Setenv(envReattachProviders, reattachEnv(t, map[string]reattachEntry{"test/mini": entry}))
 
 	p, err := NamedProvider(context.Background(), "registry.opentofu.org/test/mini", "")
 	require.NoError(t, err)
@@ -117,4 +158,48 @@ func TestNamedProviderReattachInvalidEnv(t *testing.T) {
 
 	_, err := NamedProvider(context.Background(), "test/mini", "")
 	require.ErrorContains(t, err, envReattachProviders)
+}
+
+// A malformed key rejects the env var deterministically, even when a valid
+// matching entry is also present.
+func TestNamedProviderReattachMalformedSiblingKey(t *testing.T) {
+	entry := serveReattachProvider(t, "test/mini", 6)
+	t.Setenv(envReattachProviders, reattachEnv(t, map[string]reattachEntry{
+		"test/mini": entry,
+		"bad key!":  {},
+	}))
+
+	_, err := NamedProvider(context.Background(), "test/mini", "")
+	require.ErrorContains(t, err, `provider key "bad key!"`)
+}
+
+func TestReattachProviderRejectsUnsupportedEntries(t *testing.T) {
+	t.Parallel()
+
+	addr, err := regaddr.ParseProviderSource("test/mini")
+	require.NoError(t, err)
+
+	grpcUnix := func(network, protocol string) reattachEntry {
+		entry := reattachEntry{Protocol: protocol, ProtocolVersion: 6}
+		entry.Addr.Network = network
+		entry.Addr.String = "/tmp/plugin.sock"
+		return entry
+	}
+
+	tests := []struct {
+		name    string
+		entry   reattachEntry
+		wantErr string
+	}{
+		{"unsupported network", grpcUnix("pipe", "grpc"), `unsupported network "pipe"`},
+		{"unsupported protocol", grpcUnix("unix", "netrpc"), `unsupported protocol "netrpc"`},
+		{"empty protocol", grpcUnix("unix", ""), `unsupported protocol ""`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := reattachProvider(context.Background(), addr, tt.entry)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Adds a `PULUMI_BRIDGE_REATTACH_PROVIDERS` environment variable to the dynamic provider's loader. It uses the same JSON format Terraform and OpenTofu accept in `TF_REATTACH_PROVIDERS`: a map from provider source address to the reattach information printed by a provider running in debug mode (or served with go-plugin's test mode). When a provider requested through `NamedProvider` matches an entry (keys and requests are compared after `ParseProviderSource` normalization, so `simple` and `registry.opentofu.org/hashicorp/simple` spellings interoperate), the loader connects to the already-running server via go-plugin's `Reattach` client mode instead of downloading and launching the provider binary. Reattached providers report version `0.0.0`, and any version constraint on them is ignored, since the caller controls the running server.

## Design notes

- Reattaching performs no go-plugin handshake, so the protocol version (5 or 6) comes from the reattach entry rather than negotiation; the connection then flows into the same v5→v6 upgrade / v6 shim path as launched providers (extracted as `protov6ServerFromConn`, now shared with `runProvider`).
- The returned provider's `Closer` is the bare gRPC connection, not the go-plugin client: `GRPCClient.Close` also issues a `grpc_controller` Shutdown RPC, which stops the *server* — for a shared reattach server that would kill it for every other attached client. (Launched providers keep the full client close, since they own their child process.)

## Motivation

This lets a test harness serve an in-memory TF provider (e.g. via `tf6server.WithDebug` or go-plugin test mode) and drive the shipped `terraform-provider` plugin against it end to end — real `Parameterize`, wire-schema `GetSchema`, and `GetMapping`. pulumi-hcl's tfcompat suite is the first consumer: its Pulumi path now runs through the actual parameterization flow against the same in-memory providers its OpenTofu path reattaches to with `TF_REATTACH_PROVIDERS`, instead of bridging them in-process. That work needs a release containing this change.

## Testing

Unit tests in `dynamic/internal/shim/run/reattach_test.go` serve an in-process protocol-6 provider in debug mode and cover: successful reattach + `GetProviderSchema` round-trip, address normalization between bare and fully-qualified keys, and strict rejection of a malformed environment value. Also verified end to end by pulumi-hcl's tfcompat suite running against a dev build of this branch.