### PR TITLE
Reproduce PF nested set value crossing

### DIFF
--- a/pkg/pf/tests/internal/cross-tests/create.go
+++ b/pkg/pf/tests/internal/cross-tests/create.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	pulumiresource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -81,11 +82,14 @@ func Create(t *testing.T, res pb.Resource, tfConfig map[string]cty.Value, option
 	})
 	shimProvider := tfbridge.ShimProvider(tfProvider)
 
-	puConfig := crosstestsimpl.InferPulumiValue(t,
-		shimProvider.ResourcesMap().Get("testprovider_test").Schema(),
-		opts.resourceInfo,
-		cty.ObjectVal(tfConfig),
-	)
+	puConfig := opts.pulumiConfig
+	if puConfig == nil {
+		puConfig = crosstestsimpl.InferPulumiValue(t,
+			shimProvider.ResourcesMap().Get("testprovider_test").Schema(),
+			opts.resourceInfo,
+			cty.ObjectVal(tfConfig),
+		)
+	}
 	pulumiYaml := yamlResource(t, puConfig)
 	bytes, err := yaml.Marshal(pulumiYaml)
 	require.NoError(t, err)
@@ -108,6 +112,14 @@ type CreateOption func(*createOpts)
 
 type createOpts struct {
 	resourceInfo map[string]*info.Schema
+	pulumiConfig pulumiresource.PropertyMap
+}
+
+// CreatePulumiConfig provides Pulumi input without deriving it from the Terraform configuration.
+func CreatePulumiConfig(config pulumiresource.PropertyMap) CreateOption {
+	return func(o *createOpts) {
+		o.pulumiConfig = config
+	}
 }
 
 func CreateResourceInfo(info map[string]*info.Schema) CreateOption {

--- a/pkg/pf/tests/set_nested_block_create_test.go
+++ b/pkg/pf/tests/set_nested_block_create_test.go
@@ -1,0 +1,154 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tfbridgetests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	pulumiresource "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/zclconf/go-cty/cty"
+
+	pb "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/internal/providerbuilder"
+	crosstests "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tests/internal/cross-tests"
+)
+
+type preserveConfiguredString struct{}
+
+func (preserveConfiguredString) Description(context.Context) string {
+	return "preserve configured value"
+}
+
+func (preserveConfiguredString) MarkdownDescription(context.Context) string {
+	return "preserve configured value"
+}
+
+func (preserveConfiguredString) PlanModifyString(
+	_ context.Context,
+	req planmodifier.StringRequest,
+	resp *planmodifier.StringResponse,
+) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = types.StringValue(req.ConfigValue.ValueString())
+}
+
+type setOrderModel struct {
+	ID      types.String            `tfsdk:"id"`
+	GroupBy []*setOrderGroupByModel `tfsdk:"group_by"`
+}
+
+type setOrderGroupByModel struct {
+	Path    types.String `tfsdk:"path"`
+	TagName types.String `tfsdk:"tag_name"`
+}
+
+func TestPFCreateSetNestedBlockPreservesElementCorrelation(t *testing.T) {
+	res := pb.NewResource(pb.NewResourceArgs{
+		ResourceSchema: schema.Schema{
+			Blocks: map[string]schema.Block{
+				"group_by": schema.SetNestedBlock{
+					NestedObject: schema.NestedBlockObject{
+						Attributes: map[string]schema.Attribute{
+							"path": schema.StringAttribute{
+								Required: true,
+							},
+							"tag_name": schema.StringAttribute{
+								Optional: true,
+								Computed: true,
+								PlanModifiers: []planmodifier.String{
+									preserveConfiguredString{},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		CreateFunc: func(
+			ctx context.Context,
+			req resource.CreateRequest,
+			resp *resource.CreateResponse,
+		) {
+			var plan setOrderModel
+			resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+			// Resolve computed values so Terraform can complete apply. The cross-test
+			// captures req.Plan before this function returns.
+			for _, item := range plan.GroupBy {
+				if item.TagName.IsNull() || item.TagName.IsUnknown() {
+					item.TagName = types.StringValue("")
+				}
+			}
+
+			plan.ID = types.StringValue("test-id")
+			resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+		},
+	})
+
+	groupBy := func(path string, tagName cty.Value) cty.Value {
+		return cty.ObjectVal(map[string]cty.Value{
+			"path":     cty.StringVal(path),
+			"tag_name": tagName,
+		})
+	}
+
+	tfConfig := map[string]cty.Value{
+		"group_by": cty.SetVal([]cty.Value{
+			groupBy("env", cty.NullVal(cty.String)),
+			groupBy("service", cty.NullVal(cty.String)),
+			groupBy("status", cty.NullVal(cty.String)),
+			groupBy("@stream", cty.StringVal("stream")),
+			groupBy("@tier", cty.StringVal("tier")),
+		}),
+	}
+
+	// Keep the original user order. Do not derive this value from tfConfig,
+	// because cty.SetVal has already canonicalized that set.
+	pulumiConfig := pulumiresource.PropertyMap{
+		"groupBies": pulumiresource.NewArrayProperty([]pulumiresource.PropertyValue{
+			groupByPulumi("env", ""),
+			groupByPulumi("service", ""),
+			groupByPulumi("status", ""),
+			groupByPulumi("@stream", "stream"),
+			groupByPulumi("@tier", "tier"),
+		}),
+	}
+
+	crosstests.Create(
+		t,
+		res,
+		tfConfig,
+		crosstests.CreatePulumiConfig(pulumiConfig),
+	)
+}
+
+func groupByPulumi(path, tagName string) pulumiresource.PropertyValue {
+	value := pulumiresource.PropertyMap{
+		"path": pulumiresource.NewStringProperty(path),
+	}
+
+	if tagName != "" {
+		value["tagName"] = pulumiresource.NewStringProperty(tagName)
+	}
+
+	return pulumiresource.NewObjectProperty(value)
+}


### PR DESCRIPTION
Pulumi can cross nested `Optional+Computed` values between elements of a Plugin Framework `SetNestedBlock` during create. In the Datadog `SpansMetric` case, this silently assigns explicit `tag_name` values to the wrong `group_by` paths.

The proposed state canonicalizes the set, while the PF config keeps the Pulumi source-array order. The Plugin Framework walks planned set elements but obtains each config element by the same numeric index. When a nested attribute plan modifier runs, it can therefore read a value from one config element and write it into another planned element.

This draft adds a focused Terraform/Pulumi create cross-test. The existing helper derives Pulumi input from `cty.SetVal`, which canonicalizes the set and masks the bug. The new option lets the test preserve the original Pulumi input order.

The test currently fails as intended:

```text
                 Terraform plan     Pulumi plan
@stream.tag_name "stream"           "stream"
@tier.tag_name   "tier"             "tier"
service.tag_name unknown             "stream"
status.tag_name  unknown             "tier"
```

A later change can use this test to verify the runtime fix. This PR does not propose that fix yet.

Downstream: https://github.com/pulumi/pulumi-datadog/issues/1249

Validation:

- `go test ./pkg/pf/tests/internal/cross-tests -count=1` passes.
- `make test RUN_TEST_CMD='./pkg/pf/tests -run ^TestPFCreateSetNestedBlockPreservesElementCorrelation$ -count=1'` fails at the plan comparison as intended. Pulumi assigns `stream` to `service` and `tier` to `status`.
