### PR TITLE
Fall back when raw state delta recovery fails

### DIFF
--- a/pkg/pf/tests/provider_read_test.go
+++ b/pkg/pf/tests/provider_read_test.go
@@ -41,6 +41,7 @@ func TestReadFromRefresh(t *testing.T) {
 	// - __meta writing out the schema version
 	// - implicit upgrade from version 1 to version 3 is performed ("numeric": true) appears
 	// - inputs being populated
+	// - invalid raw state delta falling back to legacy state decoding
 
 	server, err := newProviderServer(t, testprovider.RandomProvider())
 	require.NoError(t, err)
@@ -73,6 +74,15 @@ func TestReadFromRefresh(t *testing.T) {
 	    "urn": "urn:pulumi:dev::repro-pulumi-random-258::random:index/randomPassword:RandomPassword::access-token-",
 	    "properties": {
 	      "__meta": "{\"schema_version\":\"1\"}",
+	      "__pulumi_raw_state_delta": {
+	        "obj": {
+	          "ps": {
+	            "length": {
+	              "map": {}
+	            }
+	          }
+	        }
+	      },
 	      "bcryptHash": "$2a$10$HHwx0gQztkpPIc7WkE4Wt.v7ibWT9Ug24/F5XLa6xNm/gOuyS5WRa",
 	      "id": "none",
 	      "length": 8,

--- a/pkg/pf/tfbridge/resource_state.go
+++ b/pkg/pf/tfbridge/resource_state.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 
@@ -242,18 +241,20 @@ func (p *provider) parseAndUpgradeResourceState(
 	// States written by newer version of the bridge should be able to recover the raw state.
 	if delta, hasDelta := props[reservedkeys.RawStateDelta]; hasDelta {
 		rawState, err := recoverRawState(props, delta)
-		if err != nil {
-			// Log details at Debug level since they may contain secrets.
-			tflog.Debug(ctx, "[pf/tfbridge] Failed to recover raw state for Plugin Framework",
-				map[string]any{
-					"token": rh.token,
-					"props": props.Mappable(),
-				})
-			return nil, fmt.Errorf("[pf/tfbridge] Failed to recover raw state for Plugin Framework")
+		if err == nil {
+			// Always call the upgrade method, even if at current schema version.
+			return p.upgradeResourceState(ctx, rh, rawState, parsedMeta.PrivateState, stateVersion)
 		}
 
-		// Always call the upgrade method, even if at current schema version.
-		return p.upgradeResourceState(ctx, rh, rawState, parsedMeta.PrivateState, stateVersion)
+		// Delta and state values can contain secrets. Keep the error details in debug logs.
+		logger := tfbridge.GetLogger(ctx)
+		logger.Debug(fmt.Sprintf("[pf/tfbridge] Failed to recover raw state for %s: %v; props=%v",
+			rh.token, err, props.Mappable()))
+		logger.Warn(fmt.Sprintf("Failed to apply %q. The provider will use legacy state decoding.",
+			reservedkeys.RawStateDelta))
+
+		props = props.Copy()
+		delete(props, reservedkeys.RawStateDelta)
 	}
 
 	// Otherwise fallback to imprecise legacy parsing.

--- a/pkg/tfbridge/provider.go
+++ b/pkg/tfbridge/provider.go
@@ -1152,7 +1152,8 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 	var state shim.InstanceState
 	var oldAssets AssetTable
 	if pNew, enabled := makeTerraformStateViaUpgradeEnabled(p.tf, olds); enabled {
-		state, err = makeTerraformStateViaUpgrade(ctx, pNew, res, olds)
+		state, err = makeTerraformStateViaUpgrade(
+			ctx, pNew, res, req.GetId(), olds, makeTerraformStateOptions(opts))
 		if err != nil {
 			return nil, errors.Wrapf(err, "unmarshaling %s's instance state via upgrade", urn)
 		}
@@ -1465,7 +1466,8 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 
 	var state shim.InstanceState
 	if pNew, enabled := makeTerraformStateViaUpgradeEnabled(p.tf, props); enabled {
-		state, err = makeTerraformStateViaUpgrade(ctx, pNew, res, props)
+		state, err = makeTerraformStateViaUpgrade(
+			ctx, pNew, res, req.GetId(), props, makeTerraformStateOptions(opts))
 		if err != nil {
 			return nil, errors.Wrapf(err, "unmarshaling %s's instance state via upgrade", urn)
 		}
@@ -1674,7 +1676,8 @@ func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*p
 
 	var state shim.InstanceState
 	if pNew, enabled := makeTerraformStateViaUpgradeEnabled(p.tf, olds); enabled {
-		state, err = makeTerraformStateViaUpgrade(ctx, pNew, res, olds)
+		state, err = makeTerraformStateViaUpgrade(
+			ctx, pNew, res, req.GetId(), olds, makeTerraformStateOptions(opts))
 		if err != nil {
 			return nil, errors.Wrapf(err, "unmarshaling %s's instance state via upgrade", urn)
 		}
@@ -1833,7 +1836,8 @@ func (p *Provider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*p
 
 	var state shim.InstanceState
 	if pNew, enabled := makeTerraformStateViaUpgradeEnabled(p.tf, props); enabled {
-		state, err = makeTerraformStateViaUpgrade(ctx, pNew, res, props)
+		state, err = makeTerraformStateViaUpgrade(
+			ctx, pNew, res, req.GetId(), props, makeTerraformStateOptions(opts))
 		if err != nil {
 			return nil, errors.Wrapf(err, "unmarshaling %s's instance state via upgrade", urn)
 		}

--- a/pkg/tfbridge/rawstate.go
+++ b/pkg/tfbridge/rawstate.go
@@ -116,7 +116,7 @@ func (d RawStateDelta) recoverRepr(pv resource.PropertyValue) (rawstate.Builder,
 		for k, v := range pm {
 			element, err := d.Map.ElementDeltas[k].recoverRepr(v)
 			if err != nil {
-				return rawstate.Null(), err
+				return rawstate.Null(), fmt.Errorf("property %q: %w", k, err)
 			}
 			recovered[string(k)] = element
 		}
@@ -149,7 +149,7 @@ func (d RawStateDelta) recoverRepr(pv resource.PropertyValue) (rawstate.Builder,
 			}
 			prop, err := d.Obj.PropertyDeltas[k].recoverRepr(v)
 			if err != nil {
-				return rawstate.Null(), err
+				return rawstate.Null(), fmt.Errorf("property %q: %w", k, err)
 			}
 			recovered[name] = prop
 		}
@@ -166,7 +166,7 @@ func (d RawStateDelta) recoverRepr(pv resource.PropertyValue) (rawstate.Builder,
 			}
 			prop, err := pd.recoverRepr(resource.NewNullProperty())
 			if err != nil {
-				return rawstate.Null(), err
+				return rawstate.Null(), fmt.Errorf("property %q: %w", k, err)
 			}
 			recovered[name] = prop
 		}
@@ -190,7 +190,7 @@ func (d RawStateDelta) recoverRepr(pv resource.PropertyValue) (rawstate.Builder,
 		for k, v := range arr {
 			r, err := d.ArrayOrSet.ElementDeltas[k].recoverRepr(v)
 			if err != nil {
-				return rawstate.Null(), err
+				return rawstate.Null(), fmt.Errorf("element %d: %w", k, err)
 			}
 			elements = append(elements, r)
 		}
@@ -250,10 +250,10 @@ func rawStateRecoverNatural(pv resource.PropertyValue) (rawstate.Builder, error)
 		return rawstate.Null(), errors.New("rawStateRecoverNatural cannot process Computed values")
 	case pv.IsArray():
 		var elements []rawstate.Builder
-		for _, v := range pv.ArrayValue() {
+		for i, v := range pv.ArrayValue() {
 			vv, err := rawStateRecoverNatural(v)
 			if err != nil {
-				return rawstate.Null(), err
+				return rawstate.Null(), fmt.Errorf("element %d: %w", i, err)
 			}
 			elements = append(elements, vv)
 		}

--- a/pkg/tfbridge/rawstate.go
+++ b/pkg/tfbridge/rawstate.go
@@ -89,7 +89,9 @@ func (d RawStateDelta) recoverRepr(pv resource.PropertyValue) (rawstate.Builder,
 		return d.recoverRepr(pv.OutputValue().Element)
 	}
 	isUnknown := pv.IsComputed() || pv.IsOutput() && !pv.OutputValue().Known
-	contract.Assertf(!isUnknown, "rawStateRecover cannot process unknown values")
+	if isUnknown {
+		return rawstate.Null(), errors.New("raw state recovery cannot process unknown values")
+	}
 
 	switch {
 	case d.isEmpty():
@@ -224,10 +226,14 @@ func (d RawStateDelta) recoverRepr(pv resource.PropertyValue) (rawstate.Builder,
 			return rawstate.Null(), errors.New("Expected PropertyValue to be a String")
 		}
 		v := json.Number(pv.StringValue())
+		// Converting a string to json.Number does not validate it. Validate it here because
+		// rawstate.Builder.Build cannot return the marshal error and would panic instead.
+		if _, err := json.Marshal(v); err != nil {
+			return rawstate.Null(), fmt.Errorf("invalid JSON number: %w", err)
+		}
 		return rawstate.Number(v), nil
 	default:
-		contract.Failf("RawStateDelta.Recover does not recognize this rawStateDelta case")
-		return rawstate.Null(), errors.New("impossible")
+		return rawstate.Null(), errors.New("raw state recovery does not recognize this delta variant")
 	}
 }
 
@@ -243,11 +249,12 @@ func rawStateRecoverNatural(pv resource.PropertyValue) (rawstate.Builder, error)
 		return rawStateRecoverNatural(pv.SecretValue().Element)
 	case pv.IsOutput():
 		ov := pv.OutputValue()
-		contract.Assertf(ov.Known, "rawStateRecoverNatural cannot process unknowns")
+		if !ov.Known {
+			return rawstate.Null(), errors.New("natural raw state recovery cannot process unknown outputs")
+		}
 		return rawStateRecoverNatural(ov.Element)
 	case pv.IsComputed():
-		contract.Failf("rawStateRecoverNatural cannot process Computed values")
-		return rawstate.Null(), errors.New("rawStateRecoverNatural cannot process Computed values")
+		return rawstate.Null(), errors.New("natural raw state recovery cannot process computed values")
 	case pv.IsArray():
 		var elements []rawstate.Builder
 		for i, v := range pv.ArrayValue() {
@@ -271,8 +278,7 @@ func rawStateRecoverNatural(pv resource.PropertyValue) (rawstate.Builder, error)
 	case pv.IsResourceReference():
 		return rawstate.Null(), errors.New("rawStateRecoverNatural cannot process ResourceReference values")
 	default:
-		contract.Failf("rawStateRecoverNatural does not recognize this PropertyValue case")
-		return rawstate.Null(), errors.New("impossible")
+		return rawstate.Null(), errors.New("natural raw state recovery does not recognize this PropertyValue variant")
 	}
 }
 
@@ -330,7 +336,9 @@ func (d RawStateDelta) Marshal() resource.PropertyValue {
 func UnmarshalRawStateDelta(pv resource.PropertyValue) (RawStateDelta, error) {
 	pvNoSecret := propertyvalue.RemoveSecrets(pv)
 	bytes, err := json.Marshal(pvNoSecret.Mappable())
-	contract.AssertNoErrorf(err, "Failed to json.Marshal(pv.Mappable())")
+	if err != nil {
+		return RawStateDelta{}, fmt.Errorf("failed to marshal raw state delta: %w", err)
+	}
 	var rsd RawStateDelta
 	err = json.Unmarshal(bytes, &rsd)
 	if err != nil {

--- a/pkg/tfbridge/rawstate_test.go
+++ b/pkg/tfbridge/rawstate_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -511,6 +512,66 @@ func Test_rawstate_delta_timeouts_with_null_read(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, string(cvJSON), string(recoveredJSON))
+}
+
+func TestRawStateDeltaRecoverReturnsErrorsForInvalidStoredValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		delta RawStateDelta
+		value resource.PropertyValue
+		err   string
+	}{
+		{
+			name: "computed value",
+			value: resource.NewComputedProperty(resource.Computed{
+				Element: resource.NewStringProperty(""),
+			}),
+			err: "raw state recovery cannot process unknown values",
+		},
+		{
+			name:  "unknown output",
+			value: resource.NewOutputProperty(resource.Output{Known: false}),
+			err:   "raw state recovery cannot process unknown values",
+		},
+		{
+			name: "nested unknown output",
+			value: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewOutputProperty(resource.Output{Known: false}),
+			}),
+			err: "element 0: natural raw state recovery cannot process unknown outputs",
+		},
+		{
+			name: "nested computed value",
+			value: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewComputedProperty(resource.Computed{Element: resource.NewStringProperty("")}),
+			}),
+			err: "element 0: natural raw state recovery cannot process computed values",
+		},
+		{
+			name:  "invalid number",
+			delta: RawStateDelta{Num: &numDelta{}},
+			value: resource.NewStringProperty("not-a-number"),
+			err:   "invalid JSON number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := tt.delta.Recover(tt.value)
+			require.ErrorContains(t, err, tt.err)
+		})
+	}
+}
+
+func TestUnmarshalRawStateDeltaReturnsJSONErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := UnmarshalRawStateDelta(resource.NewNumberProperty(math.NaN()))
+	require.ErrorContains(t, err, "failed to marshal raw state delta")
 }
 
 func Test_rawstate_delta_serialization(t *testing.T) {

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -561,8 +561,7 @@ func (ctx *conversionContext) makeTerraformInput(
 		}
 		return makeTerraformUnknown(tfs), nil
 	default:
-		contract.Failf("Unexpected value marshaled: %v", v)
-		return nil, nil
+		return nil, fmt.Errorf("%s: unsupported Pulumi property value type", name)
 	}
 }
 

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1451,12 +1451,14 @@ func makeTerraformStateWithOpts(
 
 // The preferred method for recreating TF state that is used when the Pulumi state was written with a recent enough
 // bridge code is to reconstruct the TF raw state and pass it to the state upgrade TF life-cycle method. This most
-// closely approximates how TF runs internally.
+// closely approximates how TF runs internally. If the stored delta is invalid, this falls back to legacy state decoding.
 func makeTerraformStateViaUpgrade(
 	ctx context.Context,
 	p shim.ProviderWithRawStateSupport,
 	res Resource,
+	id string,
 	m resource.PropertyMap,
+	opts makeTerraformStateOptions,
 ) (shim.InstanceState, error) {
 	// Only log error details at Debug level to avoid leaking secrets to errors.
 	logger := log.TryGetLogger(ctx)
@@ -1468,25 +1470,25 @@ func makeTerraformStateViaUpgrade(
 	contract.Assertf(ok, "makeTerraformStateViaUpgrade should only be called if %s key is set",
 		reservedkeys.RawStateDelta)
 
+	fallback := func(err error) (shim.InstanceState, error) {
+		// Delta and state values can contain secrets. Keep the error details in debug logs.
+		logger.Debug(fmt.Sprintf("Failed to recover raw state from %q: %v; props=%v",
+			reservedkeys.RawStateDelta, err, m.Mappable()))
+		logger.Warn(fmt.Sprintf("Failed to apply %q. The provider will use legacy state decoding.",
+			reservedkeys.RawStateDelta))
+
+		props := m.Copy()
+		delete(props, reservedkeys.RawStateDelta)
+		return makeTerraformStateWithOpts(ctx, res, id, props, opts)
+	}
+
 	delta, err := UnmarshalRawStateDelta(deltaValue)
 	if err != nil {
-		logger.Debug(fmt.Sprintf("Failed to parse raw state markers:\n"+
-			"  %q: %#v\n"+
-			"  error: %v",
-			reservedkeys.RawStateDelta,
-			delta.Marshal().String(),
-			err))
-		contract.AssertNoErrorf(err, "Failed to parse raw state markers")
+		return fallback(err)
 	}
 	recoveredRawState, err := delta.Recover(resource.NewObjectProperty(m))
 	if err != nil {
-		logger.Debug(fmt.Sprintf("Failed recover raw state:\n"+
-			"  %q: %#v\n"+
-			"  error: %v",
-			reservedkeys.RawStateDelta,
-			delta.Marshal().String(),
-			err))
-		contract.AssertNoErrorf(err, "Failed to recover raw state")
+		return fallback(err)
 	}
 	meta, err := parseMeta(m, res, makeTerraformStateOptions{defaultZeroSchemaVersion: true})
 	if err != nil {

--- a/pkg/tfbridge/schema.go
+++ b/pkg/tfbridge/schema.go
@@ -1451,7 +1451,8 @@ func makeTerraformStateWithOpts(
 
 // The preferred method for recreating TF state that is used when the Pulumi state was written with a recent enough
 // bridge code is to reconstruct the TF raw state and pass it to the state upgrade TF life-cycle method. This most
-// closely approximates how TF runs internally. If the stored delta is invalid, this falls back to legacy state decoding.
+// closely approximates how TF runs internally. If the stored delta is invalid, this falls back to legacy state
+// decoding.
 func makeTerraformStateViaUpgrade(
 	ctx context.Context,
 	p shim.ProviderWithRawStateSupport,

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -15,6 +15,7 @@
 package tfbridge
 
 import (
+	"bytes"
 	"context"
 	"sort"
 	"strconv"
@@ -35,6 +36,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/logging"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/internal/testprovider"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/reservedkeys"
 	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/info"
@@ -645,6 +647,43 @@ func TestTerraformOutputsWithSecretsUnsupported(t *testing.T) {
 			}), result)
 		})
 	}
+}
+
+func TestMakeTerraformStateViaUpgradeFallsBackForInvalidRawStateDelta(t *testing.T) {
+	t.Parallel()
+
+	prov := shimv2.NewProvider(testprovider.ProviderV2())
+	provWithRawState, ok := prov.(shim.ProviderWithRawStateSupport)
+	require.True(t, ok)
+
+	const resName = "example_resource"
+	res := prov.ResourcesMap().Get(resName)
+	resourceState := Resource{TF: res, Schema: &ResourceInfo{}, TFName: resName}
+	props := resource.NewPropertyMapFromMap(map[string]any{
+		"arrayPropertyValue":  []any{"an array"},
+		"stringPropertyValue": "a string",
+	})
+	props[reservedkeys.RawStateDelta] = RawStateDelta{Obj: &objDelta{
+		PropertyDeltas: map[resource.PropertyKey]RawStateDelta{
+			"stringPropertyValue": {Map: &mapDelta{}},
+		},
+	}}.Marshal()
+
+	var logs bytes.Buffer
+	ctx := logging.InitLogging(context.Background(), logging.LogOptions{
+		LogSink: &testLogSink{buf: &logs},
+	})
+	state, err := makeTerraformStateViaUpgrade(
+		ctx, provWithRawState, resourceState, "resource-id", props, makeTerraformStateOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "resource-id", state.ID())
+	require.Contains(t, logs.String(),
+		`Failed to apply "__pulumi_raw_state_delta". The provider will use legacy state decoding.`)
+	require.Contains(t, logs.String(), `property "stringPropertyValue"`)
+	require.Contains(t, logs.String(), `a string`)
+	// The fallback must not modify the caller's state map.
+	_, hasDelta := props[reservedkeys.RawStateDelta]
+	require.True(t, hasDelta)
 }
 
 // Test that meta-properties are correctly produced.

--- a/pkg/tfbridge/schema_test.go
+++ b/pkg/tfbridge/schema_test.go
@@ -649,6 +649,17 @@ func TestTerraformOutputsWithSecretsUnsupported(t *testing.T) {
 	}
 }
 
+func TestMakeTerraformInputReturnsErrorForUnsupportedPropertyValue(t *testing.T) {
+	t.Parallel()
+
+	value := resource.NewResourceReferenceProperty(resource.ResourceReference{
+		ID: resource.NewStringProperty("resource-id"),
+	})
+	_, err := (&conversionContext{}).makeTerraformInput(
+		"value", resource.PropertyValue{}, value, nil, nil)
+	require.EqualError(t, err, "value: unsupported Pulumi property value type")
+}
+
 func TestMakeTerraformStateViaUpgradeFallsBackForInvalidRawStateDelta(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When a stored raw state delta cannot be parsed or applied 
(either because the `__pulumi_raw_state_delta` is incorrect _or_ 
the actual property value has been corrupted), warn and use
legacy state decoding instead of failing the operation.

Apply the fallback to SDKv2 and Plugin Framework resources. Add property
context to recovery errors and keep state values in debug logs because
they can contain secrets.

This should be safe to do because before returning we re-create the raw state delta
and do a turnaroundCheck to validate it applies. So regardless of whether the issue is with
the resource state or the raw_state_delta we should recover

```ascii
   Read stored state
           |
           v
   Apply raw-state delta
           |
      +----+----+
      |         |
   Success    Error
      |         |
      |         v
      |    Remove delta
      |         |
      |         v
      |    Legacy decoding
      |         |
      +----+----+
           |
           v
    Read cloud state
           |
           v
   Compute new delta
           |
           v
    Turnaround check
           |
           v
   Return refreshed state

```


Fixes #3031
