### PR TITLE
tfbridge: unwrap secrets when extracting inputs from refreshed state

### DIFF
--- a/pkg/tests/regress_3119_test.go
+++ b/pkg/tests/regress_3119_test.go
@@ -1,0 +1,138 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/internal/tests/pulcheck"
+)
+
+// A no-op refresh must not rewrite the inputs recorded in state for secret-valued objects.
+//
+// extractInputs had no secret case, so a secret-wrapped object matched none of its array, object or
+// string branches and fell through to `default: return newState`. Refresh therefore replaced the
+// recorded input with the raw state, dropping nested __defaults markers. The resulting per-resource
+// input drift defeats the engine's checkpoint-write elision in sameSnapshotMutation.mustWrite.
+//
+// The assertion is deliberately made against state rather than against a preview diff: the bridge
+// reports DIFF_NONE for this drift, so ExpectNoChanges passes on both refresh and preview while the
+// stored inputs have in fact changed.
+//
+// See https://github.com/pulumi/pulumi-terraform-bridge/issues/3119.
+func TestRegress3119(t *testing.T) {
+	t.Parallel()
+
+	resMap := map[string]*schema.Resource{
+		"prov_test": {
+			Schema: map[string]*schema.Schema{
+				"credentials": {
+					Type:      schema.TypeList,
+					MaxItems:  1,
+					Optional:  true,
+					Sensitive: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"key":       {Type: schema.TypeString, Optional: true},
+							"generated": {Type: schema.TypeString, Computed: true},
+						},
+					},
+				},
+			},
+			ReadContext: func(_ context.Context, rd *schema.ResourceData, _ interface{}) diag.Diagnostics {
+				require.NoError(t, rd.Set("credentials", []interface{}{
+					map[string]interface{}{"key": "k", "generated": "g"},
+				}))
+				return nil
+			},
+			CreateContext: func(_ context.Context, rd *schema.ResourceData, _ interface{}) diag.Diagnostics {
+				require.NoError(t, rd.Set("credentials", []interface{}{
+					map[string]interface{}{"key": "k", "generated": "g"},
+				}))
+				rd.SetId("id0")
+				return nil
+			},
+		},
+	}
+
+	bridgedProvider := pulcheck.BridgedProvider(t, "prov", &schema.Provider{ResourcesMap: resMap})
+	pt := pulcheck.PulCheck(t, bridgedProvider, `
+name: test
+runtime: yaml
+resources:
+  mainRes:
+    type: prov:index:Test
+    properties:
+      credentials:
+        key: "k"
+`)
+	pt.Up(t)
+
+	before := secretCredentials(t, pt)
+	require.Equal(t, "k", before["key"])
+	require.NotContains(t, before, "generated",
+		"precondition: a computed field is not an input")
+
+	pt.Refresh(t)
+
+	require.NotContains(t, secretCredentials(t, pt), "generated",
+		"refresh must not copy computed state into the recorded inputs of a secret object")
+}
+
+// secretCredentials returns the plaintext contents of the secret `credentials` input.
+func secretCredentials(t *testing.T, pt *pulumitest.PulumiTest) map[string]interface{} {
+	t.Helper()
+
+	credentials, ok := stackResourceInputs(t, pt)["credentials"].(map[string]interface{})
+	require.True(t, ok, "credentials should be an object")
+
+	plaintext, ok := credentials["plaintext"].(string)
+	require.True(t, ok, "credentials should be a secret with a plaintext field")
+
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(plaintext), &decoded))
+	return decoded
+}
+
+func stackResourceInputs(t *testing.T, pt *pulumitest.PulumiTest) map[string]interface{} {
+	t.Helper()
+
+	data, err := pt.ExportStack(t).Deployment.MarshalJSON()
+	require.NoError(t, err)
+
+	var deployment struct {
+		Resources []struct {
+			Type   string                 `json:"type"`
+			Inputs map[string]interface{} `json:"inputs"`
+		} `json:"resources"`
+	}
+	require.NoError(t, json.Unmarshal(data, &deployment))
+
+	for _, r := range deployment.Resources {
+		if r.Type == "prov:index/test:Test" {
+			return r.Inputs
+		}
+	}
+
+	t.Fatal("did not find the resource in the exported stack")
+	return nil
+}

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1718,6 +1718,22 @@ func matchSetElements(
 func extractInputs(
 	oldInput, newState resource.PropertyValue, tfs shim.Schema, ps *SchemaInfo,
 ) (resource.PropertyValue, bool) {
+	// Unwrap secrets before doing anything else. A secret is not an array, object or string, so
+	// without this a secret-wrapped value falls through to the default branch below and the raw
+	// state is substituted for the recorded input, discarding nested `__defaults` markers along
+	// with the input/output distinction. Re-wrap afterwards so a value never loses secretness.
+	if oldInput.IsSecret() || newState.IsSecret() {
+		oldElem, newElem := oldInput, newState
+		if oldElem.IsSecret() {
+			oldElem = oldElem.SecretValue().Element
+		}
+		if newElem.IsSecret() {
+			newElem = newElem.SecretValue().Element
+		}
+		extracted, possibleDefault := extractInputs(oldElem, newElem, tfs, ps)
+		return resource.MakeSecret(extracted), possibleDefault
+	}
+
 	if IsMaxItemsOne(tfs, ps) {
 		tfs, ps = elemSchemas(tfs, ps)
 	}


### PR DESCRIPTION
# Human:

This PR was generated by Claude Opus 5. Also see #3568.

# LLM:

Fixes #3119.

## Root cause

`extractInputs` in `pkg/tfbridge/schema.go` has no case for secrets. Its switch tests `oldInput.IsArray() && newState.IsArray()`, `oldInput.IsObject() && newState.IsObject()`, and so on. A secret is none of those, so a secret-wrapped value matches nothing and falls through to:

```go
default:
    return newState, oldInput.DeepEquals(newState)
```

That returns the raw refreshed state as if it were the input. For a secret object this throws away the input/output distinction entirely:

- computed, output-only fields get copied into the recorded inputs, and
- nested `__defaults` markers are dropped.

The dropped markers are what this issue observes. The report's own log shows it precisely - the secret `credentials` object loses its nested `__defaults` across the refresh while the adjacent plain `kafkaCluster` map keeps it:

```
.oldInputs]: credentials={&{{map[key:{REDACTED} secret:{REDACTED}]}}}
.newInputs]: credentials={&{{map[__defaults:{[]} key:{REDACTED} secret:{REDACTED}]}}}
.oldInputs]: kafkaCluster={map[__defaults:{[]} id:{lkc-REDACTED}]}
.newInputs]: kafkaCluster={map[__defaults:{[]} id:{lkc-REDACTED}]}
```

`Check` re-adds the marker on the next run, so the inputs recorded in state and the inputs the program produces disagree on every run. `sameSnapshotMutation.mustWrite` compares raw input bags with `DeepEquals`, so it cannot elide the checkpoint write even though `Diff` returns `DIFF_NONE`. Because the engine rewrites the entire state file per non-elided step on a single serialized goroutine, the cost is quadratic in stack size - which matches the reported ">3000 resource stacks taking >40min with no changes".

## The fix

Unwrap secrets at the top of `extractInputs`, recurse on the element, and re-wrap. Unwrapping happens before the `IsMaxItemsOne` adjustment so the existing logic runs unchanged on the unwrapped value. Both sides are re-wrapped if either was secret, so a value can never lose secretness.

## Testing

`TestRegress3119` runs a real `up` followed by a real `refresh` and asserts that a computed field inside a secret block does not leak into the recorded inputs. It fails on `main` with `refresh must not copy computed state into the recorded inputs of a secret object` and passes with this change.

I deliberately assert on the computed-field leak rather than on `__defaults`, so that this test isolates the secret bug and does not also depend on #3567 (a separate refresh defect that independently perturbs `__defaults`).

Two notes on test design:

- The assertion is made against `ExportStack` rather than a preview. The bridge returns `DIFF_NONE` for this drift, so `optrefresh.ExpectNoChanges()` and `optpreview.ExpectNoChanges()` both pass while the stored inputs have in fact changed. State is the only place this is observable, and it is what the engine actually compares.
- The computed-field leak is a correctness problem in its own right, independent of the performance symptom in this issue.

`go test ./pkg/tfbridge/...` is green. `go test ./pkg/tests/` shows the same single pre-existing failure before and after this change (`TestAccProviderConfig`, which needs `make install_plugins` to fetch `pulumi-resource-random`); I verified that against a clean checkout of `main` rather than assuming.

## Relationship to #3567 and #3356

These are two distinct defects that produce the same `mustWrite() true because of Inputs` symptom:

- This PR fixes the secret handling, which is the cause reported in #3119.
- #3567 covers `deleteDefaultsKey`, added in #3356 as an attempted fix for this issue. It strips empty `__defaults` from all refreshed inputs, which does not stabilize (`Check` re-adds them every run) and also changes `applyDefaults` semantics, since an absent marker means "every old value may be reused as a default" while an empty marker means "no old value is a default".

The two changes are independent and do not conflict. They are both needed for a refresh to leave inputs untouched.