### PR TITLE
tfgen: skip required underscore-prefixed properties unless explicitly mapped

### DIFF
--- a/pkg/tfgen/generate.go
+++ b/pkg/tfgen/generate.go
@@ -2035,6 +2035,14 @@ func (g *Generator) propertyVariable(parentPath paths.TypePath, key string,
 				return nil, err
 			}
 			return nil, nil
+		} else if (varInfo == nil || varInfo.Name == "") && strings.HasPrefix(key, "_") {
+			if !isOptional(varInfo, shimSchema, false, false /* config */) {
+				return nil, fmt.Errorf(
+					"required property %q (@ %s) starts with an underscore and cannot be generated; "+
+						"map it to a valid name with an explicit SchemaInfo.Name",
+					propName, typePath)
+			}
+			return nil, nil
 		}
 		typ, err := g.makePropertyType(typePath, strings.ToLower(key), shimSchema, varInfo, out, entityDocs)
 		if err != nil {


### PR DESCRIPTION
Terraform attributes whose names begin with an underscore (for example `_scopes`, `_gui_meta`) are provider-internal and produce broken bindings (unexported fields in Go, name-mangled members in Python). Optional and computed underscore attributes are now dropped from the generated Pulumi schema; a required underscore attribute is a hard error at tfgen time. An attribute can still be included by giving it an explicit `Name` in its `SchemaInfo` mapping.

The regenerated fortimanager golden (`dynamic/testdata/TestSchemaGenerationFullDocs`) drops ~370 underscore-prefixed properties and their nested types. Goldens were regenerated with the pinned-plugin harness (`make test_accept`) plus `PULUMI_IGNORE_AMBIENT_PLUGINS=true` so the output matches CI's pinned `pulumi-converter-terraform` 1.0.20 rather than an ambient dev build.

Overlaps with #3565, which implements the same semantics.