### PR TITLE
Respect PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION in the dynamic provider loader

### DIFF
--- a/dynamic/internal/shim/run/loader.go
+++ b/dynamic/internal/shim/run/loader.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
 	regaddr "github.com/opentofu/registry-address/v2"
 	disco "github.com/opentofu/svchost/disco"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/env"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"google.golang.org/grpc"
@@ -237,6 +238,13 @@ func getProviderServer(
 
 	// We have not found a package that fits our constraints, so we need to download
 	// one.
+
+	// Downloading contacts the registry, so honor PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION.
+	if env.DisableAutomaticPluginAcquisition.Value() {
+		return nil, fmt.Errorf(
+			"%s %s is not in the plugin cache and PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION is set",
+			addr, version)
+	}
 
 	source := getproviders.NewRegistrySource(ctx, registryDisco, nil, getproviders.LocationConfig{})
 

--- a/dynamic/internal/shim/run/loader_test.go
+++ b/dynamic/internal/shim/run/loader_test.go
@@ -24,8 +24,12 @@ import (
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	regaddr "github.com/opentofu/registry-address/v2"
+	disco "github.com/opentofu/svchost/disco"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/vendored/opentofu/getproviders"
 )
 
 func TestRetryOnTextFileBusy_NonRetryableErrorReturnsImmediately(t *testing.T) {
@@ -68,6 +72,24 @@ func TestRetryOnTextFileBusy_BackoffIsCalledBeforeRetries(t *testing.T) {
 	require.NoError(t, err)
 	// First attempt has no backoff; second attempt is preceded by one backoff call with attempt=1.
 	assert.Equal(t, []int{1}, backoffCalls)
+}
+
+// A cache miss with PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION set must error instead of
+// contacting the registry. The use of t.Setenv makes it necessary to not call t.Parallel().
+func TestGetProviderServerDisablesAutomaticAcquisition(t *testing.T) {
+	// Point the cache at an empty directory to force a cache miss.
+	t.Setenv(envPluginCache, t.TempDir())
+	t.Setenv("PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION", "true")
+
+	addr, err := regaddr.ParseProviderSource("hashicorp/tls")
+	require.NoError(t, err)
+
+	v, err := getproviders.ParseVersionConstraints("")
+	require.NoError(t, err)
+
+	_, err = getProviderServer(context.Background(), addr, v, disco.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION")
 }
 
 func Integration(t *testing.T) {


### PR DESCRIPTION
### Motivation

When the dynamic bridge loads a named Terraform provider and the requested
version is not present in the local plugin cache, `getProviderServer` downloads
it from the registry. That download performs `terraform-svchost` discovery,
which is a genuine outbound HTTP call.

This happened even when the user set `PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION`,
because that variable previously only gated Pulumi's own plugin-binary
acquisition in the engine — it never reached the dynamic bridge's Terraform
provider download path. In air-gapped or hermetic environments this is
surprising: setting the variable is expected to prevent automatic network
acquisition entirely.

### Change

Honor `PULUMI_DISABLE_AUTOMATIC_PLUGIN_ACQUISITION` in `getProviderServer`. On a
cache miss with acquisition disabled, fail fast with an actionable error instead
of contacting the registry.

The variable is already inherited by provider plugins — the engine launches them
with `os.Environ()` (`sdk/go/common/resource/plugin/plugin.go`) — so no
additional forwarding is required; the guard reads it inside the plugin process
where the download occurs.

Behavior is unchanged when the variable is unset, and cached providers continue
to load regardless of the variable.

### Testing

- New unit test `TestGetProviderServerDisablesAutomaticAcquisition` forces a
  cache miss with the variable set and asserts an error is returned; the test
  provides no network access, so a regression would surface as a registry-reach
  attempt.
- `gofmt -s`, `go build ./dynamic/...`, `golangci-lint run ./dynamic/internal/shim/run/...`
  (0 issues), and the dynamic unit tests all pass.
