### PR TITLE
tfgen: disambiguate colliding nested types

### DIFF
--- a/pkg/tfgen/generate_schema.go
+++ b/pkg/tfgen/generate_schema.go
@@ -67,6 +67,7 @@ type schemaGenerator struct {
 
 type schemaNestedType struct {
 	typ             *propertyType
+	propertyTypes   []*propertyType
 	declarer        declarer
 	required        codegen.StringSet
 	requiredInputs  codegen.StringSet
@@ -77,25 +78,216 @@ type schemaNestedType struct {
 }
 
 type schemaNestedTypes struct {
-	nameToType map[string]*schemaNestedType
+	nameToTypes map[string][]*schemaNestedType
+	types       []*schemaNestedType
 }
 
-func gatherSchemaNestedTypesForModule(mod *module) map[string]*schemaNestedType {
-	nt := &schemaNestedTypes{
-		nameToType: make(map[string]*schemaNestedType),
+type schemaNestedTypeClass struct {
+	declarations []*schemaNestedType
+}
+
+func (c *schemaNestedTypeClass) representative() *schemaNestedType {
+	return c.declarations[len(c.declarations)-1]
+}
+
+func (c *schemaNestedTypeClass) explicitlyNamed() bool {
+	for _, declaration := range c.declarations {
+		if declaration.typ.typeName != nil || declaration.typ.nestedType != "" {
+			return true
+		}
 	}
+	return false
+}
+
+func newSchemaNestedTypes() *schemaNestedTypes {
+	return &schemaNestedTypes{
+		nameToTypes: make(map[string][]*schemaNestedType),
+		types:       make([]*schemaNestedType, 0),
+	}
+}
+
+func gatherSchemaNestedTypesForModule(mod *module) []*schemaNestedType {
+	nt := newSchemaNestedTypes()
 	for _, member := range mod.members {
 		nt.gatherFromMember(member)
 	}
-	return nt.nameToType
+	return nt.types
 }
 
-func gatherSchemaNestedTypesForMember(member moduleMember) map[string]*schemaNestedType {
-	nt := &schemaNestedTypes{
-		nameToType: make(map[string]*schemaNestedType),
-	}
+func gatherSchemaNestedTypesForMember(member moduleMember) []*schemaNestedType {
+	nt := newSchemaNestedTypes()
 	nt.gatherFromMember(member)
-	return nt.nameToType
+	return nt.types
+}
+
+func schemaNestedTypeLocation(typePath paths.TypePath) string {
+	switch typePath := typePath.(type) {
+	case *paths.ResourceMemberPath:
+		// Inputs, outputs, state, and list inputs for the same resource property intentionally share a type.
+		return typePath.ResourcePath.String()
+	case *paths.DataSourceMemberPath:
+		// Arguments and results for the same data source property intentionally share a type.
+		return typePath.DataSourcePath.String()
+	case *paths.ConfigPath:
+		return typePath.String()
+	case *paths.PropertyPath:
+		return schemaNestedTypeLocation(typePath.Parent()) + "." + typePath.PropertyName.String()
+	case *paths.ElementPath:
+		return schemaNestedTypeLocation(typePath.Parent()) + ".$"
+	default:
+		contract.Failf("unsupported nested type path %T", typePath)
+		return ""
+	}
+}
+
+func schemaNestedTypeHasLocation(nestedType *schemaNestedType, typePath paths.TypePath) bool {
+	location := schemaNestedTypeLocation(typePath)
+	for _, existingPath := range nestedType.typePaths.Paths() {
+		if schemaNestedTypeLocation(existingPath) == location {
+			return true
+		}
+	}
+	return false
+}
+
+func mergeSchemaNestedTypeDeclarations(declarations []*schemaNestedType) *schemaNestedType {
+	representative := declarations[len(declarations)-1]
+	for _, declaration := range declarations[:len(declarations)-1] {
+		representative.propertyTypes = append(representative.propertyTypes, declaration.propertyTypes...)
+		for _, typePath := range declaration.typePaths.Paths() {
+			representative.typePaths.Add(typePath)
+		}
+		if representative.requiredInputs == nil && declaration.requiredInputs != nil {
+			representative.requiredInputs = declaration.requiredInputs
+		}
+		if representative.requiredOutputs == nil && declaration.requiredOutputs != nil {
+			representative.requiredOutputs = declaration.requiredOutputs
+		}
+	}
+	return representative
+}
+
+func (t *schemaNestedType) setName(name string) {
+	t.typ.name = name
+	for _, propertyType := range t.propertyTypes {
+		propertyType.name = name
+	}
+}
+
+func schemaNestedTypeSourcePaths(class *schemaNestedTypeClass) string {
+	var sourcePaths []string
+	for _, declaration := range class.declarations {
+		for _, typePath := range declaration.typePaths.Paths() {
+			sourcePaths = append(sourcePaths, typePath.String())
+		}
+	}
+	sort.Strings(sourcePaths)
+	return strings.Join(sourcePaths, ", ")
+}
+
+// resolveSchemaNestedTypeCollisions ensures that types which project to the same Pulumi token have compatible shapes.
+// Historically nested types were gathered per source module, even though modulePlacementForType can place types from
+// several source modules into one schema module. A later declaration could then silently overwrite the earlier type.
+func (g *schemaGenerator) resolveSchemaNestedTypeCollisions(
+	declarations []*schemaNestedType,
+) ([]*schemaNestedType, error) {
+	type tokenGroup struct {
+		token        string
+		declarations []*schemaNestedType
+	}
+
+	groupsByToken := map[string]*tokenGroup{}
+	var groups []*tokenGroup
+	reservedTokens := map[string]struct{}{}
+	for _, declaration := range declarations {
+		token := g.genObjectTypeToken(declaration)
+		group, ok := groupsByToken[token]
+		if !ok {
+			group = &tokenGroup{token: token}
+			groupsByToken[token] = group
+			groups = append(groups, group)
+			reservedTokens[token] = struct{}{}
+		}
+		group.declarations = append(group.declarations, declaration)
+	}
+
+	var resolved []*schemaNestedType
+	for _, group := range groups {
+		var classes []*schemaNestedTypeClass
+		for _, declaration := range group.declarations {
+			var compatible *schemaNestedTypeClass
+			for _, class := range classes {
+				if class.representative().typ.equals(declaration.typ) {
+					compatible = class
+					break
+				}
+			}
+			if compatible == nil {
+				compatible = &schemaNestedTypeClass{}
+				classes = append(classes, compatible)
+			}
+			compatible.declarations = append(compatible.declarations, declaration)
+		}
+
+		if len(classes) == 1 {
+			resolved = append(resolved, mergeSchemaNestedTypeDeclarations(classes[0].declarations))
+			continue
+		}
+
+		var explicitlyNamed []*schemaNestedTypeClass
+		for _, class := range classes {
+			if class.explicitlyNamed() {
+				explicitlyNamed = append(explicitlyNamed, class)
+			}
+		}
+		if len(explicitlyNamed) > 1 {
+			return nil, fmt.Errorf(
+				"nested type token %q is explicitly assigned to incompatible types at %s and %s",
+				group.token, schemaNestedTypeSourcePaths(explicitlyNamed[0]),
+				schemaNestedTypeSourcePaths(explicitlyNamed[1]))
+		}
+
+		// Preserve the shape that would previously have won the map overwrite. An explicit provider-authored name
+		// takes precedence; otherwise this is the last shape in deterministic gathering order.
+		lastDeclaration := group.declarations[len(group.declarations)-1]
+		var baseClass *schemaNestedTypeClass
+		for _, class := range classes {
+			if class.representative() == lastDeclaration {
+				baseClass = class
+				break
+			}
+		}
+		contract.Assertf(baseClass != nil, "last nested type declaration belongs to a compatibility class")
+		if len(explicitlyNamed) == 1 {
+			baseClass = explicitlyNamed[0]
+		}
+
+		nextVariant := 2
+		for _, class := range classes {
+			if class == baseClass {
+				resolved = append(resolved, mergeSchemaNestedTypeDeclarations(class.declarations))
+				continue
+			}
+
+			baseName := class.representative().typ.name
+			for {
+				candidateName := fmt.Sprintf("%sV%d", baseName, nextVariant)
+				for _, declaration := range class.declarations {
+					declaration.setName(candidateName)
+				}
+				candidateToken := g.genObjectTypeToken(class.representative())
+				nextVariant++
+				if _, occupied := reservedTokens[candidateToken]; occupied {
+					continue
+				}
+				reservedTokens[candidateToken] = struct{}{}
+				resolved = append(resolved, mergeSchemaNestedTypeDeclarations(class.declarations))
+				break
+			}
+		}
+	}
+
+	return resolved, nil
 }
 
 func (nt *schemaNestedTypes) gatherFromMember(member moduleMember) {
@@ -162,8 +354,11 @@ func (nt *schemaNestedTypes) declareType(typePath paths.TypePath, declarer decla
 	}
 
 	// Merging makes sure that structurally identical types are shared and not generated more than once.
-	if existing, ok := nt.nameToType[typeName]; ok {
-		contract.Assertf(existing.declarer == declarer || existing.typ.equals(typ), "duplicate type %v", typeName)
+	for _, existing := range nt.nameToTypes[typeName] {
+		sameLocation := existing.declarer == declarer && schemaNestedTypeHasLocation(existing, typePath)
+		if !sameLocation && !existing.typ.equals(typ) {
+			continue
+		}
 
 		// Remember that existing type is now also seen at the current typePath.
 		existing.typePaths.Add(typePath)
@@ -178,17 +373,21 @@ func (nt *schemaNestedTypes) declareType(typePath paths.TypePath, declarer decla
 		}
 
 		existing.typ, existing.required = typ, required
+		existing.propertyTypes = append(existing.propertyTypes, typ)
 		return typeName
 	}
 
-	nt.nameToType[typeName] = &schemaNestedType{
+	nestedType := &schemaNestedType{
 		typ:             typ,
+		propertyTypes:   []*propertyType{typ},
 		declarer:        declarer,
 		required:        required,
 		requiredInputs:  requiredInputs,
 		requiredOutputs: requiredOutputs,
 		typePaths:       paths.SingletonTypePathSet(typePath),
 	}
+	nt.nameToTypes[typeName] = append(nt.nameToTypes[typeName], nestedType)
+	nt.types = append(nt.types, nestedType)
 	return typeName
 }
 
@@ -306,23 +505,34 @@ func (g *schemaGenerator) genPackageSpec(ctx context.Context, pack *pkg) (pschem
 	spec.Description = g.info.Description
 	spec.Attribution = fmt.Sprintf(attributionFormatString, g.info.Name, g.info.GetGitHubOrg(), g.info.GetGitHubHost())
 
+	// Gather all nested types before emitting any references to them. Source modules do not necessarily correspond to
+	// schema modules, so collisions can only be resolved correctly at package scope.
+	gn0 := time.Now()
+	var nestedTypeDeclarations []*schemaNestedType
+	for _, mod := range pack.modules.values() {
+		nestedTypeDeclarations = append(nestedTypeDeclarations, gatherSchemaNestedTypesForModule(mod)...)
+	}
+	if pack.provider != nil {
+		nestedTypeDeclarations = append(nestedTypeDeclarations, gatherSchemaNestedTypesForMember(pack.provider)...)
+	}
+	nestedTypes, err := g.resolveSchemaNestedTypeCollisions(nestedTypeDeclarations)
+	if err != nil {
+		return pschema.PackageSpec{}, err
+	}
+	gatherNestedDur += time.Since(gn0)
+	for _, t := range nestedTypes {
+		tok := g.genObjectTypeToken(t)
+		t0 := time.Now()
+		ts := g.genObjectType(t, false)
+		typesDur += time.Since(t0)
+		typesN++
+		spec.Types[tok] = pschema.ComplexTypeSpec{
+			ObjectTypeSpec: ts,
+		}
+	}
+
 	var config []*variable
 	for _, mod := range pack.modules.values() {
-		// Generate nested types.
-		gn0 := time.Now()
-		nestedTypes := gatherSchemaNestedTypesForModule(mod)
-		gatherNestedDur += time.Since(gn0)
-		for _, t := range nestedTypes {
-			tok := g.genObjectTypeToken(t)
-			t0 := time.Now()
-			ts := g.genObjectType(t, false)
-			typesDur += time.Since(t0)
-			typesN++
-			spec.Types[tok] = pschema.ComplexTypeSpec{
-				ObjectTypeSpec: ts,
-			}
-		}
-
 		// Enumerate each module member, in the order presented to us, and do the right thing.
 		for _, member := range mod.members {
 			switch t := member.(type) {
@@ -377,13 +587,6 @@ func (g *schemaGenerator) genPackageSpec(ctx context.Context, pack *pkg) (pschem
 
 	if pack.provider != nil {
 		indexModToken := tokens.NewModuleToken(g.pkg, indexMod)
-		for _, t := range gatherSchemaNestedTypesForMember(pack.provider) {
-			tok := g.genObjectTypeToken(t)
-			ts := g.genObjectType(t, false)
-			spec.Types[tok] = pschema.ComplexTypeSpec{
-				ObjectTypeSpec: ts,
-			}
-		}
 		provider := g.genResourceType(indexModToken, pack.provider)
 		spec.Provider = &provider
 

--- a/pkg/tfgen/generate_schema_test.go
+++ b/pkg/tfgen/generate_schema_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"runtime"
 	"sort"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -39,6 +40,7 @@ import (
 	bridgetesting "github.com/pulumi/pulumi-terraform-bridge/v3/internal/testing"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
+	bridgetokens "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/tokens"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen/internal/paths"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfgen/internal/testprovider"
 	sdkv2 "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfshim/sdk-v2"
@@ -427,6 +429,190 @@ func TestNestedTypeSingularization(t *testing.T) {
 	})
 }
 
+func TestNestedTypeTokenCollisions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("disambiguates incompatible generated types", func(t *testing.T) {
+		nestedBlock := func(innerMaxItems int) *schema.Schema {
+			return &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+					"inner_block": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: innerMaxItems,
+						Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+							"attr": {Type: schema.TypeString, Required: true},
+						}},
+					},
+				}},
+			}
+		}
+		provider := tfbridge.ProviderInfo{
+			P: sdkv2.NewProvider(&schema.Provider{ResourcesMap: map[string]*schema.Resource{
+				"tc_res": {Schema: map[string]*schema.Schema{
+					"block": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+							"name":         {Type: schema.TypeString, Required: true},
+							"nested_block": nestedBlock(1),
+						}},
+					},
+				}},
+				"tc_res_block": {Schema: map[string]*schema.Schema{
+					"nested_block": nestedBlock(0),
+				}},
+			}}),
+			Name:         "tc",
+			Version:      "0.0.1",
+			MetadataInfo: tfbridge.NewProviderMetadata(nil),
+		}
+		provider.MustComputeTokens(bridgetokens.SingleModule("tc", "index", bridgetokens.MakeStandard("tc")))
+
+		actual, err := GenerateSchema(provider, diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
+			Color: colors.Never,
+		}))
+		require.NoError(t, err)
+
+		resBlockRef := actual.Resources["tc:index/res:Res"].InputProperties["blocks"].Items.Ref
+		resNestedBlockRef := actual.Types[strings.TrimPrefix(resBlockRef, "#/types/")].
+			Properties["nestedBlocks"].Items.Ref
+		standaloneNestedBlockRef := actual.Resources["tc:index/resBlock:ResBlock"].
+			InputProperties["nestedBlocks"].Items.Ref
+
+		assert.Equal(t,
+			"#/types/tc:index/ResBlockNestedBlockV2:ResBlockNestedBlockV2", resNestedBlockRef)
+		assert.Equal(t,
+			"#/types/tc:index/ResBlockNestedBlock:ResBlockNestedBlock", standaloneNestedBlockRef)
+
+		resNestedBlock := actual.Types[strings.TrimPrefix(resNestedBlockRef, "#/types/")]
+		standaloneNestedBlock := actual.Types[strings.TrimPrefix(standaloneNestedBlockRef, "#/types/")]
+		assert.Contains(t, resNestedBlock.Properties, "innerBlock")
+		assert.NotContains(t, resNestedBlock.Properties, "innerBlocks")
+		assert.Contains(t, standaloneNestedBlock.Properties, "innerBlocks")
+		assert.NotContains(t, standaloneNestedBlock.Properties, "innerBlock")
+		assert.Equal(t, "array", standaloneNestedBlock.Properties["innerBlocks"].Type)
+	})
+
+	t.Run("disambiguates singularized names within one resource", func(t *testing.T) {
+		objectList := func(field string, maxItems int) *schema.Schema {
+			return &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: maxItems,
+				Elem: &schema.Resource{Schema: map[string]*schema.Schema{
+					field: {Type: schema.TypeString, Optional: true},
+				}},
+			}
+		}
+		provider := tfbridge.ProviderInfo{
+			P: sdkv2.NewProvider(&schema.Provider{ResourcesMap: map[string]*schema.Resource{
+				"tc_policy": {Schema: map[string]*schema.Schema{
+					"restriction":  objectList("start_hour", 1),
+					"restrictions": objectList("start_day", 0),
+				}},
+			}}),
+			Name:         "tc",
+			Version:      "0.0.1",
+			MetadataInfo: tfbridge.NewProviderMetadata(nil),
+		}
+		provider.MustComputeTokens(bridgetokens.SingleModule("tc", "index", bridgetokens.MakeStandard("tc")))
+
+		actual, err := GenerateSchema(provider, diag.DefaultSink(io.Discard, io.Discard, diag.FormatOptions{
+			Color: colors.Never,
+		}))
+		require.NoError(t, err)
+
+		policy := actual.Resources["tc:index/policy:Policy"]
+		restrictionRef := policy.InputProperties["restriction"].Ref
+		restrictionsRef := policy.InputProperties["restrictions"].Items.Ref
+		assert.Equal(t, "#/types/tc:index/PolicyRestrictionV2:PolicyRestrictionV2", restrictionRef)
+		assert.Equal(t, "#/types/tc:index/PolicyRestriction:PolicyRestriction", restrictionsRef)
+		assert.Contains(t, actual.Types[strings.TrimPrefix(restrictionRef, "#/types/")].Properties, "startHour")
+		assert.Contains(t, actual.Types[strings.TrimPrefix(restrictionsRef, "#/types/")].Properties, "startDay")
+	})
+
+	newDeclaration := func(tfName, resourceToken, typeName string, different, explicit bool) *schemaNestedType {
+		typ := &propertyType{name: typeName, kind: kindObject}
+		if different {
+			typ.properties = []*variable{{
+				name: "different",
+				opt:  true,
+				typ:  &propertyType{kind: kindString},
+			}}
+		}
+		if explicit {
+			typ.typeName = tfbridge.Ref(typeName)
+		}
+		path := paths.NewProperyPath(
+			paths.NewResourcePath(tfName, tokens.Type(resourceToken), false).Inputs(),
+			paths.PropertyName{Key: "nested", Name: "nested"})
+		return &schemaNestedType{
+			typ:       typ,
+			declarer:  &resourceType{name: tfName},
+			typePaths: paths.SingletonTypePathSet(path),
+		}
+	}
+	generator := &schemaGenerator{pkg: "tc"}
+
+	t.Run("shares compatible types", func(t *testing.T) {
+		first := newDeclaration("tc_first", "tc:index/first:First", "Collision", false, false)
+		second := newDeclaration("tc_second", "tc:index/second:Second", "Collision", false, false)
+		resolved, err := generator.resolveSchemaNestedTypeCollisions([]*schemaNestedType{first, second})
+		require.NoError(t, err)
+		require.Len(t, resolved, 1)
+		assert.Len(t, resolved[0].typePaths, 2)
+	})
+
+	t.Run("preserves the last declared shape", func(t *testing.T) {
+		first := newDeclaration("tc_first", "tc:index/first:First", "Collision", false, false)
+		second := newDeclaration("tc_second", "tc:index/second:Second", "Collision", true, false)
+		last := newDeclaration("tc_last", "tc:index/last:Last", "Collision", false, false)
+		resolved, err := generator.resolveSchemaNestedTypeCollisions(
+			[]*schemaNestedType{first, second, last})
+		require.NoError(t, err)
+		assert.Equal(t, "Collision", first.typ.name)
+		assert.Equal(t, "CollisionV2", second.typ.name)
+		assert.Equal(t, "Collision", last.typ.name)
+		assert.Len(t, resolved, 2)
+	})
+
+	t.Run("skips occupied variants", func(t *testing.T) {
+		first := newDeclaration("tc_first", "tc:index/first:First", "Collision", false, false)
+		occupied := newDeclaration("tc_occupied", "tc:index/occupied:Occupied", "CollisionV2", false, false)
+		winner := newDeclaration("tc_winner", "tc:index/winner:Winner", "Collision", true, false)
+		resolved, err := generator.resolveSchemaNestedTypeCollisions(
+			[]*schemaNestedType{first, occupied, winner})
+		require.NoError(t, err)
+		assert.Equal(t, "CollisionV3", first.typ.name)
+		assert.Equal(t, "Collision", winner.typ.name)
+		assert.Len(t, resolved, 3)
+	})
+
+	t.Run("explicit name takes precedence", func(t *testing.T) {
+		explicit := newDeclaration("tc_explicit", "tc:index/explicit:Explicit", "Collision", false, true)
+		implicit := newDeclaration("tc_implicit", "tc:index/implicit:Implicit", "Collision", true, false)
+		resolved, err := generator.resolveSchemaNestedTypeCollisions(
+			[]*schemaNestedType{explicit, implicit})
+		require.NoError(t, err)
+		assert.Equal(t, "Collision", explicit.typ.name)
+		assert.Equal(t, "CollisionV2", implicit.typ.name)
+		assert.Len(t, resolved, 2)
+	})
+
+	t.Run("rejects incompatible explicit names", func(t *testing.T) {
+		first := newDeclaration("tc_first", "tc:index/first:First", "Collision", false, true)
+		second := newDeclaration("tc_second", "tc:index/second:Second", "Collision", true, true)
+		_, err := generator.resolveSchemaNestedTypeCollisions([]*schemaNestedType{first, second})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, `nested type token "tc:index/Collision:Collision"`)
+		assert.ErrorContains(t, err, `resource[key="tc_first"`)
+		assert.ErrorContains(t, err, `resource[key="tc_second"`)
+	})
+}
+
 func TestNestedDescriptions(t *testing.T) {
 	t.Parallel()
 	provider := testprovider.ProviderNestedDescriptions()
@@ -735,12 +921,10 @@ func Test_DynamicAttributeHandling(t *testing.T) {
 			typ:          nil, // This represents a dynamic attribute
 		}
 
-		nt := &schemaNestedTypes{
-			nameToType: make(map[string]*schemaNestedType),
-		}
+		nt := newSchemaNestedTypes()
 		assert.NotPanics(t, func() { nt.gatherFromMember(dynamicVar) })
 		nt.gatherFromMember(dynamicVar)
-		assert.Empty(t, nt.nameToType, "Dynamic attributes should not generate nested types")
+		assert.Empty(t, nt.types, "Dynamic attributes should not generate nested types")
 	})
 
 	t.Run("should handle mixed variable types including dynamic", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- gather nested schema types package-wide before emitting references
- deterministically disambiguate incompatible implicit shapes with `V2`, `V3`, and later suffixes while preserving the current unsuffixed winner
- preserve explicit type names and report incompatible explicit assignments with source paths
- cover the same-resource singularization collision reported in #3315

This follows the automatic collision-naming precedent from #3197 while retaining existing input/output/state sharing for the same logical property.

Fixes #3583
Fixes #3315

This also resolves the schema mismatch underlying pulumi/pulumi-hcl#561.

## Testing

- `GOTOOLCHAIN=go1.25.11 make test RUN_TEST_CMD="./pkg/tfgen -run TestNestedTypeTokenCollisions"`
- `GOTOOLCHAIN=go1.25.11 go test ./pkg/tfgen -run "TestNestedTypeTokenCollisions|TestNestedTypeSingularization|TestTypeSharing|Test_DynamicAttributeHandling" -count=1`
- `make lint` with Go 1.25.11 and golangci-lint 2.5.0 from `mise.toml`

## Notes

A full `pkg/tfgen` test run reaches an unrelated existing golden mismatch in `TestConvertExamples/aws_lambda_function`: generated Go examples resolve `pulumi-aws/sdk/v7`, while the checked-in golden expects `sdk/v6`.