### PR TITLE
Fix computed numeric resource ID mapping

### DIFF
--- a/pkg/tfbridge/tokens/fixups.go
+++ b/pkg/tfbridge/tokens/fixups.go
@@ -513,7 +513,7 @@ func fixID(providerName, tokenPrefix string) fixupProperty {
 			if f := r.Schema.Fields["id"]; f != nil && f.Type == "string" {
 				return nil
 			}
-			if r.Schema.ComputeID != nil && computedIDTypeIsCoercibleToString(tfIDProperty.Type()) {
+			if computedIDTypeIsCoercibleToString(tfIDProperty.Type()) {
 				getField(&r.Schema.Fields, "id").Type = "string"
 				return nil
 			}

--- a/pkg/tfbridge/tokens/fixups_test.go
+++ b/pkg/tfbridge/tokens/fixups_test.go
@@ -167,6 +167,18 @@ func TestFixPropertyConflicts(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name: "coerce numeric output ID to the Pulumi resource ID",
+			schema: schema.SchemaMap{
+				"id": (&schema.Schema{
+					Type:     shim.TypeInt,
+					Computed: true,
+				}).Shim(),
+			},
+			expected: map[string]*info.Schema{
+				"id": {Type: "string"},
+			},
+		},
+		{
 			name: "ignore overridden ID property name",
 			schema: schema.SchemaMap{
 				"id": (&schema.Schema{
@@ -554,7 +566,7 @@ func TestPrecomputedDefaultFixupsAvoidResourceSchema(t *testing.T) {
 			},
 		},
 		{
-			name: "computed non-string ID uses missing ID",
+			name: "computed non-string ID is coerced to the Pulumi resource ID",
 			schema: schema.SchemaMap{
 				"id": (&schema.Schema{
 					Type:     shim.TypeInt,
@@ -563,11 +575,9 @@ func TestPrecomputedDefaultFixupsAvoidResourceSchema(t *testing.T) {
 			},
 			verify: func(t *testing.T, res *info.Resource) {
 				t.Helper()
-				require.Equal(t, "resId", res.Fields["id"].Name)
-				require.NotNil(t, res.ComputeID)
-				got, err := res.ComputeID(context.Background(), resource.PropertyMap{})
-				require.NoError(t, err)
-				assert.Equal(t, resource.ID("missing ID"), got)
+				require.Equal(t, ptokens.Type("string"), res.Fields["id"].Type)
+				assert.Empty(t, res.Fields["id"].Name)
+				assert.Nil(t, res.ComputeID)
 			},
 		},
 		{


### PR DESCRIPTION
Computed-only numeric `id` attributes currently fall through the reserved-property fixup, get renamed as an ordinary output, and then receive the literal `missing ID` fallback. This happens even though the PF runtime can stringify these IDs.

Coerce supported computed-only IDs into Pulumi's string resource-ID slot before the rename/fallback path. The change preserves explicit field mappings and provider-authored `ComputeID` behavior.

The tests cover both eager fixups and build-time metadata replay.

Fixes #3415.

Validation: `go test ./pkg/tfbridge/tokens`