### PR TITLE
Drop ignoreChanges paths that do not resolve against prior state

### DIFF
--- a/pkg/tests/regress_3560_test.go
+++ b/pkg/tests/regress_3560_test.go
@@ -10,11 +10,9 @@ import (
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/pulcheck"
 )
 
-// Regression test for https://github.com/pulumi/pulumi-terraform-bridge/issues/3560.
-//
-// ignoreChanges on a list index that does not resolve against the prior state must be
-// dropped (matching Terraform), not applied to the flatmap diff where it materializes an
-// empty element.
+// Regression test for https://github.com/pulumi/pulumi-terraform-bridge/issues/3560:
+// ignoring a list index absent from the prior state used to materialize an empty
+// element (["a", ""]) instead of leaving the append in place.
 func TestRegress3560(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tests/regress_3560_test.go
+++ b/pkg/tests/regress_3560_test.go
@@ -1,0 +1,56 @@
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/pulcheck"
+)
+
+// Regression test for https://github.com/pulumi/pulumi-terraform-bridge/issues/3560.
+//
+// ignoreChanges on a list index that does not resolve against the prior state must be
+// dropped (matching Terraform), not applied to the flatmap diff where it materializes an
+// empty element.
+func TestRegress3560(t *testing.T) {
+	t.Parallel()
+
+	resMap := map[string]*schema.Resource{
+		"prov_test": {
+			Schema: map[string]*schema.Schema{
+				"zones": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
+	}
+	prov := &schema.Provider{ResourcesMap: resMap}
+	bridgedProvider := pulcheck.BridgedProvider(t, "prov", prov)
+
+	program := `
+name: test
+runtime: yaml
+resources:
+  mainRes:
+    type: prov:index:Test
+    properties:
+      zones: %s
+    options:
+      ignoreChanges: ["zones[1]"]
+outputs:
+  zones: ${mainRes.zones}
+`
+
+	pt := pulcheck.PulCheck(t, bridgedProvider, fmt.Sprintf(program, `["a"]`))
+	pt.Up(t)
+
+	pt.WritePulumiYaml(t, fmt.Sprintf(program, `["a", "z"]`))
+	res := pt.Up(t)
+
+	require.Equal(t, []interface{}{"a", "z"}, res.Outputs["zones"].Value)
+}

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -284,6 +284,29 @@ func newIgnoreChanges(
 	}
 }
 
+// ignoredPathResolvesAgainstOlds reports whether an ignoreChanges path can be resolved
+// against the prior state. Terraform drops an ignore_changes entry whose traversal does
+// not resolve against the prior state; we emulate that for list indexes. Missing
+// attributes and map keys remain ignorable (matching Terraform's handling of maps)
+// unless a list index follows them.
+//
+// Applying an unresolvable list index to the flatmap diff deletes the element's diff
+// while leaving the list's count diff in place, materializing a zero value for the
+// element (see pulumi/pulumi-terraform-bridge#3560).
+func ignoredPathResolvesAgainstOlds(path resource.PropertyPath, olds resource.PropertyMap) bool {
+	last := -1
+	for i, step := range path {
+		if _, ok := step.(int); ok {
+			last = i
+		}
+	}
+	if last < 0 {
+		return true
+	}
+	_, ok := path[:last+1].Get(resource.NewObjectProperty(olds))
+	return ok
+}
+
 // Computes the ignored key set.
 func computeIgnoreChanges(
 	ctx context.Context,
@@ -294,6 +317,9 @@ func computeIgnoreChanges(
 ) map[string]struct{} {
 	ignoredPathSet := map[string]bool{}
 	for _, p := range ignoredPaths {
+		if pp, err := resource.ParsePropertyPath(p); err == nil && !ignoredPathResolvesAgainstOlds(pp, olds) {
+			continue
+		}
 		ignoredPathSet[p] = true
 	}
 	ignoredKeySet := map[string]struct{}{}

--- a/pkg/tfbridge/diff.go
+++ b/pkg/tfbridge/diff.go
@@ -284,15 +284,11 @@ func newIgnoreChanges(
 	}
 }
 
-// ignoredPathResolvesAgainstOlds reports whether an ignoreChanges path can be resolved
-// against the prior state. Terraform drops an ignore_changes entry whose traversal does
-// not resolve against the prior state; we emulate that for list indexes. Missing
-// attributes and map keys remain ignorable (matching Terraform's handling of maps)
-// unless a list index follows them.
-//
-// Applying an unresolvable list index to the flatmap diff deletes the element's diff
-// while leaving the list's count diff in place, materializing a zero value for the
-// element (see pulumi/pulumi-terraform-bridge#3560).
+// Terraform drops an ignore_changes entry whose traversal does not resolve against the
+// prior state. Only list indexes are checked: Terraform still allows ignoring map keys
+// and attributes absent from the prior state, while applying an unresolvable index to
+// the flatmap diff deletes the element's diff but keeps the list's count diff,
+// materializing a zero value for the element (pulumi/pulumi-terraform-bridge#3560).
 func ignoredPathResolvesAgainstOlds(path resource.PropertyPath, olds resource.PropertyMap) bool {
 	last := -1
 	for i, step := range path {

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -2310,9 +2310,7 @@ func TestComputeIgnoreChanges(t *testing.T) {
 		want         map[string]struct{}
 	}{
 		{
-			// See https://github.com/pulumi/pulumi-terraform-bridge/issues/3560: a list
-			// index that does not resolve against the prior state must be dropped, like
-			// Terraform drops unresolvable ignore_changes entries.
+			// https://github.com/pulumi/pulumi-terraform-bridge/issues/3560
 			name:         "list index beyond prior state is dropped",
 			ignoredPaths: []string{"zones[1]"},
 			want:         map[string]struct{}{},

--- a/pkg/tfbridge/diff_test.go
+++ b/pkg/tfbridge/diff_test.go
@@ -322,7 +322,8 @@ func diffTest(t *testing.T, tfs map[string]*v2Schema.Schema, inputs,
 	for _, s := range setup {
 		t.Run(s.name, func(t *testing.T) {
 			// Add an ignoreChanges entry for each path in the expected diff, then re-convert the diff
-			// and check the result.
+			// and check the result. Ignores that do not resolve against the prior state are dropped
+			// (https://github.com/pulumi/pulumi-terraform-bridge/issues/3560), so their diffs remain.
 			t.Run("withIgnoreAllExpected", func(t *testing.T) {
 				t.Parallel()
 				sch, r, provider, info := s.setup(tfs)
@@ -333,8 +334,17 @@ func diffTest(t *testing.T, tfs map[string]*v2Schema.Schema, inputs,
 				config, _, err := MakeTerraformConfig(ctx, &Provider{tf: provider}, nil, inputsMap, sch, info)
 				assert.NoError(t, err)
 
-				for k := range expected {
+				expectedResidualDiff := map[string]*pulumirpc.PropertyDiff{}
+				expectedResidualChanges := pulumirpc.DiffResponse_DIFF_NONE
+				for k, v := range expected {
 					ignoreChanges = append(ignoreChanges, k)
+
+					pp, err := resource.ParsePropertyPath(k)
+					require.NoError(t, err)
+					if !ignoredPathResolvesAgainstOlds(pp, stateMap) {
+						expectedResidualDiff[k] = &pulumirpc.PropertyDiff{Kind: v}
+						expectedResidualChanges = pulumirpc.DiffResponse_DIFF_SOME
+					}
 				}
 				tfDiff, err := provider.Diff(ctx, "resource", tfState, config, shim.DiffOptions{
 					IgnoreChanges: newIgnoreChanges(ctx, sch, info, stateMap, inputsMap, ignoreChanges),
@@ -342,8 +352,8 @@ func diffTest(t *testing.T, tfs map[string]*v2Schema.Schema, inputs,
 				assert.NoError(t, err)
 
 				diff, changes := makeDetailedDiff(ctx, sch, info, stateMap, inputsMap, tfDiff)
-				assert.Equal(t, pulumirpc.DiffResponse_DIFF_NONE, changes)
-				assert.Equal(t, map[string]*pulumirpc.PropertyDiff{}, diff)
+				assert.Equal(t, expectedResidualChanges, changes)
+				assert.Equal(t, expectedResidualDiff, diff)
 			})
 		})
 	}
@@ -2268,4 +2278,67 @@ func TestChangingMaxItems1FilterProperty(t *testing.T) {
 			"rules[0].filter": {},
 		},
 	})
+}
+
+func TestComputeIgnoreChanges(t *testing.T) {
+	t.Parallel()
+
+	tfs := shimv2.NewSchemaMap(map[string]*v2Schema.Schema{
+		"zones": {
+			Type:     v2Schema.TypeList,
+			Optional: true,
+			Elem:     &v2Schema.Schema{Type: v2Schema.TypeString},
+		},
+		"tags": {
+			Type:     v2Schema.TypeMap,
+			Optional: true,
+			Elem:     &v2Schema.Schema{Type: v2Schema.TypeString},
+		},
+	})
+	olds := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"zones": []interface{}{"a"},
+		"tags":  map[string]interface{}{"k": "v"},
+	})
+	news := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"zones": []interface{}{"a", "z"},
+		"tags":  map[string]interface{}{"k": "v2", "new": "v"},
+	})
+
+	tests := []struct {
+		name         string
+		ignoredPaths []string
+		want         map[string]struct{}
+	}{
+		{
+			// See https://github.com/pulumi/pulumi-terraform-bridge/issues/3560: a list
+			// index that does not resolve against the prior state must be dropped, like
+			// Terraform drops unresolvable ignore_changes entries.
+			name:         "list index beyond prior state is dropped",
+			ignoredPaths: []string{"zones[1]"},
+			want:         map[string]struct{}{},
+		},
+		{
+			name:         "list index within prior state",
+			ignoredPaths: []string{"zones[0]"},
+			want:         map[string]struct{}{"zones.0": {}},
+		},
+		{
+			name:         "whole attribute",
+			ignoredPaths: []string{"zones"},
+			want:         map[string]struct{}{"zones": {}},
+		},
+		{
+			name:         "map key added in news is kept",
+			ignoredPaths: []string{"tags.new"},
+			want:         map[string]struct{}{"tags.new": {}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := computeIgnoreChanges(context.Background(), tfs, nil, olds, news, tt.ignoredPaths)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #3560.

With `ignoreChanges: ["zones[1]"]` on a resource whose prior state holds `zones: ["a"]`, updating the program to `zones: ["a", "z"]` produced `zones: ["a", ""]`: the classic bridge translated the path to the flat key `zones.1` and deleted it from the `InstanceDiff` while keeping `zones.#: 2`, so SDKv2 materialized the flatmap zero value for the appended element.

Terraform drops an `ignore_changes` entry whose traversal cannot be resolved against the prior state. This change emulates that in `computeIgnoreChanges`: an ignore path is dropped when its list indexes do not resolve against the prior state (checked with `PropertyPath.Get` on the path prefix up to its last index step). Missing map keys and attributes remain ignorable, matching Terraform's handling of maps, unless a list index follows them.

The `withIgnoreAllExpected` diff-test harness previously asserted the corrupting behavior for element-add cases (ignoring `prop[N]` where the prior list has fewer than N+1 elements suppressed the whole diff); it now expects those diffs to remain.

- End-to-end regression test: `pkg/tests/regress_3560_test.go` (reproduced `["a", ""]` before the fix).
- Unit test: `TestComputeIgnoreChanges` in `pkg/tfbridge/diff_test.go`.