### PR TITLE
info: carry declared resource timeouts in the GetMapping provider schema

### DIFF
--- a/pkg/pf/internal/schemashim/datasource.go
+++ b/pkg/pf/internal/schemashim/datasource.go
@@ -57,9 +57,7 @@ func (*schemaOnlyDataSource) Importer() shim.ImportFunc {
 	panic("schemaOnlyDataSource does not implement runtime operation ImporterFunc")
 }
 
-func (*schemaOnlyDataSource) Timeouts() *shim.ResourceTimeout {
-	panic("schemaOnlyDataSource does not implement runtime operation Timeouts")
-}
+func (*schemaOnlyDataSource) Timeouts() *shim.ResourceTimeout { return nil }
 
 func (*schemaOnlyDataSource) InstanceState(id string, object,
 	meta map[string]interface{},

--- a/pkg/pf/internal/schemashim/datasource.go
+++ b/pkg/pf/internal/schemashim/datasource.go
@@ -57,6 +57,7 @@ func (*schemaOnlyDataSource) Importer() shim.ImportFunc {
 	panic("schemaOnlyDataSource does not implement runtime operation ImporterFunc")
 }
 
+// Timeouts is nil; see schemaOnlyResource.Timeouts.
 func (*schemaOnlyDataSource) Timeouts() *shim.ResourceTimeout { return nil }
 
 func (*schemaOnlyDataSource) InstanceState(id string, object,

--- a/pkg/pf/internal/schemashim/list_resource.go
+++ b/pkg/pf/internal/schemashim/list_resource.go
@@ -66,6 +66,7 @@ func (*schemaOnlyListResource) Importer() shim.ImportFunc {
 	panic("schemaOnlyListResource does not implement runtime operation ImporterFunc")
 }
 
+// Timeouts is nil; see schemaOnlyResource.Timeouts.
 func (*schemaOnlyListResource) Timeouts() *shim.ResourceTimeout { return nil }
 
 func (*schemaOnlyListResource) InstanceState(id string, object,

--- a/pkg/pf/internal/schemashim/list_resource.go
+++ b/pkg/pf/internal/schemashim/list_resource.go
@@ -66,9 +66,7 @@ func (*schemaOnlyListResource) Importer() shim.ImportFunc {
 	panic("schemaOnlyListResource does not implement runtime operation ImporterFunc")
 }
 
-func (*schemaOnlyListResource) Timeouts() *shim.ResourceTimeout {
-	panic("schemaOnlyListResource does not implement runtime operation Timeouts")
-}
+func (*schemaOnlyListResource) Timeouts() *shim.ResourceTimeout { return nil }
 
 func (*schemaOnlyListResource) InstanceState(id string, object,
 	meta map[string]interface{},

--- a/pkg/pf/internal/schemashim/resource.go
+++ b/pkg/pf/internal/schemashim/resource.go
@@ -58,9 +58,9 @@ func (*schemaOnlyResource) Importer() shim.ImportFunc {
 	panic("schemaOnlyResource does not implement runtime operation ImporterFunc")
 }
 
-func (*schemaOnlyResource) Timeouts() *shim.ResourceTimeout {
-	panic("schemaOnlyResource does not implement runtime operation Timeouts")
-}
+// Timeouts is nil: a Plugin Framework resource has no SDKv2-style declared
+// operation timeouts; any timeouts block is an ordinary part of its schema.
+func (*schemaOnlyResource) Timeouts() *shim.ResourceTimeout { return nil }
 
 func (*schemaOnlyResource) InstanceState(id string, object,
 	meta map[string]interface{},

--- a/pkg/pf/proto/resource.go
+++ b/pkg/pf/proto/resource.go
@@ -92,9 +92,10 @@ func (r resource) Importer() shim.ImportFunc {
 
 func (r resource) DeprecationMessage() string { return deprecated(r.r.Block.Deprecated) }
 
-func (r resource) Timeouts() *shim.ResourceTimeout {
-	panic("Cannot call Timeouts for a schema only resource")
-}
+// Timeouts is nil: the SDKv2-style declared operation timeouts do not exist for
+// a protocol-level resource, where any timeouts block is an ordinary part of the
+// schema.
+func (r resource) Timeouts() *shim.ResourceTimeout { return nil }
 
 func (r resource) InstanceState(id string, object, meta map[string]interface{}) (shim.InstanceState, error) {
 	panic("Cannot call InstanceState for a schema only resource")

--- a/pkg/tfbridge/info/info.go
+++ b/pkg/tfbridge/info/info.go
@@ -22,6 +22,7 @@ package info
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -1044,11 +1045,15 @@ func MarshalResourceShim(r shim.Resource) MarshallableResourceShim {
 
 // Unmarshal creates a mostly-initialized Terraform resource schema from the given MarshallableResourceShim.
 func (m MarshallableResourceShim) Unmarshal() shim.Resource {
+	return m.unmarshalWithTimeouts(nil)
+}
+
+func (m MarshallableResourceShim) unmarshalWithTimeouts(t *MarshallableResourceTimeoutShim) shim.Resource {
 	s := schema.SchemaMap{}
 	for k, v := range m {
 		s[k] = v.Unmarshal()
 	}
-	return (&schema.Resource{Schema: s}).Shim()
+	return (&schema.Resource{Schema: s, Timeouts: t.Unmarshal()}).Shim()
 }
 
 // MarshallableElemShim is the JSON-marshallable form of a Terraform schema's element field.
@@ -1213,6 +1218,66 @@ type MarshallableProviderShim struct {
 	Resources   map[string]MarshallableResourceShim `json:"resources,omitempty"`
 	DataSources map[string]MarshallableResourceShim `json:"dataSources,omitempty"`
 	Functions   map[string]MarshallableFunctionShim `json:"functions,omitempty"`
+
+	// ResourceTimeouts and DataSourceTimeouts carry the operation timeouts a
+	// resource or data source declares (shim.Resource.Timeouts), keyed by
+	// Terraform type name. They are kept apart from Resources/DataSources
+	// because a MarshallableResourceShim is the bare schema map, and adding a
+	// key to it would read as a field.
+	ResourceTimeouts   map[string]*MarshallableResourceTimeoutShim `json:"resourceTimeouts,omitempty"`
+	DataSourceTimeouts map[string]*MarshallableResourceTimeoutShim `json:"dataSourceTimeouts,omitempty"`
+}
+
+// MarshallableResourceTimeoutShim is the JSON-marshallable form of a shim.ResourceTimeout.
+// A nil entry means the operation declares no timeout.
+type MarshallableResourceTimeoutShim struct {
+	Create  *time.Duration `json:"create,omitempty"`
+	Read    *time.Duration `json:"read,omitempty"`
+	Update  *time.Duration `json:"update,omitempty"`
+	Delete  *time.Duration `json:"delete,omitempty"`
+	Default *time.Duration `json:"default,omitempty"`
+}
+
+// MarshalResourceTimeoutShim converts a shim.ResourceTimeout into a MarshallableResourceTimeoutShim.
+func MarshalResourceTimeoutShim(t *shim.ResourceTimeout) *MarshallableResourceTimeoutShim {
+	if t == nil {
+		return nil
+	}
+	return &MarshallableResourceTimeoutShim{
+		Create:  t.Create,
+		Read:    t.Read,
+		Update:  t.Update,
+		Delete:  t.Delete,
+		Default: t.Default,
+	}
+}
+
+// Unmarshal creates a shim.ResourceTimeout from the given MarshallableResourceTimeoutShim.
+func (m *MarshallableResourceTimeoutShim) Unmarshal() *shim.ResourceTimeout {
+	if m == nil {
+		return nil
+	}
+	return &shim.ResourceTimeout{
+		Create:  m.Create,
+		Read:    m.Read,
+		Update:  m.Update,
+		Delete:  m.Delete,
+		Default: m.Default,
+	}
+}
+
+func marshalResourceTimeoutShims(rm shim.ResourceMap) map[string]*MarshallableResourceTimeoutShim {
+	var out map[string]*MarshallableResourceTimeoutShim
+	rm.Range(func(k string, v shim.Resource) bool {
+		if t := v.Timeouts(); t != nil {
+			if out == nil {
+				out = map[string]*MarshallableResourceTimeoutShim{}
+			}
+			out[k] = MarshalResourceTimeoutShim(t)
+		}
+		return true
+	})
+	return out
 }
 
 // MarshalProviderShim converts a Terraform provider schema into a MarshallableProviderShim.
@@ -1244,10 +1309,12 @@ func MarshalProviderShim(p shim.Provider) *MarshallableProviderShim {
 		}
 	}
 	return &MarshallableProviderShim{
-		Schema:      config,
-		Resources:   resources,
-		DataSources: dataSources,
-		Functions:   functions,
+		Schema:             config,
+		Resources:          resources,
+		DataSources:        dataSources,
+		Functions:          functions,
+		ResourceTimeouts:   marshalResourceTimeoutShims(p.ResourcesMap()),
+		DataSourceTimeouts: marshalResourceTimeoutShims(p.DataSourcesMap()),
 	}
 }
 
@@ -1263,11 +1330,11 @@ func (m *MarshallableProviderShim) Unmarshal() shim.Provider {
 	}
 	resources := schema.ResourceMap{}
 	for k, v := range m.Resources {
-		resources[k] = v.Unmarshal()
+		resources[k] = v.unmarshalWithTimeouts(m.ResourceTimeouts[k])
 	}
 	dataSources := schema.ResourceMap{}
 	for k, v := range m.DataSources {
-		dataSources[k] = v.Unmarshal()
+		dataSources[k] = v.unmarshalWithTimeouts(m.DataSourceTimeouts[k])
 	}
 	var functions map[string]shim.Function
 	if len(m.Functions) > 0 {

--- a/pkg/tfbridge/info/info_test.go
+++ b/pkg/tfbridge/info/info_test.go
@@ -1,11 +1,15 @@
 package info
 
 import (
+	"encoding/json"
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/hexops/autogold/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	schemashim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
@@ -157,10 +161,35 @@ func TestMarshallableProviderTimeouts(t *testing.T) {
 		"test_source": {Read: &read},
 	}, marshalled.DataSourceTimeouts)
 
-	unmarshalled := marshalled.Unmarshal()
+	data, err := json.Marshal(marshalled)
+	require.NoError(t, err)
+	var decoded MarshallableProviderShim
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	unmarshalled := decoded.Unmarshal()
 	assert.Equal(t, &shim.ResourceTimeout{Create: &create, Default: &deflt},
 		unmarshalled.ResourcesMap().Get("test_timed").Timeouts())
 	assert.Nil(t, unmarshalled.ResourcesMap().Get("test_untimed").Timeouts())
 	assert.Equal(t, &shim.ResourceTimeout{Read: &read},
 		unmarshalled.DataSourcesMap().Get("test_source").Timeouts())
+}
+
+// A provider that declares no timeouts marshals to the same JSON as before the
+// timeout maps existed, so older consumers of the wire form are unaffected.
+func TestMarshallableProviderTimeoutsAbsentFromJSON(t *testing.T) {
+	t.Parallel()
+
+	providerShim := &schemashim.Provider{
+		ResourcesMap: schemashim.ResourceMap{
+			"test_untimed": (&schemashim.Resource{
+				Schema: schemashim.SchemaMap{"name": (&schemashim.Schema{Type: shim.TypeString}).Shim()},
+			}).Shim(),
+		},
+	}
+
+	data, err := json.Marshal(MarshalProviderShim(providerShim.Shim()))
+	require.NoError(t, err)
+	var keys map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &keys))
+	assert.Equal(t, []string{"resources"}, slices.Sorted(maps.Keys(keys)))
 }

--- a/pkg/tfbridge/info/info_test.go
+++ b/pkg/tfbridge/info/info_test.go
@@ -2,8 +2,10 @@ package info
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hexops/autogold/v2"
+	"github.com/stretchr/testify/assert"
 
 	shim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim"
 	schemashim "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/schema"
@@ -120,4 +122,45 @@ func TestMarshallableProviderPreservesSkipDefaultFixups(t *testing.T) {
 	unmarshalled := marshalled.Unmarshal()
 
 	autogold.Expect(true).Equal(t, unmarshalled.SkipDefaultFixups)
+}
+
+// Declared operation timeouts round-trip through the JSON wire form, so mapping
+// consumers can tell which operations a resource or data source accepts a
+// timeout for. Resources declaring none stay nil.
+func TestMarshallableProviderTimeouts(t *testing.T) {
+	t.Parallel()
+
+	create, read, deflt := 10*time.Minute, 2*time.Minute, 5*time.Minute
+	providerShim := &schemashim.Provider{
+		ResourcesMap: schemashim.ResourceMap{
+			"test_timed": (&schemashim.Resource{
+				Schema:   schemashim.SchemaMap{"name": (&schemashim.Schema{Type: shim.TypeString}).Shim()},
+				Timeouts: &shim.ResourceTimeout{Create: &create, Default: &deflt},
+			}).Shim(),
+			"test_untimed": (&schemashim.Resource{
+				Schema: schemashim.SchemaMap{"name": (&schemashim.Schema{Type: shim.TypeString}).Shim()},
+			}).Shim(),
+		},
+		DataSourcesMap: schemashim.ResourceMap{
+			"test_source": (&schemashim.Resource{
+				Schema:   schemashim.SchemaMap{"name": (&schemashim.Schema{Type: shim.TypeString}).Shim()},
+				Timeouts: &shim.ResourceTimeout{Read: &read},
+			}).Shim(),
+		},
+	}
+
+	marshalled := MarshalProviderShim(providerShim.Shim())
+	assert.Equal(t, map[string]*MarshallableResourceTimeoutShim{
+		"test_timed": {Create: &create, Default: &deflt},
+	}, marshalled.ResourceTimeouts)
+	assert.Equal(t, map[string]*MarshallableResourceTimeoutShim{
+		"test_source": {Read: &read},
+	}, marshalled.DataSourceTimeouts)
+
+	unmarshalled := marshalled.Unmarshal()
+	assert.Equal(t, &shim.ResourceTimeout{Create: &create, Default: &deflt},
+		unmarshalled.ResourcesMap().Get("test_timed").Timeouts())
+	assert.Nil(t, unmarshalled.ResourcesMap().Get("test_untimed").Timeouts())
+	assert.Equal(t, &shim.ResourceTimeout{Read: &read},
+		unmarshalled.DataSourcesMap().Get("test_source").Timeouts())
 }


### PR DESCRIPTION
The provider schema section of the GetMapping payload (`MarshallableProviderShim`) serializes each resource's and data source's schema map, but not the operation timeouts it declares (`shim.Resource.Timeouts`). Consumers that evaluate HCL against the mapping need that set: the SDK implies a `timeouts` block whose attributes are exactly the declared operations (`helper/schema/core_schema.go`), and its value is copied back into state, so `<resource>.timeouts.<op>` is readable only for declared operations, and `<resource>.timeouts` is null when no block is configured. Without the declared set, pulumi-hcl can only hardcode a four-key object (https://github.com/pulumi/pulumi-hcl/pull/439).

- `MarshallableProviderShim` gains `resourceTimeouts` / `dataSourceTimeouts`, keyed by Terraform type, `omitempty`. They are sibling maps rather than part of the per-resource entry because `MarshallableResourceShim` *is* the bare schema map: any extra key there reads as a field to older consumers, while sibling maps leave existing payloads byte-identical and older readers unaffected. `Unmarshal` restores them onto `schema.Resource.Timeouts`, so consumers use the existing `shim.Resource.Timeouts()`.
- Plugin Framework schema-only shims (`pf/proto`, `pf/internal/schemashim`) now return nil from `Timeouts()` instead of panicking: marshalling calls it for every resource (including in a PF provider's `GetMapping`), and a PF resource has no SDK-style declared timeouts — its `timeouts` block, if any, is an ordinary part of the schema. The nested pseudo-resources keep their panics; they are never marshalled at that level.
- Round-trip test in `pkg/tfbridge/info`.

Verified end to end with the pulumi-hcl consumer against a local `replace`: `<resource>.timeouts` typed by the declared operations, null when unset, `default` and data sources included, with tfcompat cases comparing against OpenTofu.
