### PR TITLE
rapidgen: draw ForceNew on attributes and blocks

### DIFF
--- a/pkg/tfshim/sdk-v2/internal/rapid/generators.go
+++ b/pkg/tfshim/sdk-v2/internal/rapid/generators.go
@@ -80,6 +80,7 @@ func SchemaAttrGen(depth int) *rapid.Generator[*schema.Schema] {
 
 		attrKind := AttributeKindGen().Draw(t, "attrKind")
 		attrKind.Set(s)
+		s.ForceNew = rapid.Bool().Draw(t, "forceNew")
 		return s
 	})
 }
@@ -107,6 +108,7 @@ func SchemaBlockGen(depth int) *rapid.Generator[*schema.Schema] {
 
 		attrKind := AttributeKindGen().Draw(t, "attrKind")
 		attrKind.Set(s)
+		s.ForceNew = rapid.Bool().Draw(t, "forceNew")
 		return s
 	})
 }


### PR DESCRIPTION
ForceNew marks a diff as RequiresNew. Draw it on every generated
attribute and block so that planning tests cover replacement diffs.