### PR TITLE
Fix inverted state checks in the test provider's TupleType

### DIFF
--- a/pkg/pf/tests/internal/testprovider/tuple_type.go
+++ b/pkg/pf/tests/internal/testprovider/tuple_type.go
@@ -107,7 +107,7 @@ func (c TupleType) ValueFromTerraform(ctx context.Context, val tftypes.Value) (a
 			typ:   c,
 		}, nil
 	}
-	if !val.IsNull() {
+	if val.IsNull() {
 		return TupleValue{
 			state: attr.ValueStateNull,
 			typ:   c,
@@ -140,7 +140,7 @@ func (c TupleValue) Type(context.Context) attr.Type { return c.typ }
 
 func (c TupleValue) ToTerraformValue(ctx context.Context) (tftypes.Value, error) {
 	t := c.typ.tftype(ctx)
-	if c.state == attr.ValueStateKnown {
+	if c.state == attr.ValueStateUnknown {
 		return tftypes.NewValue(t, tftypes.UnknownValue), nil
 	}
 	if c.state == attr.ValueStateNull {

--- a/pkg/pf/tests/testdata/basicprogram/Pulumi.yaml
+++ b/pkg/pf/tests/testdata/basicprogram/Pulumi.yaml
@@ -187,11 +187,10 @@ outputs:
             port: 22
         protocol: ssh
 
-  # TODO this is currently failing.
-  # tupleElementAttrRes__actual: ${tupleElementAttrRes.tuplesOptionals}
-  # tupleElementAttrRes__expect:
-  #   - { t0: false, t1: "no" }
-  #   - { t0: true, t1: "yes"}
+  tupleElementAttrRes__actual: ${tupleElementAttrRes.tuplesOptionals}
+  tupleElementAttrRes__expect:
+    - { t0: false, t1: "no" }
+    - { t0: true, t1: "yes"}
 
   setElementAttrRes__actual: ${setElementAttrRes.setOptionals}
 


### PR DESCRIPTION
The tuple assertion in the `basicprogram` integration test has been commented out since #1011 because `tuplesOptionals` outputs came back as `[null, null]`.

The cause was never in the bridge — the tuple encoder/decoder in `pkg/convert` and the schemashim tuple mapping are correct. The test provider's custom `TupleType` had two inverted state checks:

- `ValueFromTerraform` used `if !val.IsNull()`, returning a null-state value for every non-null tuple.
- `ToTerraformValue` used `if c.state == attr.ValueStateKnown`, returning Unknown for known values.

terraform-plugin-framework round-trips attribute values through these two methods during planning, so every tuple element was nulled while the containing list kept its shape.

This flips both conditions and re-enables the `tupleElementAttrRes__actual/__expect` assertion, which now passes (`TestBasicProgram`, all 16 subtests). Rebuilding the testbridge provider produced no schema diff, confirming the change is value-logic only.

Fixes #1012.