### PR TITLE
rapidgen: draw Default on optional scalar attributes

### DIFF
--- a/pkg/tfshim/sdk-v2/internal/rapid/generators.go
+++ b/pkg/tfshim/sdk-v2/internal/rapid/generators.go
@@ -81,8 +81,36 @@ func SchemaAttrGen(depth int) *rapid.Generator[*schema.Schema] {
 		attrKind := AttributeKindGen().Draw(t, "attrKind")
 		attrKind.Set(s)
 		s.ForceNew = rapid.Bool().Draw(t, "forceNew")
+		if attrKind == Optional && isScalar(valueType) && rapid.Bool().Draw(t, "hasDefault") {
+			s.Default = DefaultValueGen(valueType).Draw(t, "default")
+		}
 		return s
 	})
+}
+
+// DefaultValueGen generates a Go value of the kind that schema.Schema.Default
+// expects for a scalar valueType.
+func DefaultValueGen(valueType schema.ValueType) *rapid.Generator[interface{}] {
+	switch valueType {
+	case schema.TypeBool:
+		return rapid.Bool().AsAny()
+	case schema.TypeInt:
+		return rapid.IntRange(-2, 2).AsAny()
+	case schema.TypeFloat:
+		return rapid.Float64Range(-2, 2).AsAny()
+	case schema.TypeString:
+		return rapid.SampledFrom([]string{"", "a", "b"}).AsAny()
+	}
+	contract.Failf("no default for non-scalar type %v", valueType)
+	return nil
+}
+
+func isScalar(valueType schema.ValueType) bool {
+	switch valueType {
+	case schema.TypeBool, schema.TypeInt, schema.TypeFloat, schema.TypeString:
+		return true
+	}
+	return false
 }
 
 func SchemaBlockGen(depth int) *rapid.Generator[*schema.Schema] {


### PR DESCRIPTION
The SDK fills a Default into the diff when the configuration leaves an
optional attribute unset. Draw a typed Default on optional scalar
attributes, which is the only place the SDK permits one.