### PR TITLE
Add Accept Goldens workflow for CI-side regeneration

### DIFF
--- a/.github/workflows/accept-goldens.yml
+++ b/.github/workflows/accept-goldens.yml
@@ -62,12 +62,34 @@ jobs:
           key: ubuntu-latest-plugins
           restore-keys: |
             ubuntu-latest-plugins
-      # Runs `make test_accept` (sets PULUMI_HOME, PULUMI_ACCEPT=1, installs
-      # plugins). RUN_TEST_CMD adds `-args -update` so autogold-based tests
-      # accept new expected values in the same run.
-      - name: Regenerate goldens
+      # Discover Go packages that import hexops/autogold so we can pass
+      # `-args -update` only to those. `-update` is registered by autogold's
+      # init(), so packages that don't import it fail with "flag provided
+      # but not defined".
+      - name: Compute autogold packages
+        id: autogold_pkgs
         run: |
-          make test_accept RUN_TEST_CMD='./... -args -update'
+          set -euo pipefail
+          # List of package dirs (relative) that import autogold.
+          pkgs=$(git grep -l 'hexops/autogold' -- '*.go' \
+            | xargs -n1 dirname | sort -u | sed 's|^|./|')
+          echo "packages<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$pkgs" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "found $(echo "$pkgs" | wc -l) autogold packages"
+      # Two passes:
+      #   1. Full suite with PULUMI_ACCEPT=1 (regenerates all non-autogold goldens).
+      #   2. Autogold-importing packages with `-args -update` to refresh their
+      #      autogold values.
+      # `make test_accept` handles PULUMI_HOME + plugin install and sets
+      # PULUMI_ACCEPT=1 for us.
+      - name: Regenerate PULUMI_ACCEPT goldens
+        run: |
+          make test_accept RUN_TEST_CMD='./...'
+      - name: Regenerate autogold goldens
+        run: |
+          pkgs=$(echo '${{ steps.autogold_pkgs.outputs.packages }}' | tr '\n' ' ')
+          make test_accept RUN_TEST_CMD="$pkgs -args -update"
       - name: Commit and push
         run: |
           git config user.name  'github-actions[bot]'

--- a/.github/workflows/accept-goldens.yml
+++ b/.github/workflows/accept-goldens.yml
@@ -1,9 +1,10 @@
 name: Accept Goldens
 
 # Triggered manually from the Actions tab. Checks out the specified branch,
-# runs the dynamic full-docs tests with PULUMI_ACCEPT=1, and commits any
-# refreshed golden files back to the branch. Used when local golden
-# regeneration cannot reproduce CI (e.g. plugins missing on darwin-arm64).
+# runs the full test suite with PULUMI_ACCEPT=1 (and autogold `-update`), and
+# commits any refreshed golden files back to the branch. Used when local
+# golden regeneration cannot reproduce CI (e.g. plugins missing on
+# darwin-arm64).
 
 on:
   workflow_dispatch:
@@ -12,14 +13,6 @@ on:
         description: 'Branch (or ref) to regenerate goldens on'
         required: true
         default: 'main'
-      test_pattern:
-        description: 'Go -run pattern for tests to regenerate'
-        required: true
-        default: 'TestSchemaGenerationFullDocs|TestSchemaGenerationIndexDocOutDir'
-      test_package:
-        description: 'Go package to run'
-        required: true
-        default: './dynamic/'
 
 permissions:
   contents: write
@@ -31,6 +24,7 @@ env:
 jobs:
   accept:
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -59,6 +53,8 @@ jobs:
           pulumi-version: ${{ steps.pulumi_version.outputs.pulumi_version }}
       - name: Build
         run: make build
+      - name: Build PF
+        run: cd pkg/pf && make build
       - name: Restore plugins
         uses: actions/cache/restore@v4
         with:
@@ -66,13 +62,12 @@ jobs:
           key: ubuntu-latest-plugins
           restore-keys: |
             ubuntu-latest-plugins
-      - name: Install plugins
-        run: make install_plugins
+      # Runs `make test_accept` (sets PULUMI_HOME, PULUMI_ACCEPT=1, installs
+      # plugins). RUN_TEST_CMD adds `-args -update` so autogold-based tests
+      # accept new expected values in the same run.
       - name: Regenerate goldens
         run: |
-          PULUMI_ACCEPT=1 go test -v -count=1 -timeout 30m \
-            -run '${{ github.event.inputs.test_pattern }}' \
-            ${{ github.event.inputs.test_package }}
+          make test_accept RUN_TEST_CMD='./... -args -update'
       - name: Commit and push
         run: |
           git config user.name  'github-actions[bot]'

--- a/.github/workflows/accept-goldens.yml
+++ b/.github/workflows/accept-goldens.yml
@@ -1,0 +1,86 @@
+name: Accept Goldens
+
+# Triggered manually from the Actions tab. Checks out the specified branch,
+# runs the dynamic full-docs tests with PULUMI_ACCEPT=1, and commits any
+# refreshed golden files back to the branch. Used when local golden
+# regeneration cannot reproduce CI (e.g. plugins missing on darwin-arm64).
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch (or ref) to regenerate goldens on'
+        required: true
+        default: 'main'
+      test_pattern:
+        description: 'Go -run pattern for tests to regenerate'
+        required: true
+        default: 'TestSchemaGenerationFullDocs|TestSchemaGenerationIndexDocOutDir'
+      test_package:
+        description: 'Go package to run'
+        required: true
+        default: './dynamic/'
+
+permissions:
+  contents: write
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PULUMI_SKIP_UPDATE_CHECK: 'true'
+
+jobs:
+  accept:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          persist-credentials: true
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.25.x
+          cache-dependency-path: |
+            **/go.sum
+      - name: Find pulumi version
+        id: pulumi_version
+        shell: bash
+        run: |
+          GO_MODULE_VERSION=$(go list -m -f '{{.Version}}' github.com/pulumi/pulumi/pkg/v3)
+          echo "pulumi_version=${GO_MODULE_VERSION#v}" >> "$GITHUB_OUTPUT"
+      - name: Install pulumi
+        uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7
+        with:
+          pulumi-version: ${{ steps.pulumi_version.outputs.pulumi_version }}
+      - name: Build
+        run: make build
+      - name: Restore plugins
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.pulumi/plugins
+          key: ubuntu-latest-plugins
+          restore-keys: |
+            ubuntu-latest-plugins
+      - name: Install plugins
+        run: make install_plugins
+      - name: Regenerate goldens
+        run: |
+          PULUMI_ACCEPT=1 go test -v -count=1 -timeout 30m \
+            -run '${{ github.event.inputs.test_pattern }}' \
+            ${{ github.event.inputs.test_package }}
+      - name: Commit and push
+        run: |
+          git config user.name  'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          if git diff --quiet; then
+            echo 'No golden changes.'
+            exit 0
+          fi
+          git add -A
+          git commit -m 'Regenerate goldens via CI'
+          git push origin HEAD:${{ github.event.inputs.ref }}


### PR DESCRIPTION
Manual workflow_dispatch that runs PULUMI_ACCEPT=1 against the given branch and pushes any refreshed goldens back. Use when local regen cannot reproduce CI (e.g. platform-specific plugin unavailability).