### PR TITLE
rapidgen: generate only maps of primitives

### DIFF
--- a/pkg/tfshim/sdk-v2/internal/rapid/generators.go
+++ b/pkg/tfshim/sdk-v2/internal/rapid/generators.go
@@ -65,7 +65,12 @@ func SchemaAttrGen(depth int) *rapid.Generator[*schema.Schema] {
 		}
 
 		switch valueType {
-		case schema.TypeMap, schema.TypeSet, schema.TypeInt:
+		case schema.TypeMap:
+			// The SDK only supports maps of primitives at runtime.
+			if rapid.Bool().Draw(t, "hasElementSchema") {
+				s.Elem = &schema.Schema{Type: ValueTypeScalarGen().Draw(t, "elementType")}
+			}
+		case schema.TypeSet, schema.TypeInt:
 			hasElem := rapid.Bool().Draw(t, "hasElementSchema")
 			if hasElem {
 				elem := SchemaGen(depth-1).Draw(t, "elementSchema")


### PR DESCRIPTION
The SDK panics in MapFieldWriter when a TypeMap element is a set or a
block. Draw a scalar element type for TypeMap schemas, which is the only
shape the SDK supports at runtime.