### PR TITLE
Fix datasource autonaming 

### DIFF
--- a/pkg/tfbridge/tokens/fallbackstrat/fallback_strategy_test.go
+++ b/pkg/tfbridge/tokens/fallbackstrat/fallback_strategy_test.go
@@ -87,3 +87,38 @@ func TestTokensKnownModulesWithInferredFallback(t *testing.T) {
 		"cs101_buzz_ten":  {Tok: "cs101:buzz:Ten"},
 	}, info.Resources)
 }
+
+func TestTokensMappedModulesWithInferredFallbackPrefixesDataSourcesWithGet(t *testing.T) {
+	t.Parallel()
+	info := tfbridge.ProviderInfo{
+		P: (&schema.Provider{
+			DataSourcesMap: schema.ResourceMap{
+				"cs101_fizz_three": nil,
+				"cs101_buzz_five":  nil,
+				"cs101_buzz_ten":   nil,
+			},
+		}).Shim(),
+	}
+	strategy, err := fallbackstrat.MappedModulesWithInferredFallback(
+		&info,
+		"cs101_", "", map[string]string{
+			"fizz_": "fIzZ",
+		},
+		func(module, name string) (string, error) {
+			return fmt.Sprintf("cs101:%s:%s", module, name), nil
+		},
+	)
+	require.NoError(t, err)
+
+	err = info.ComputeTokens(tfbridge.Strategy{
+		DataSource: strategy.DataSource,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]*tfbridge.DataSourceInfo{
+		"cs101_fizz_three": {Tok: "cs101:fIzZ:getThree"},
+		// inferred
+		"cs101_buzz_five": {Tok: "cs101:buzz:getFive"},
+		"cs101_buzz_ten":  {Tok: "cs101:buzz:getTen"},
+	}, info.DataSources)
+}

--- a/pkg/tfbridge/tokens/inferred_modules.go
+++ b/pkg/tfbridge/tokens/inferred_modules.go
@@ -86,7 +86,7 @@ func InferredModules(
 		Resource: tokenFromMap(tokenMap, rIsEmpty, finalize, func(tk string, resource *info.Resource) {
 			checkedApply(&resource.Tok, tokens.Type(tk))
 		}),
-		DataSource: tokenFromMap(tokenMap, dIsEmpty, finalize, func(tk string, datasource *info.DataSource) {
+		DataSource: tokenFromMap(tokenMap, dIsEmpty, dataSourceMake(finalize), func(tk string, datasource *info.DataSource) {
 			checkedApply(&datasource.Tok, tokens.ModuleMember(tk))
 		}),
 		Function: topLevelFunction(finalize),

--- a/pkg/tfbridge/tokens/known_modules.go
+++ b/pkg/tfbridge/tokens/known_modules.go
@@ -104,7 +104,7 @@ func knownDataSource(finalize Make) func(mod, tk string, d *info.DataSource, err
 		if err != nil {
 			return err
 		}
-		tk, err = finalize(mod, "get"+tk)
+		tk, err = dataSourceMake(finalize)(mod, tk)
 		if err != nil {
 			return err
 		}

--- a/pkg/tfbridge/tokens/tokens.go
+++ b/pkg/tfbridge/tokens/tokens.go
@@ -42,6 +42,13 @@ const (
 //	}
 type Make func(module, name string) (string, error)
 
+// dataSourceMake wraps finalize so data sources receive the `get` prefix.
+func dataSourceMake(finalize Make) Make {
+	return func(module, name string) (string, error) {
+		return finalize(module, "get"+name)
+	}
+}
+
 // Convert a Terraform token to a Pulumi token with the standard mapping.
 //
 // The mapping is


### PR DESCRIPTION
There was a bug when a data source being autonamed used the InferredModules strategy (but didn't match any existing module prefix mappings) would not receive the datasource `get` prefix to its name. Discovered during https://github.com/pulumi/pulumi-signalfx/pull/1062. Fixes #3593.
